### PR TITLE
b3sum: add no-mmap option

### DIFF
--- a/b3sum/tests/test.rs
+++ b/b3sum/tests/test.rs
@@ -98,6 +98,19 @@ fn test_derive_key() {
 }
 
 #[test]
+fn test_no_mmap() {
+    let f = tempfile::NamedTempFile::new().unwrap();
+    f.as_file().write_all(b"foo").unwrap();
+    f.as_file().flush().unwrap();
+
+    let expected = blake3::hash(b"foo").to_hex();
+    let output = cmd!(b3sum_exe(), "--no-mmap", "--no-names", f.path())
+        .read()
+        .unwrap();
+    assert_eq!(&*expected, &*output);
+}
+
+#[test]
 fn test_length_without_value_is_an_error() {
     let result = cmd!(b3sum_exe(), "--length")
         .stdin_bytes("foo")


### PR DESCRIPTION
Using mmap is not always the best option. For instance, if the file is
truncated while being read, b3sum will receive a SIGBUS and abort.

Follow ripgrep's lead and add a --no-mmap option to disable mmap. This
can also help benchmark the mmap versus the read path, and help debug
performance issues potentially caused by mmap access patterns (like
issue #32).