### PR TITLE
b3sum: do not mmap files smaller than 16 KiB

### DIFF
--- a/b3sum/src/main.rs
+++ b/b3sum/src/main.rs
@@ -78,6 +78,9 @@ fn maybe_memmap_file(file: &File) -> Result<Option<memmap::Mmap>> {
         // Mapping an empty file currently fails.
         // https://github.com/danburkert/memmap-rs/issues/72
         None
+    } else if file_size < 16 * 1024 {
+        // Mapping small files is not worth it.
+        None
     } else {
         // Explicitly set the length of the memory map, so that filesystem
         // changes can't race to violate the invariants we just checked.


### PR DESCRIPTION
closes #23

I also have tried disabling mmap at all to emulate heuristic based on the number of files (https://github.com/BLAKE3-team/BLAKE3/issues/23#issuecomment-574703452), but it impacts the Linux kernel source case, so it's not worth it.

# Benchmarks

1000 tiny files:
`for i in {1..1000};do echo $i > f$i;done; hyperfine 'b3sum f{1..1000}'`
```
14.9 ms (this PR)
21.6 ms (prior this PR)
17.7 ms (md5sum)
13.2 ms (do not mmap at all)
```

Linux kernel sources:
`cd linux-5.4.12; time sh -c 'find -type f | xargs b3sum > /dev/null'`
```
3.359 s (this PR)
3.826 s (prior this PR)
3.612 s (md5sum)
4.256 s (do not mmap at all)
```