### PR TITLE
C impl: Prevent memcpy undefined behavior

### DIFF
--- a/c/blake3.c
+++ b/c/blake3.c
@@ -34,6 +34,9 @@ INLINE size_t chunk_state_len(const blake3_chunk_state *self) {
 
 INLINE size_t chunk_state_fill_buf(blake3_chunk_state *self,
                                    const uint8_t *input, size_t input_len) {
+  if (input_len == 0) {
+      return 0;
+  }
   size_t take = BLAKE3_BLOCK_LEN - ((size_t)self->buf_len);
   if (take > input_len) {
     take = input_len;


### PR DESCRIPTION
This prevents a (potential, depending on the caller) case of undefined behavior in the call to ```memcpy``` in ```chunk_state_fill_buf```. This can happen when ```blake3_hasher_update``` is called with ```input=NULL``` and ```input_len=0```. Passing a null pointer to memcpy is undefined behavior even if the ```n``` argument is 0.

Empy C++ vectors (can) behave this way, eg.:

```cpp
std::vector<uint8_t> v;
blake3_hasher_update(&hasher, v.data(), v.size());
```