### PR TITLE
Use fixed-size constant_time_eq

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ std = []
 [dependencies]
 arrayref = "0.3.5"
 arrayvec = { version = "0.5.1", default-features = false, features = ["array-sizes-33-128"] }
-constant_time_eq = "0.1.4"
+constant_time_eq = "0.1.5"
 # A performance note for the "rayon" feature: Multi-threading can have
 # significant overhead for small inputs, particularly on x86 where individual
 # cores are very fast. On the other hand, on slower platforms like ARM,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,14 +180,14 @@ impl From<Hash> for [u8; OUT_LEN] {
 /// This implementation is constant-time.
 impl PartialEq for Hash {
     fn eq(&self, other: &Hash) -> bool {
-        constant_time_eq::constant_time_eq(&self.0[..], &other.0[..])
+        constant_time_eq::constant_time_eq_32(&self.0, &other.0)
     }
 }
 
 /// This implementation is constant-time.
 impl PartialEq<[u8; OUT_LEN]> for Hash {
     fn eq(&self, other: &[u8; OUT_LEN]) -> bool {
-        constant_time_eq::constant_time_eq(&self.0[..], other)
+        constant_time_eq::constant_time_eq_32(&self.0, other)
     }
 }
 


### PR DESCRIPTION
The generic constant_time_eq has several branches on the slice length,
which are not necessary when the slice length is known. However, the
optimizer is not allowed to look into the core of constant_time_eq, so
these branches cannot be elided.

Use instead a fixed-size variant of constant_time_eq, which has no
branches since the length is known.