### PR TITLE
Bump digest crypto-mac

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,8 +75,8 @@ arrayvec = { version = "0.5.1", default-features = false, features = ["array-siz
 constant_time_eq = "0.1.5"
 rayon = { version = "1.2.1", optional = true }
 cfg-if = "0.1.10"
-digest = "0.8.1"
-crypto-mac = "0.7.0"
+digest = "0.9.0"
+crypto-mac = "0.8.0"
 
 [dev-dependencies]
 hex = "0.4.2"

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -35,14 +35,12 @@ impl digest::FixedOutput for Hasher {
     #[inline]
     fn finalize_into(self, out: &mut GenericArray<u8, Self::OutputSize>) {
         let bytes = self.finalize();
-        let mut bytes: &[u8] = bytes.as_bytes();
-        std::io::copy(&mut bytes, &mut out.as_mut_slice()).expect("failed to copy data");
+        out.as_mut_slice().clone_from_slice(bytes.as_bytes());
     }
 
     fn finalize_into_reset(&mut self, out: &mut GenericArray<u8, Self::OutputSize>) {
         let bytes = self.finalize();
-        let mut bytes: &[u8] = bytes.as_bytes();
-        std::io::copy(&mut bytes, &mut out.as_mut_slice()).expect("failed to copy data");
+        out.as_mut_slice().clone_from_slice(bytes.as_bytes());
 
         self.reset();
     }


### PR DESCRIPTION
This PR bumps digest to 0.9.0 and crypto-mac to 0.8.0

Resolves #89 