### PR TITLE
Adds support for raw output to b3sum

### DIFF
--- a/b3sum/src/main.rs
+++ b/b3sum/src/main.rs
@@ -191,28 +191,26 @@ fn main() -> Result<()> {
 
     if let Some(files) = args.values_of_os(FILE_ARG) {
         if raw_output && files.len() > 1 {
-            did_error = true;
-            eprintln!("b3sum: Only one filename can be provided when using --raw");
-        } else {
-            for filepath in files {
-                let filepath_str = filepath.to_string_lossy();
-                match hash_file(&base_hasher, filepath) {
-                    Ok(output) => {
-                        if raw_output {
-                            write_raw_output(output, len)?;
+            bail!("b3sum: Only one filename can be provided when using --raw");
+        }
+        for filepath in files {
+            let filepath_str = filepath.to_string_lossy();
+            match hash_file(&base_hasher, filepath) {
+                Ok(output) => {
+                    if raw_output {
+                        write_raw_output(output, len)?;
+                    } else {
+                        write_hex_output(output, len)?;
+                        if print_names {
+                            println!("  {}", filepath_str);
                         } else {
-                            write_hex_output(output, len)?;
-                            if print_names {
-                                println!("  {}", filepath_str);
-                            } else {
-                                println!();
-                            }
+                            println!();
                         }
                     }
-                    Err(e) => {
-                        did_error = true;
-                        eprintln!("b3sum: {}: {}", filepath_str, e);
-                    }
+                }
+                Err(e) => {
+                    did_error = true;
+                    eprintln!("b3sum: {}: {}", filepath_str, e);
                 }
             }
         }

--- a/b3sum/src/main.rs
+++ b/b3sum/src/main.rs
@@ -10,6 +10,7 @@ const LENGTH_ARG: &str = "length";
 const KEYED_ARG: &str = "keyed";
 const DERIVE_KEY_ARG: &str = "derive-key";
 const NO_NAMES_ARG: &str = "no-names";
+const RAW_ARG: &str = "raw";
 
 fn clap_parse_argv() -> clap::ArgMatches<'static> {
     App::new("b3sum")
@@ -41,6 +42,11 @@ fn clap_parse_argv() -> clap::ArgMatches<'static> {
             Arg::with_name(NO_NAMES_ARG)
                 .long(NO_NAMES_ARG)
                 .help("Omits filenames in the output"),
+        )
+        .arg(
+            Arg::with_name(RAW_ARG)
+                .long(RAW_ARG)
+                .help("Raw output without hexidecimal encoding. \nOnly one filename may be provided and no filenames will be displayed."),
         )
         .get_matches()
 }
@@ -105,7 +111,7 @@ fn maybe_hash_memmap(
     Ok(None)
 }
 
-fn write_output(mut output: blake3::OutputReader, mut len: u64) -> Result<()> {
+fn write_hex_output(mut output: blake3::OutputReader, mut len: u64) -> Result<()> {
     // Encoding multiples of the block size is most efficient.
     let mut block = [0; blake3::BLOCK_LEN];
     while len > 0 {
@@ -115,6 +121,19 @@ fn write_output(mut output: blake3::OutputReader, mut len: u64) -> Result<()> {
         print!("{}", &hex_str[..2 * take_bytes as usize]);
         len -= take_bytes;
     }
+    Ok(())
+}
+
+fn write_raw_output(mut output: blake3::OutputReader, mut len: u64) -> Result<()> {
+    let mut stdout = std::io::stdout();
+    let mut block = [0; blake3::BLOCK_LEN];
+    while len > 0 {
+        output.fill(&mut block);
+        let take_bytes = cmp::min(len, block.len() as u64);
+        stdout.write(&block[..take_bytes as usize])?;
+        len -= take_bytes;
+    }
+
     Ok(())
 }
 
@@ -166,22 +185,33 @@ fn main() -> Result<()> {
         blake3::Hasher::new()
     };
     let print_names = !args.is_present(NO_NAMES_ARG);
+    let raw_output = args.is_present(RAW_ARG);
     let mut did_error = false;
+
     if let Some(files) = args.values_of_os(FILE_ARG) {
-        for filepath in files {
-            let filepath_str = filepath.to_string_lossy();
-            match hash_file(&base_hasher, filepath) {
-                Ok(output) => {
-                    write_output(output, len)?;
-                    if print_names {
-                        println!("  {}", filepath_str);
-                    } else {
-                        println!();
+        if raw_output && files.len() > 1 {
+            did_error = true;
+            eprintln!("b3sum: Only one filename can be provided when using --raw");
+        } else {
+            for filepath in files {
+                let filepath_str = filepath.to_string_lossy();
+                match hash_file(&base_hasher, filepath) {
+                    Ok(output) => {
+                        if raw_output {
+                            write_raw_output(output, len)?;
+                        } else {
+                            write_hex_output(output, len)?;
+                            if print_names {
+                                println!("  {}", filepath_str);
+                            } else {
+                                println!();
+                            }
+                        }
                     }
-                }
-                Err(e) => {
-                    did_error = true;
-                    println!("b3sum: {}: {}", filepath_str, e);
+                    Err(e) => {
+                        did_error = true;
+                        eprintln!("b3sum: {}: {}", filepath_str, e);
+                    }
                 }
             }
         }
@@ -189,8 +219,12 @@ fn main() -> Result<()> {
         let stdin = std::io::stdin();
         let stdin = stdin.lock();
         let output = hash_reader(&base_hasher, stdin)?;
-        write_output(output, len)?;
-        println!();
+        if raw_output {
+            write_raw_output(output, len)?;
+        } else {
+            write_hex_output(output, len)?;
+            println!();
+        }
     }
     std::process::exit(if did_error { 1 } else { 0 });
 }

--- a/b3sum/src/main.rs
+++ b/b3sum/src/main.rs
@@ -125,7 +125,7 @@ fn write_hex_output(mut output: blake3::OutputReader, mut len: u64) -> Result<()
 }
 
 fn write_raw_output(mut output: blake3::OutputReader, mut len: u64) -> Result<()> {
-    let mut stdout = std::io::stdout();
+    let mut stdout = std::io::stdout().lock();
     let mut block = [0; blake3::BLOCK_LEN];
     while len > 0 {
         output.fill(&mut block);

--- a/b3sum/src/main.rs
+++ b/b3sum/src/main.rs
@@ -124,16 +124,11 @@ fn write_hex_output(mut output: blake3::OutputReader, mut len: u64) -> Result<()
     Ok(())
 }
 
-fn write_raw_output(mut output: blake3::OutputReader, mut len: u64) -> Result<()> {
+fn write_raw_output(output: blake3::OutputReader, len: u64) -> Result<()> {
+    let mut output = output.take(len);
     let stdout = std::io::stdout();
     let mut handler = stdout.lock();
-    let mut block = [0; blake3::BLOCK_LEN];
-    while len > 0 {
-        output.fill(&mut block);
-        let take_bytes = cmp::min(len, block.len() as u64);
-        handler.write(&block[..take_bytes as usize])?;
-        len -= take_bytes;
-    }
+    std::io::copy(&mut output, &mut handler)?;
 
     Ok(())
 }

--- a/b3sum/src/main.rs
+++ b/b3sum/src/main.rs
@@ -125,12 +125,13 @@ fn write_hex_output(mut output: blake3::OutputReader, mut len: u64) -> Result<()
 }
 
 fn write_raw_output(mut output: blake3::OutputReader, mut len: u64) -> Result<()> {
-    let mut stdout = std::io::stdout().lock();
+    let stdout = std::io::stdout();
+    let mut handler = stdout.lock();
     let mut block = [0; blake3::BLOCK_LEN];
     while len > 0 {
         output.fill(&mut block);
         let take_bytes = cmp::min(len, block.len() as u64);
-        stdout.write(&block[..take_bytes as usize])?;
+        handler.write(&block[..take_bytes as usize])?;
         len -= take_bytes;
     }
 

--- a/b3sum/tests/test.rs
+++ b/b3sum/tests/test.rs
@@ -108,7 +108,15 @@ fn test_length_without_value_is_an_error() {
 
 #[test]
 fn test_raw_with_multi_files_is_an_error() {
-    let result = cmd!(b3sum_exe(), "--raw", "file1", "file2")
+    let f1 = tempfile::NamedTempFile::new().unwrap();
+    let f2 = tempfile::NamedTempFile::new().unwrap();
+
+    // Make sure it doesn't error with just one file
+    let result = cmd!(b3sum_exe(), "--raw", f1.path()).stdout_capture().run();
+    assert!(result.is_ok());
+
+    // Make sure it errors when both file are passed
+    let result = cmd!(b3sum_exe(), "--raw", f1.path(), f2.path())
         .stderr_capture()
         .run();
     assert!(result.is_err());

--- a/b3sum/tests/test.rs
+++ b/b3sum/tests/test.rs
@@ -17,13 +17,13 @@ fn test_hash_one() {
 #[test]
 fn test_hash_one_raw() {
     let expected = blake3::hash(b"foo").as_bytes().to_owned();
-    let mut stdout = Vec::new();
-    let mut output_reader = cmd!(b3sum_exe(), "--raw")
+    let output = cmd!(b3sum_exe(), "--raw")
         .stdin_bytes("foo")
-        .reader()
-        .unwrap();
-    output_reader.read_to_end(&mut stdout).unwrap();
-    assert_eq!(expected, stdout.as_slice());
+        .stdout_capture()
+        .run()
+        .unwrap()
+        .stdout;
+    assert_eq!(expected, output.as_slice());
 }
 
 #[test]


### PR DESCRIPTION
This PR adds support for raw output (as opposed to hex encoded output). 

This is useful for piping the output of the hash function to another process (eg to openssl for signing). 

```
b3sum --raw README.md
����.2O����c��+�=[F�˱��STQ
```

Some details:
 1. Raw output only works on stdin or a single file. It will return an error if multiple files are passed. This is documented in `--help`
2. No file names are displayed with `--raw`
3. No terminating linebreak is printed. This is correct behavior for raw binary output.

This resolve issue #18 . 