### PR TITLE
Adding from_hex and implementing FromStr for Hash

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,12 +177,18 @@ impl Hash {
         s
     }
 
-    /// Parse a fixed-length hexidecimal string and return the resulting Hash.
+    /// Parse a hexidecimal string and return the resulting Hash.
     ///
-    /// [`ArrayString`]: https://docs.rs/arrayvec/0.5.1/arrayvec/struct.ArrayString.html
-    pub fn from_hex(hex: ArrayString<[u8; 2 * OUT_LEN]>) -> Result<Self, ParseError> {
+    /// The string must be 64 characters long, producting a 32 byte digest.
+    /// All other string length will return a `ParseError::InvalidLen`.
+    pub fn from_hex(hex: &str) -> Result<Self, ParseError> {
+        let str_bytes = hex.as_bytes();
+        if str_bytes.len() != OUT_LEN * 2 {
+            return Err(ParseError::InvalidLen);
+        }
+
         let mut bytes: [u8; OUT_LEN] = [0; OUT_LEN];
-        for (i, pair) in hex.as_str().as_bytes().chunks(2).enumerate() {
+        for (i, pair) in str_bytes.chunks(2).enumerate() {
             bytes[i] = hex_val(pair[0])? << 4 | hex_val(pair[1])?;
         }
 
@@ -217,9 +223,7 @@ impl core::str::FromStr for Hash {
     type Err = ParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let string =
-            ArrayString::<[u8; OUT_LEN * 2]>::from(s).map_err(|_| ParseError::InvalidLen)?;
-        Hash::from_hex(string)
+        Hash::from_hex(s)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,6 +166,27 @@ impl Hash {
         }
         s
     }
+
+    /// Parse a fixed-length hexidecimal string and return the resulting Hash.
+    ///
+    /// [`ArrayString`]: https://docs.rs/arrayvec/0.5.1/arrayvec/struct.ArrayString.html
+    pub fn from_hex(hex: ArrayString<[u8; 2 * OUT_LEN]>) -> Result<Self, std::io::ErrorKind> {
+        let mut bytes: [u8; OUT_LEN] = [0; OUT_LEN];
+        for (i, pair) in hex.as_str().as_bytes().chunks(2).enumerate() {
+            bytes[i] = hex_val(pair[0])? << 4 | hex_val(pair[1])?;
+        }
+
+        return Ok(Hash::from(bytes));
+
+        fn hex_val(c: u8) -> Result<u8, std::io::ErrorKind> {
+            match c {
+                b'A'..=b'F' => Ok(c - b'A' + 10),
+                b'a'..=b'f' => Ok(c - b'a' + 10),
+                b'0'..=b'9' => Ok(c - b'0'),
+                _ => Err(std::io::ErrorKind::InvalidInput),
+            }
+        }
+    }
 }
 
 impl From<[u8; OUT_LEN]> for Hash {
@@ -179,6 +200,16 @@ impl From<Hash> for [u8; OUT_LEN] {
     #[inline]
     fn from(hash: Hash) -> Self {
         hash.0
+    }
+}
+
+impl core::str::FromStr for Hash {
+    type Err = std::io::ErrorKind;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let string = ArrayString::<[u8; OUT_LEN * 2]>::from(s)
+            .map_err(|_| std::io::ErrorKind::InvalidInput)?;
+        Hash::from_hex(string)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,7 @@ const DERIVE_KEY_CONTEXT: u8 = 1 << 5;
 const DERIVE_KEY_MATERIAL: u8 = 1 << 6;
 
 /// Errors from parsing hex values
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum ParseError {
     /// Hexadecimal str contains invalid character
     InvalidChar,

--- a/src/test.rs
+++ b/src/test.rs
@@ -449,3 +449,22 @@ fn test_msg_schdule_permutation() {
 
     assert_eq!(generated, crate::MSG_SCHEDULE);
 }
+
+#[test]
+fn test_hex_encoding_decoding() {
+    let digest_str = "04e0bb39f30b1a3feb89f536c93be15055482df748674b00d26e5a75777702e9";
+    let mut hasher = crate::Hasher::new();
+    hasher.update(b"foo");
+    let digest = hasher.finalize();
+    assert_eq!(digest.to_hex().as_str(), digest_str);
+
+    // Test round trip
+    let input = arrayvec::ArrayString::from(digest_str).unwrap();
+    assert_eq!(digest.to_hex().as_str(), digest_str);
+    let digest = crate::Hash::from_hex(input).unwrap();
+    assert_eq!(digest.to_hex().as_str(), digest_str);
+
+    // Test string parsing
+    let digest: crate::Hash = digest_str.parse().unwrap();
+    assert_eq!(digest.to_hex().as_str(), digest_str);
+}

--- a/src/test.rs
+++ b/src/test.rs
@@ -459,12 +459,10 @@ fn test_hex_encoding_decoding() {
     assert_eq!(digest.to_hex().as_str(), digest_str);
 
     // Test round trip
-    let input = arrayvec::ArrayString::from(digest_str).unwrap();
-    assert_eq!(digest.to_hex().as_str(), digest_str);
-    let digest = crate::Hash::from_hex(input).unwrap();
+    let digest = crate::Hash::from_hex(digest_str).unwrap();
     assert_eq!(digest.to_hex().as_str(), digest_str);
 
-    // Test string parsing
+    // Test string parsing via FromStr
     let digest: crate::Hash = digest_str.parse().unwrap();
     assert_eq!(digest.to_hex().as_str(), digest_str);
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -465,4 +465,13 @@ fn test_hex_encoding_decoding() {
     // Test string parsing via FromStr
     let digest: crate::Hash = digest_str.parse().unwrap();
     assert_eq!(digest.to_hex().as_str(), digest_str);
+
+    // Test errors
+    let bad_len = "04e0bb39f30b1";
+    let result = crate::Hash::from_hex(bad_len).unwrap_err();
+    assert_eq!(result, crate::ParseError::InvalidLen);
+
+    let bad_char = "Z4e0bb39f30b1a3feb89f536c93be15055482df748674b00d26e5a75777702e9";
+    let result = crate::Hash::from_hex(bad_char).unwrap_err();
+    assert_eq!(result, crate::ParseError::InvalidChar);
 }


### PR DESCRIPTION
This PR adds:

1. `from_hex` for `Hash` as the inverse of `to_hex`, for completeness and convenience. 
2. `FromStr` for `Hash`
3. Adds tests for both `to_hex` and `from_hex`


