### PR TITLE
work in progress to remove arrayvec as a dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ std = []
 
 [dependencies]
 arrayref = "0.3.5"
-arrayvec = { version = "0.5.1", default-features = false, features = ["array-sizes-33-128"] }
 constant_time_eq = "0.1.5"
 # A performance note for the "rayon" feature: Multi-threading can have
 # significant overhead for small inputs, particularly on x86 where individual
@@ -34,6 +33,11 @@ constant_time_eq = "0.1.5"
 # it for your specific use case.
 rayon = { version = "1.2.1", optional = true }
 cfg-if = "0.1.10"
+
+# replace with crates.io version when available (probably 0.3.0 or 0.2.1)
+[dependencies.tinyvec]
+git = "https://github.com/Lokathor/tinyvec"
+features = ["nightly_const_generics", "alloc"]
 
 [dev-dependencies]
 page_size = "0.4.1"

--- a/src/avx2.rs
+++ b/src/avx2.rs
@@ -380,7 +380,7 @@ pub unsafe fn hash8(
 }
 
 #[target_feature(enable = "avx2")]
-pub unsafe fn hash_many<A: arrayvec::Array<Item = u8>>(
+pub unsafe fn hash_many<A: tinyvec::Array<Item = u8>>(
     mut inputs: &[&A],
     key: &CVWords,
     mut counter: u64,

--- a/src/c_avx512.rs
+++ b/src/c_avx512.rs
@@ -34,7 +34,7 @@ pub unsafe fn compress_xof(
 }
 
 // Unsafe because this may only be called on platforms supporting AVX-512.
-pub unsafe fn hash_many<A: arrayvec::Array<Item = u8>>(
+pub unsafe fn hash_many<A: tinyvec::Array<Item = u8>>(
     inputs: &[&A],
     key: &CVWords,
     counter: u64,

--- a/src/c_neon.rs
+++ b/src/c_neon.rs
@@ -3,7 +3,7 @@ use crate::{CVWords, IncrementCounter, BLOCK_LEN, OUT_LEN};
 pub const DEGREE: usize = 4;
 
 // Unsafe because this may only be called on platforms supporting NEON.
-pub unsafe fn hash_many<A: arrayvec::Array<Item = u8>>(
+pub unsafe fn hash_many<A: tinyvec::Array<Item = u8>>(
     inputs: &[&A],
     key: &CVWords,
     counter: u64,

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -167,7 +167,7 @@ impl Platform {
     // after every block, there's a small but measurable performance loss.
     // Compressing chunks with a dedicated loop avoids this.
 
-    pub(crate) fn hash_many<A: arrayvec::Array<Item = u8>>(
+    pub(crate) fn hash_many<A: tinyvec::Array<Item = u8>>(
         &self,
         inputs: &[&A],
         key: &CVWords,

--- a/src/portable.rs
+++ b/src/portable.rs
@@ -120,7 +120,7 @@ pub fn compress_xof(
     crate::platform::le_bytes_from_words_64(&state)
 }
 
-pub fn hash1<A: arrayvec::Array<Item = u8>>(
+pub fn hash1<A: tinyvec::Array<Item = u8>>(
     input: &A,
     key: &CVWords,
     counter: u64,
@@ -150,7 +150,7 @@ pub fn hash1<A: arrayvec::Array<Item = u8>>(
     *out = crate::platform::le_bytes_from_words_32(&cv);
 }
 
-pub fn hash_many<A: arrayvec::Array<Item = u8>>(
+pub fn hash_many<A: tinyvec::Array<Item = u8>>(
     inputs: &[&A],
     key: &CVWords,
     mut counter: u64,

--- a/src/sse41.rs
+++ b/src/sse41.rs
@@ -629,7 +629,7 @@ pub unsafe fn hash4(
 }
 
 #[target_feature(enable = "sse4.1")]
-unsafe fn hash1<A: arrayvec::Array<Item = u8>>(
+unsafe fn hash1<A: tinyvec::Array<Item = u8>>(
     input: &A,
     key: &CVWords,
     counter: u64,
@@ -660,7 +660,7 @@ unsafe fn hash1<A: arrayvec::Array<Item = u8>>(
 }
 
 #[target_feature(enable = "sse4.1")]
-pub unsafe fn hash_many<A: arrayvec::Array<Item = u8>>(
+pub unsafe fn hash_many<A: tinyvec::Array<Item = u8>>(
     mut inputs: &[&A],
     key: &CVWords,
     mut counter: u64,

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,6 +1,5 @@
 use crate::{CVBytes, CVWords, IncrementCounter, BLOCK_LEN, CHUNK_LEN, OUT_LEN};
 use arrayref::array_ref;
-use arrayvec::ArrayVec;
 use core::usize;
 use rand::prelude::*;
 
@@ -105,9 +104,9 @@ pub fn test_hash_many_fn(
     let counter = (1u64 << 32) - 1;
 
     // First hash chunks.
-    let mut chunks = ArrayVec::<[&[u8; CHUNK_LEN]; NUM_INPUTS]>::new();
-    for i in 0..NUM_INPUTS {
-        chunks.push(array_ref!(input_buf, i * CHUNK_LEN, CHUNK_LEN));
+    let mut chunks = [&[0u8; CHUNK_LEN]; NUM_INPUTS];
+    for (i, chunk) in (0..NUM_INPUTS).into_iter().zip(&mut chunks) {
+        *chunk = array_ref!(input_buf, i * CHUNK_LEN, CHUNK_LEN);
     }
     let mut portable_chunks_out = [0; NUM_INPUTS * OUT_LEN];
     crate::portable::hash_many(
@@ -144,9 +143,9 @@ pub fn test_hash_many_fn(
     }
 
     // Then hash parents.
-    let mut parents = ArrayVec::<[&[u8; 2 * OUT_LEN]; NUM_INPUTS]>::new();
-    for i in 0..NUM_INPUTS {
-        parents.push(array_ref!(input_buf, i * 2 * OUT_LEN, 2 * OUT_LEN));
+    let mut parents = [&[0u8; 2 * OUT_LEN]; NUM_INPUTS];
+    for (i, parent) in (0..NUM_INPUTS).into_iter().zip(&mut parents) {
+        *parent = array_ref!(input_buf, i * 2 * OUT_LEN, 2 * OUT_LEN);
     }
     let mut portable_parents_out = [0; NUM_INPUTS * OUT_LEN];
     crate::portable::hash_many(


### PR DESCRIPTION
[`arrayvec`](https://docs.rs/arrayvec) contains a fair bit of unsafe code ~~and is generally preferred against; in favor of straight up arrays or [`tinyvec`](https://docs.rs/tinyvec)~~. Tinyvec is 100% safe, but requires the containing items to implement `Default` and doesn't yet support `String`s (because `&mut str` isn't awfully useful in Rust without unsafe code).

I'm not sure this BLAKE3 implementation needs either `ArrayVec` implementation; does the state ever need to grow past the allocated array? If not, it can be replaced with just an array. If necessary, `tinyvec::TinyVec` does support switching over to the heap when the collection exceeds the array allocation (with the `alloc` feature).

A couple tests are failing but I cannot pin these down. Any ideas?

**Edit**: I would also suggest against `arrayref` too because `std::convert::TryInto` exists; but as usual this is highly restricted until const-generics land and once they do; [`arrayref` is set to go safe anyway](https://github.com/droundy/arrayref/issues/18) and the unsafe code does look correct.