### PR TITLE
create /tmp/bigfile with truncate instead of head

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ hashing it, for example as follows:
 
 ```bash
 # Create a 1 GB file.
-head -c 1000000000 /dev/zero > /tmp/bigfile
+truncate -s 1GB /tmp/bigfile
 # Hash it with SHA-256.
 time openssl sha256 /tmp/bigfile
 # Hash it with BLAKE3.


### PR DESCRIPTION
 truncate will create a sparse file if supported by the system, which should rule out IO bottlenecks, and not actually consume 1 GB of disk space, and be much faster to create (especially if you're not running on a SSD) - unlike `head >`

- on my laptop with a Intel i7-9750H running in power-saving mode on battery with a 1TB Samsung 960 Evo SSD with a single-thread sequential-write performance of ~2076MB/s on CrystalMark 7:
```
$ time truncate -s 1GB bigfile

real    0m0.051s
user    0m0.000s
sys     0m0.030s

hans@LAPTOP-4AVGFSJI ~
$ rm bigfile

hans@LAPTOP-4AVGFSJI ~
$ time head -c 1000000000 /dev/zero > bigfile

real    0m1.269s
user    0m0.390s
sys     0m0.812s
```