### PR TITLE
C intrinsics: Use function attributes on GCC and Clang

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -35,13 +35,13 @@ all: blake3.c blake3_dispatch.c blake3_portable.c main.c $(TARGETS)
 	$(CC) $(CFLAGS) $(EXTRAFLAGS) $^ -o $(NAME)
 
 blake3_sse41.o: blake3_sse41.c
-	$(CC) $(CFLAGS) $(EXTRAFLAGS) -c $^ -o $@ -msse4.1
+	$(CC) $(CFLAGS) $(EXTRAFLAGS) -c $^ -o $@
 
 blake3_avx2.o: blake3_avx2.c
-	$(CC) $(CFLAGS) $(EXTRAFLAGS) -c $^ -o $@ -mavx2
+	$(CC) $(CFLAGS) $(EXTRAFLAGS) -c $^ -o $@
 
 blake3_avx512.o: blake3_avx512.c
-	$(CC) $(CFLAGS) $(EXTRAFLAGS) -c $^ -o $@ -mavx512f -mavx512vl
+	$(CC) $(CFLAGS) $(EXTRAFLAGS) -c $^ -o $@
 
 blake3_neon.o: blake3_neon.c
 	$(CC) $(CFLAGS) $(EXTRAFLAGS) -c $^ -o $@
@@ -57,5 +57,5 @@ test_asm: CFLAGS += -DBLAKE3_TESTING -fsanitize=address,undefined
 test_asm: asm
 	./test.py
 
-clean: 
+clean:
 	rm -f $(NAME) *.o

--- a/c/README.md
+++ b/c/README.md
@@ -163,24 +163,16 @@ gcc -shared -O3 -o libblake3.so blake3.c blake3_dispatch.c blake3_portable.c \
     blake3_sse41_x86-64_unix.S blake3_avx2_x86-64_unix.S blake3_avx512_x86-64_unix.S
 ```
 
-When building the intrinsics-based implementations, you need to build
-each implementation separately, with the corresponding instruction set
-explicitly enabled in the compiler. Here's the same shared library using
-the intrinsics-based implementations:
+Here's the same shared library using the intrinsics-based implementations:
 
 ```bash
-gcc -c -fPIC -O3 -msse4.1 blake3_sse41.c -o blake3_sse41.o
-gcc -c -fPIC -O3 -mavx2 blake3_avx2.c -o blake3_avx2.o
-gcc -c -fPIC -O3 -mavx512f -mavx512vl blake3_avx512.c -o blake3_avx512.o
 gcc -shared -O3 -o libblake3.so blake3.c blake3_dispatch.c blake3_portable.c \
-    blake3_avx2.o blake3_avx512.o blake3_sse41.o
+    blake3_avx2.c blake3_avx512.c blake3_sse41.c
 ```
 
-Note above that building `blake3_avx512.c` requires both `-mavx512f` and
-`-mavx512vl` under GCC and Clang, as shown above. Under MSVC, the single
-`/arch:AVX512` flag is sufficient. The MSVC equivalent of `-mavx2` is
-`/arch:AVX2`. MSVC enables SSE4.1 by defaut, and it doesn't have a
-corresponding flag.
+When building the intrinsics-based implementations under MSVC, you need to
+build `blake3_avx2.c` and `blake3_avx512.c` separately first, specifying the
+`/arch:AVX2` and `/arch:AVX512` compiler flags respectively.
 
 If you want to omit SIMD code on x86, you need to explicitly disable
 each instruction set. Here's an example of building a shared library on

--- a/c/blake3_avx512.c
+++ b/c/blake3_avx512.c
@@ -10,10 +10,12 @@ INLINE __m128i loadu_128(const uint8_t src[16]) {
   return _mm_loadu_si128((const __m128i *)src);
 }
 
+TARGET_AVX512
 INLINE __m256i loadu_256(const uint8_t src[32]) {
   return _mm256_loadu_si256((const __m256i *)src);
 }
 
+TARGET_AVX512
 INLINE __m512i loadu_512(const uint8_t src[64]) {
   return _mm512_loadu_si512((const __m512i *)src);
 }
@@ -22,54 +24,73 @@ INLINE void storeu_128(__m128i src, uint8_t dest[16]) {
   _mm_storeu_si128((__m128i *)dest, src);
 }
 
+TARGET_AVX512
 INLINE void storeu_256(__m256i src, uint8_t dest[16]) {
   _mm256_storeu_si256((__m256i *)dest, src);
 }
 
 INLINE __m128i add_128(__m128i a, __m128i b) { return _mm_add_epi32(a, b); }
 
+TARGET_AVX512
 INLINE __m256i add_256(__m256i a, __m256i b) { return _mm256_add_epi32(a, b); }
 
+TARGET_AVX512
 INLINE __m512i add_512(__m512i a, __m512i b) { return _mm512_add_epi32(a, b); }
 
 INLINE __m128i xor_128(__m128i a, __m128i b) { return _mm_xor_si128(a, b); }
 
+TARGET_AVX512
 INLINE __m256i xor_256(__m256i a, __m256i b) { return _mm256_xor_si256(a, b); }
 
+TARGET_AVX512
 INLINE __m512i xor_512(__m512i a, __m512i b) { return _mm512_xor_si512(a, b); }
 
 INLINE __m128i set1_128(uint32_t x) { return _mm_set1_epi32((int32_t)x); }
 
+TARGET_AVX512
 INLINE __m256i set1_256(uint32_t x) { return _mm256_set1_epi32((int32_t)x); }
 
+TARGET_AVX512
 INLINE __m512i set1_512(uint32_t x) { return _mm512_set1_epi32((int32_t)x); }
 
 INLINE __m128i set4(uint32_t a, uint32_t b, uint32_t c, uint32_t d) {
   return _mm_setr_epi32((int32_t)a, (int32_t)b, (int32_t)c, (int32_t)d);
 }
 
+TARGET_AVX512
 INLINE __m128i rot16_128(__m128i x) { return _mm_ror_epi32(x, 16); }
 
+TARGET_AVX512
 INLINE __m256i rot16_256(__m256i x) { return _mm256_ror_epi32(x, 16); }
 
+TARGET_AVX512
 INLINE __m512i rot16_512(__m512i x) { return _mm512_ror_epi32(x, 16); }
 
+TARGET_AVX512
 INLINE __m128i rot12_128(__m128i x) { return _mm_ror_epi32(x, 12); }
 
+TARGET_AVX512
 INLINE __m256i rot12_256(__m256i x) { return _mm256_ror_epi32(x, 12); }
 
+TARGET_AVX512
 INLINE __m512i rot12_512(__m512i x) { return _mm512_ror_epi32(x, 12); }
 
+TARGET_AVX512
 INLINE __m128i rot8_128(__m128i x) { return _mm_ror_epi32(x, 8); }
 
+TARGET_AVX512
 INLINE __m256i rot8_256(__m256i x) { return _mm256_ror_epi32(x, 8); }
 
+TARGET_AVX512
 INLINE __m512i rot8_512(__m512i x) { return _mm512_ror_epi32(x, 8); }
 
+TARGET_AVX512
 INLINE __m128i rot7_128(__m128i x) { return _mm_ror_epi32(x, 7); }
 
+TARGET_AVX512
 INLINE __m256i rot7_256(__m256i x) { return _mm256_ror_epi32(x, 7); }
 
+TARGET_AVX512
 INLINE __m512i rot7_512(__m512i x) { return _mm512_ror_epi32(x, 7); }
 
 /*
@@ -78,6 +99,7 @@ INLINE __m512i rot7_512(__m512i x) { return _mm512_ror_epi32(x, 7); }
  * ----------------------------------------------------------------------------
  */
 
+TARGET_AVX512
 INLINE void g1(__m128i *row0, __m128i *row1, __m128i *row2, __m128i *row3,
                __m128i m) {
   *row0 = add_128(add_128(*row0, m), *row1);
@@ -88,6 +110,7 @@ INLINE void g1(__m128i *row0, __m128i *row1, __m128i *row2, __m128i *row3,
   *row1 = rot12_128(*row1);
 }
 
+TARGET_AVX512
 INLINE void g2(__m128i *row0, __m128i *row1, __m128i *row2, __m128i *row3,
                __m128i m) {
   *row0 = add_128(add_128(*row0, m), *row1);
@@ -113,6 +136,7 @@ INLINE void undiagonalize(__m128i *row0, __m128i *row2, __m128i *row3) {
   *row2 = _mm_shuffle_epi32(*row2, _MM_SHUFFLE(2, 1, 0, 3));
 }
 
+TARGET_AVX512
 INLINE void compress_pre(__m128i rows[4], const uint32_t cv[8],
                          const uint8_t block[BLAKE3_BLOCK_LEN],
                          uint8_t block_len, uint64_t counter, uint8_t flags) {
@@ -284,6 +308,7 @@ INLINE void compress_pre(__m128i rows[4], const uint32_t cv[8],
   undiagonalize(&rows[0], &rows[2], &rows[3]);
 }
 
+TARGET_AVX512
 void blake3_compress_xof_avx512(const uint32_t cv[8],
                                 const uint8_t block[BLAKE3_BLOCK_LEN],
                                 uint8_t block_len, uint64_t counter,
@@ -296,6 +321,7 @@ void blake3_compress_xof_avx512(const uint32_t cv[8],
   storeu_128(xor_128(rows[3], loadu_128((uint8_t *)&cv[4])), &out[48]);
 }
 
+TARGET_AVX512
 void blake3_compress_in_place_avx512(uint32_t cv[8],
                                      const uint8_t block[BLAKE3_BLOCK_LEN],
                                      uint8_t block_len, uint64_t counter,
@@ -312,6 +338,7 @@ void blake3_compress_in_place_avx512(uint32_t cv[8],
  * ----------------------------------------------------------------------------
  */
 
+TARGET_AVX512
 INLINE void round_fn4(__m128i v[16], __m128i m[16], size_t r) {
   v[0] = add_128(v[0], m[(size_t)MSG_SCHEDULE[r][0]]);
   v[1] = add_128(v[1], m[(size_t)MSG_SCHEDULE[r][2]]);
@@ -476,6 +503,7 @@ INLINE void transpose_msg_vecs4(const uint8_t *const *inputs,
   transpose_vecs_128(&out[12]);
 }
 
+TARGET_AVX512
 INLINE void load_counters4(uint64_t counter, bool increment_counter,
                            __m128i *out_lo, __m128i *out_hi) {
   uint64_t mask = (increment_counter ? ~0 : 0);
@@ -488,6 +516,7 @@ INLINE void load_counters4(uint64_t counter, bool increment_counter,
   *out_hi = _mm256_cvtepi64_epi32(_mm256_srli_epi64(counters, 32));
 }
 
+TARGET_AVX512
 void blake3_hash4_avx512(const uint8_t *const *inputs, size_t blocks,
                          const uint32_t key[8], uint64_t counter,
                          bool increment_counter, uint8_t flags,
@@ -555,6 +584,7 @@ void blake3_hash4_avx512(const uint8_t *const *inputs, size_t blocks,
  * ----------------------------------------------------------------------------
  */
 
+TARGET_AVX512
 INLINE void round_fn8(__m256i v[16], __m256i m[16], size_t r) {
   v[0] = add_256(v[0], m[(size_t)MSG_SCHEDULE[r][0]]);
   v[1] = add_256(v[1], m[(size_t)MSG_SCHEDULE[r][2]]);
@@ -671,6 +701,7 @@ INLINE void round_fn8(__m256i v[16], __m256i m[16], size_t r) {
   v[4] = rot7_256(v[4]);
 }
 
+TARGET_AVX512
 INLINE void transpose_vecs_256(__m256i vecs[8]) {
   // Interleave 32-bit lanes. The low unpack is lanes 00/11/44/55, and the high
   // is 22/33/66/77.
@@ -705,6 +736,7 @@ INLINE void transpose_vecs_256(__m256i vecs[8]) {
   vecs[7] = _mm256_permute2x128_si256(abcd_37, efgh_37, 0x31);
 }
 
+TARGET_AVX512
 INLINE void transpose_msg_vecs8(const uint8_t *const *inputs,
                                 size_t block_offset, __m256i out[16]) {
   out[0] = loadu_256(&inputs[0][block_offset + 0 * sizeof(__m256i)]);
@@ -730,6 +762,7 @@ INLINE void transpose_msg_vecs8(const uint8_t *const *inputs,
   transpose_vecs_256(&out[8]);
 }
 
+TARGET_AVX512
 INLINE void load_counters8(uint64_t counter, bool increment_counter,
                            __m256i *out_lo, __m256i *out_hi) {
   uint64_t mask = (increment_counter ? ~0 : 0);
@@ -742,6 +775,7 @@ INLINE void load_counters8(uint64_t counter, bool increment_counter,
   *out_hi = _mm512_cvtepi64_epi32(_mm512_srli_epi64(counters, 32));
 }
 
+TARGET_AVX512
 void blake3_hash8_avx512(const uint8_t *const *inputs, size_t blocks,
                          const uint32_t key[8], uint64_t counter,
                          bool increment_counter, uint8_t flags,
@@ -806,6 +840,7 @@ void blake3_hash8_avx512(const uint8_t *const *inputs, size_t blocks,
  * ----------------------------------------------------------------------------
  */
 
+TARGET_AVX512
 INLINE void round_fn16(__m512i v[16], __m512i m[16], size_t r) {
   v[0] = add_512(v[0], m[(size_t)MSG_SCHEDULE[r][0]]);
   v[1] = add_512(v[1], m[(size_t)MSG_SCHEDULE[r][2]]);
@@ -925,6 +960,7 @@ INLINE void round_fn16(__m512i v[16], __m512i m[16], size_t r) {
 // 0b10001000, or lanes a0/a2/b0/b2 in little-endian order
 #define LO_IMM8 0x88
 
+TARGET_AVX512
 INLINE __m512i unpack_lo_128(__m512i a, __m512i b) {
   return _mm512_shuffle_i32x4(a, b, LO_IMM8);
 }
@@ -932,10 +968,12 @@ INLINE __m512i unpack_lo_128(__m512i a, __m512i b) {
 // 0b11011101, or lanes a1/a3/b1/b3 in little-endian order
 #define HI_IMM8 0xdd
 
+TARGET_AVX512
 INLINE __m512i unpack_hi_128(__m512i a, __m512i b) {
   return _mm512_shuffle_i32x4(a, b, HI_IMM8);
 }
 
+TARGET_AVX512
 INLINE void transpose_vecs_512(__m512i vecs[16]) {
   // Interleave 32-bit lanes. The _0 unpack is lanes
   // 0/0/1/1/4/4/5/5/8/8/9/9/12/12/13/13, and the _2 unpack is lanes
@@ -1018,6 +1056,7 @@ INLINE void transpose_vecs_512(__m512i vecs[16]) {
   vecs[15] = unpack_hi_128(abcdefgh_7, ijklmnop_7);
 }
 
+TARGET_AVX512
 INLINE void transpose_msg_vecs16(const uint8_t *const *inputs,
                                  size_t block_offset, __m512i out[16]) {
   out[0] = loadu_512(&inputs[0][block_offset]);
@@ -1042,6 +1081,7 @@ INLINE void transpose_msg_vecs16(const uint8_t *const *inputs,
   transpose_vecs_512(out);
 }
 
+TARGET_AVX512
 INLINE void load_counters16(uint64_t counter, bool increment_counter,
                             __m512i *out_lo, __m512i *out_hi) {
   const __m512i mask = _mm512_set1_epi32(-(int32_t)increment_counter);
@@ -1054,6 +1094,7 @@ INLINE void load_counters16(uint64_t counter, bool increment_counter,
   *out_hi = h;
 }
 
+TARGET_AVX512
 void blake3_hash16_avx512(const uint8_t *const *inputs, size_t blocks,
                           const uint32_t key[8], uint64_t counter,
                           bool increment_counter, uint8_t flags,

--- a/c/blake3_impl.h
+++ b/c/blake3_impl.h
@@ -28,7 +28,7 @@ enum blake3_flags {
 #define INLINE static inline __attribute__((always_inline))
 #endif
 
-#if defined(__x86_64__) || defined(_M_X64) 
+#if defined(__x86_64__) || defined(_M_X64)
 #define IS_X86
 #define IS_X86_64
 #endif
@@ -51,6 +51,18 @@ enum blake3_flags {
 #define MAX_SIMD_DEGREE 4
 #else
 #define MAX_SIMD_DEGREE 1
+#endif
+
+// On GCC and Clang we can enable intrinsics per function, rather than
+// requiring their respective -mavx2, -mavx512vl, etc. compiler flags.
+#if defined(__GNUC__) || defined(__clang__)
+#  define TARGET_AVX2 __attribute__((target("avx2")))
+#  define TARGET_AVX512 __attribute__((target("avx512vl,avx512f")))
+#  define TARGET_SSE41 __attribute__((target("sse4.1")))
+#else
+#  define TARGET_AVX2    // On MSVC, use the compiler flag /arch:AVX2
+#  define TARGET_AVX512  // On MSVC, use the compiler flag /argc:AVX512
+#  define TARGET_SSE41   // On MSVC, this is always enabled.
 #endif
 
 // There are some places where we want a static size that's equal to the
@@ -117,7 +129,7 @@ INLINE unsigned int popcnt(uint64_t x) {
 }
 
 // Largest power of two less than or equal to x. As a special case, returns 1
-// when x is 0. 
+// when x is 0.
 INLINE uint64_t round_down_to_power_of_2(uint64_t x) {
   return 1ULL << highest_one(x | 1);
 }
@@ -230,6 +242,5 @@ void blake3_hash_many_neon(const uint8_t *const *inputs, size_t num_inputs,
                            uint8_t flags, uint8_t flags_start,
                            uint8_t flags_end, uint8_t *out);
 #endif
-
 
 #endif /* BLAKE3_IMPL_H */

--- a/c/blake3_sse41.c
+++ b/c/blake3_sse41.c
@@ -27,6 +27,7 @@ INLINE __m128i set4(uint32_t a, uint32_t b, uint32_t c, uint32_t d) {
   return _mm_setr_epi32((int32_t)a, (int32_t)b, (int32_t)c, (int32_t)d);
 }
 
+TARGET_SSE41
 INLINE __m128i rot16(__m128i x) {
   return _mm_shuffle_epi8(
       x, _mm_set_epi8(13, 12, 15, 14, 9, 8, 11, 10, 5, 4, 7, 6, 1, 0, 3, 2));
@@ -36,6 +37,7 @@ INLINE __m128i rot12(__m128i x) {
   return xorv(_mm_srli_epi32(x, 12), _mm_slli_epi32(x, 32 - 12));
 }
 
+TARGET_SSE41
 INLINE __m128i rot8(__m128i x) {
   return _mm_shuffle_epi8(
       x, _mm_set_epi8(12, 15, 14, 13, 8, 11, 10, 9, 4, 7, 6, 5, 0, 3, 2, 1));
@@ -45,6 +47,7 @@ INLINE __m128i rot7(__m128i x) {
   return xorv(_mm_srli_epi32(x, 7), _mm_slli_epi32(x, 32 - 7));
 }
 
+TARGET_SSE41
 INLINE void g1(__m128i *row0, __m128i *row1, __m128i *row2, __m128i *row3,
                __m128i m) {
   *row0 = addv(addv(*row0, m), *row1);
@@ -55,6 +58,7 @@ INLINE void g1(__m128i *row0, __m128i *row1, __m128i *row2, __m128i *row3,
   *row1 = rot12(*row1);
 }
 
+TARGET_SSE41
 INLINE void g2(__m128i *row0, __m128i *row1, __m128i *row2, __m128i *row3,
                __m128i m) {
   *row0 = addv(addv(*row0, m), *row1);
@@ -80,6 +84,7 @@ INLINE void undiagonalize(__m128i *row0, __m128i *row2, __m128i *row3) {
   *row2 = _mm_shuffle_epi32(*row2, _MM_SHUFFLE(2, 1, 0, 3));
 }
 
+TARGET_SSE41
 INLINE void compress_pre(__m128i rows[4], const uint32_t cv[8],
                          const uint8_t block[BLAKE3_BLOCK_LEN],
                          uint8_t block_len, uint64_t counter, uint8_t flags) {
@@ -251,6 +256,7 @@ INLINE void compress_pre(__m128i rows[4], const uint32_t cv[8],
   undiagonalize(&rows[0], &rows[2], &rows[3]);
 }
 
+TARGET_SSE41
 void blake3_compress_in_place_sse41(uint32_t cv[8],
                                     const uint8_t block[BLAKE3_BLOCK_LEN],
                                     uint8_t block_len, uint64_t counter,
@@ -261,6 +267,7 @@ void blake3_compress_in_place_sse41(uint32_t cv[8],
   storeu(xorv(rows[1], rows[3]), (uint8_t *)&cv[4]);
 }
 
+TARGET_SSE41
 void blake3_compress_xof_sse41(const uint32_t cv[8],
                                const uint8_t block[BLAKE3_BLOCK_LEN],
                                uint8_t block_len, uint64_t counter,
@@ -273,6 +280,7 @@ void blake3_compress_xof_sse41(const uint32_t cv[8],
   storeu(xorv(rows[3], loadu((uint8_t *)&cv[4])), &out[48]);
 }
 
+TARGET_SSE41
 INLINE void round_fn(__m128i v[16], __m128i m[16], size_t r) {
   v[0] = addv(v[0], m[(size_t)MSG_SCHEDULE[r][0]]);
   v[1] = addv(v[1], m[(size_t)MSG_SCHEDULE[r][2]]);
@@ -443,13 +451,14 @@ INLINE void load_counters(uint64_t counter, bool increment_counter,
   const __m128i add0 = _mm_set_epi32(3, 2, 1, 0);
   const __m128i add1 = _mm_and_si128(mask, add0);
   __m128i l = _mm_add_epi32(_mm_set1_epi32(counter), add1);
-  __m128i carry = _mm_cmpgt_epi32(_mm_xor_si128(add1, _mm_set1_epi32(0x80000000)), 
+  __m128i carry = _mm_cmpgt_epi32(_mm_xor_si128(add1, _mm_set1_epi32(0x80000000)),
                                   _mm_xor_si128(   l, _mm_set1_epi32(0x80000000)));
   __m128i h = _mm_sub_epi32(_mm_set1_epi32(counter >> 32), carry);
   *out_lo = l;
   *out_hi = h;
 }
 
+TARGET_SSE41
 void blake3_hash4_sse41(const uint8_t *const *inputs, size_t blocks,
                         const uint32_t key[8], uint64_t counter,
                         bool increment_counter, uint8_t flags,


### PR DESCRIPTION
By enabling intrinsics per function, we make it easy for bindings to
compile all off `blake3_avx2.c`, `blake3_avx512.c` and `blake3_sse41.c`
without having to give to the C compiler different flags for each file,
a task that is often very hard to accomplish depending on the language's
packaging tools.

Related documentation:

  https://gcc.gnu.org/onlinedocs/gcc/x86-Function-Attributes.html#x86-Function-Attributes

  https://clang.llvm.org/docs/AttributeReference.html#id300

I am making use of these changes in the Haskell bindings https://github.com/k0001/hs-blake3/commit/d828472addc89134a37ccef3b53ef7a5679f789a