### PR TITLE
Add `#![no_std]` to the reference impl

### DIFF
--- a/reference_impl/reference_impl.rs
+++ b/reference_impl/reference_impl.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 use core::cmp::min;
 use core::convert::TryInto;
 


### PR DESCRIPTION
This ensures that no accidental uses of libstd can sneak in.

I've verified that this now compiles for ARMv6-M targets via `cargo build --target thumbv6m-none-eabi`.

(this is great work btw!)