### PR TITLE
create /tmp/bigfile with dd instead of head

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ hashing it, for example as follows:
 
 ```bash
 # Create a 1 GB file.
-head -c 1000000000 /dev/zero > /tmp/bigfile
+dd if=/dev/null bs=1 count=0 seek=1000000000 of=/tmp/bigfile
 # Hash it with SHA-256.
 time openssl sha256 /tmp/bigfile
 # Hash it with BLAKE3.


### PR DESCRIPTION
dd will create a sparse file if supported by the system, which should rule out IO bottlenecks, and not actually consume 1 GB of disk space, and be much faster to create (especially if you're not running on a SSD) - unlike `head >`

btw on GNU dd you can use `seek=1GB` instead of 1000000000, but not sure how portable that is on systems like MacOS or *BSD