### PR TITLE
Use large buffer for no-mmap

### DIFF
--- a/b3sum/Cargo.toml
+++ b/b3sum/Cargo.toml
@@ -20,6 +20,7 @@ blake3 = { version = "0.1", path = ".." }
 clap = { version = "2.33.0", default-features = false }
 hex = "0.4.0"
 memmap = { version = "0.7.0", optional = true }
+num_cpus = "1.0"
 
 [dev-dependencies]
 assert_cmd = "0.12.0"

--- a/b3sum/tests/test.rs
+++ b/b3sum/tests/test.rs
@@ -98,6 +98,19 @@ fn test_derive_key() {
 }
 
 #[test]
+fn test_no_mmap() {
+    let f = tempfile::NamedTempFile::new().unwrap();
+    f.as_file().write_all(b"foo").unwrap();
+    f.as_file().flush().unwrap();
+
+    let expected = blake3::hash(b"foo").to_hex();
+    let output = cmd!(b3sum_exe(), "--no-mmap", "--no-names", f.path())
+        .read()
+        .unwrap();
+    assert_eq!(&*expected, &*output);
+}
+
+#[test]
 fn test_length_without_value_is_an_error() {
     let result = cmd!(b3sum_exe(), "--length")
         .stdin_bytes("foo")


### PR DESCRIPTION
Instead of the default 8192-byte buffer, use a large buffer when not
using mmap. Also add a hidden command line option to vary the buffer
size for benchmarking.

The default value chosen is 256 KiB per logical core. This size should
be smaller than the L3 cache for most common desktop processors.

This pull request depends on https://github.com/BLAKE3-team/BLAKE3/pull/36 due to conflicts.

Unfortunately, this is a failed experiment. Testing with a 3 GiB zero-filled file on tmpfs, the fastest buffer size is 8192 bytes, exactly the size `std::io::copy` uses; even using mmap is slower. I'm opening this pull request in case you want to try for yourself, but feel free to close it without merging.