### PR TITLE
Assembly: enable CET

### DIFF
--- a/c/blake3_avx2_x86-64_unix.S
+++ b/c/blake3_avx2_x86-64_unix.S
@@ -1,3 +1,9 @@
+#if defined(__ELF__) && defined(__CET__) && __has_include(<cet.h>)
+#include <cet.h>
+#else
+#define _CET_ENDBR
+#endif
+
 .intel_syntax noprefix
 .global _blake3_hash_many_avx2
 .global blake3_hash_many_avx2
@@ -9,6 +15,7 @@
         .p2align  6
 _blake3_hash_many_avx2:
 blake3_hash_many_avx2:
+        _CET_ENDBR
         push    r15
         push    r14
         push    r13

--- a/c/blake3_avx512_x86-64_unix.S
+++ b/c/blake3_avx512_x86-64_unix.S
@@ -1,5 +1,10 @@
-.intel_syntax noprefix
+#if defined(__ELF__) && defined(__CET__) && __has_include(<cet.h>)
+#include <cet.h>
+#else
+#define _CET_ENDBR
+#endif
 
+.intel_syntax noprefix
 .global _blake3_hash_many_avx512
 .global blake3_hash_many_avx512
 .global blake3_compress_in_place_avx512
@@ -15,6 +20,7 @@
 .p2align  6
 _blake3_hash_many_avx512:
 blake3_hash_many_avx512:
+        _CET_ENDBR
         push    r15
         push    r14
         push    r13
@@ -2372,6 +2378,7 @@ blake3_hash_many_avx512:
 .p2align 6
 _blake3_compress_in_place_avx512:
 blake3_compress_in_place_avx512:
+        _CET_ENDBR
         vmovdqu xmm0, xmmword ptr [rdi]
         vmovdqu xmm1, xmmword ptr [rdi+0x10]
         movzx   eax, r8b
@@ -2454,6 +2461,7 @@ blake3_compress_in_place_avx512:
 .p2align 6
 _blake3_compress_xof_avx512:
 blake3_compress_xof_avx512:
+        _CET_ENDBR
         vmovdqu xmm0, xmmword ptr [rdi]
         vmovdqu xmm1, xmmword ptr [rdi+0x10]
         movzx   eax, r8b

--- a/c/blake3_sse41_x86-64_unix.S
+++ b/c/blake3_sse41_x86-64_unix.S
@@ -1,3 +1,9 @@
+#if defined(__ELF__) && defined(__CET__) && __has_include(<cet.h>)
+#include <cet.h>
+#else
+#define _CET_ENDBR
+#endif
+
 .intel_syntax noprefix
 .global blake3_hash_many_sse41
 .global _blake3_hash_many_sse41
@@ -13,6 +19,7 @@
         .p2align  6
 _blake3_hash_many_sse41:
 blake3_hash_many_sse41:
+        _CET_ENDBR
         push    r15
         push    r14
         push    r13
@@ -1774,6 +1781,7 @@ blake3_hash_many_sse41:
 .p2align 6
 blake3_compress_in_place_sse41:
 _blake3_compress_in_place_sse41:
+        _CET_ENDBR
         movups  xmm0, xmmword ptr [rdi]
         movups  xmm1, xmmword ptr [rdi+0x10]
         movaps  xmm2, xmmword ptr [BLAKE3_IV+rip]
@@ -1874,6 +1882,7 @@ _blake3_compress_in_place_sse41:
 .p2align 6
 blake3_compress_xof_sse41:
 _blake3_compress_xof_sse41:
+        _CET_ENDBR
         movups  xmm0, xmmword ptr [rdi]
         movups  xmm1, xmmword ptr [rdi+0x10]
         movaps  xmm2, xmmword ptr [BLAKE3_IV+rip]


### PR DESCRIPTION
Addresses #95.

With our current dispatcher, both on C and Rust, having `endbr64` at the top of the functions is rather pointless since these will never be at the end of an indirect call. But since this is a glorified `nop`, might as well.