### PR TITLE
allow for construction of hash in const fn context

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,6 +198,12 @@ fn counter_high(counter: u64) -> u32 {
 #[derive(Clone, Copy, Hash)]
 pub struct Hash([u8; OUT_LEN]);
 
+
+/// Provided to allow for construction of magic hash values (eg null commit in git as [0; OUT_LEN])
+pub const fn construct_magic_hash(bytes: [u8; OUT_LEN]) -> Hash {
+    Hash(bytes)
+}
+
 impl Hash {
     /// The bytes of the `Hash`. Note that byte arrays don't provide
     /// constant-time equality checking, so if  you need to compare hashes,


### PR DESCRIPTION
This might be an antipattern that you don't want to encourage, but I found myself wanting to construct a const `Hash` in rust and added a shim to allow for it, eg:

```rust
pub const NULL_HASH: MyDomainHash = MyDomainHash(blake3::construct_magic_hash([0; 32]));
```

Happy to add more documentation if this is something you'd be open to merging.