### PR TITLE
feat: Implement `core::hash::Hasher` for `Hasher`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1266,6 +1266,17 @@ impl std::io::Write for Hasher {
     }
 }
 
+#[cfg(feature = "std")]
+impl std::hash::Hasher for Hasher {
+    fn write(&mut self, bytes: &[u8]) {
+        self.update(bytes);
+    }
+
+    fn finish(&self) -> u64 {
+        self.finalize().into()
+    }
+}
+
 /// An incremental reader for extended output, returned by
 /// [`Hasher::finalize_xof`](struct.Hasher.html#method.finalize_xof).
 #[derive(Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -239,6 +239,37 @@ impl From<Hash> for [u8; OUT_LEN] {
     }
 }
 
+/// Transforming `Hash` into `u64` will increase the number of
+/// collisions as `u64` can represent fewer values than `[u8;
+/// OUT_LEN]`.
+///
+/// Bytes from `Hash` are extracted by chunks of 8, and then added to
+/// `0u64` with a modular addition.
+#[cfg(feature = "std")]
+impl From<Hash> for u64 {
+    #[inline]
+    fn from(hash: Hash) -> Self {
+        use std::convert::TryInto;
+        use std::u64;
+
+        let bytes: [u8; OUT_LEN] = hash.into();
+
+        (0..(OUT_LEN / 8))
+            .into_iter()
+            .map(|i| (i * 8, (i + 1) * 8))
+            .fold(0u64, |accumulator, (x, y)| {
+                assert_eq!(y - x, 8);
+
+                accumulator.wrapping_add(u64::from_be_bytes(
+                    (&bytes[x..y])
+                        .try_into()
+                        // SAFETY: OK, because `y - x = 8` and `wrapping_add` expects a `[u8; 8]`.
+                        .expect("failed to convert `&[u8]` into `[u8; 8]`"),
+                ))
+            })
+    }
+}
+
 /// This implementation is constant-time.
 impl PartialEq for Hash {
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -245,12 +245,10 @@ impl From<Hash> for [u8; OUT_LEN] {
 ///
 /// Bytes from `Hash` are extracted by chunks of 8, and then added to
 /// `0u64` with a modular addition.
-#[cfg(feature = "std")]
 impl From<Hash> for u64 {
     #[inline]
     fn from(hash: Hash) -> Self {
-        use std::convert::TryInto;
-        use std::u64;
+        use core::convert::TryInto;
 
         let bytes: [u8; OUT_LEN] = hash.into();
 
@@ -1266,8 +1264,7 @@ impl std::io::Write for Hasher {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::hash::Hasher for Hasher {
+impl core::hash::Hasher for Hasher {
     fn write(&mut self, bytes: &[u8]) {
         self.update(bytes);
     }

--- a/src/test.rs
+++ b/src/test.rs
@@ -551,3 +551,31 @@ fn test_join_lengths() {
     );
     assert_eq!(CUSTOM_JOIN_CALLS.load(Ordering::SeqCst), 1);
 }
+
+#[test]
+fn test_standard_hasher() {
+    fn hash<H>(mut hasher: H) -> u64
+    where
+        H: core::hash::Hasher,
+    {
+        hasher.write_u32(2020);
+        hasher.write_u8(7);
+        hasher.write_u8(23);
+        hasher.write(b"Hello, World!");
+
+        hasher.finish()
+    }
+
+    let hash = hash(crate::Hasher::new());
+    let expected = {
+        let mut hash = crate::Hasher::new();
+        hash.update(&2020u32.to_ne_bytes());
+        hash.update(&[7]);
+        hash.update(&[23]);
+        hash.update(&b"Hello, World!"[..]);
+
+        hash.finalize().into()
+    };
+
+    assert_eq!(hash, expected);
+}


### PR DESCRIPTION
This PR is an attempt to implement `core::hash::Hasher` for `Hasher`.

To achieve that, I first needed to transform `Hash` into a `u64` (https://github.com/BLAKE3-team/BLAKE3/commit/bde6e6f8918b1d909ea4e1a006da5f893a279dbf):

> This is an attempt to encode an `Hash` into `u64`. This transformation
will increase the number of collisions as `u64` can represent fewer
values than `[u8; OUT_LEN]` (at the time of writing, `OUT_LEN` is set
to 32).
>
> Bytes from `Hash` are extracted by chunks of 8, and then added to
`u64` with a modular addition.

Then, `core::hash::Hasher` can be implemented (https://github.com/BLAKE3-team/BLAKE3/commit/41baa2f7759c95d1b8469639cfc02c8946a1dfb3):

> This is an attempt to implement the standard `Hasher` API for
`blake3`, so that implementors can use `blake3` when a generic hasher
is expected.

Things that must be discussed:

1. Do you want `Hasher` to implement `core::hash::Hasher`?
2. Do you find acceptable the strategy to convert `Hash` into `u64`?
3. If `OUT_LEN % 8 != 0`, bytes will be missed by `From<Hash>` for `u64`. Can it be different? Do we have to assert that?