### PR TITLE
Fix cross compilation with clang-cl

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -39,6 +39,23 @@ fn is_x86_64() -> bool {
     target_components()[0] == "x86_64"
 }
 
+fn is_windows_target() -> bool {
+    env::var("CARGO_CFG_TARGET_OS").unwrap() == "windows"
+}
+
+fn use_msvc_asm() -> bool {
+    // cc assumes if it is passed .asm and targetting MSVC that it can use the
+    // Microsoft assemblers, which isn't true when we're not on a Windows
+    // host, but are cross-compiling with clang-cl, so we explicitly check if
+    // we're on a Windows host (with the assumption they'll have the MSVC
+    // toolchain installed if they are, though that's not necessarily true)
+    if env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default() == "gnu" {
+        false
+    } else {
+        env::var("HOST").unwrap_or_default().contains("-windows-")
+    }
+}
+
 fn is_x86_32() -> bool {
     let arch = &target_components()[0];
     arch == "i386" || arch == "i586" || arch == "i686"
@@ -132,12 +149,14 @@ fn build_sse41_avx2_assembly() {
     println!("cargo:rustc-cfg=blake3_sse41_ffi");
     println!("cargo:rustc-cfg=blake3_avx2_ffi");
     let mut build = new_build();
-    if is_windows_msvc() {
-        build.file("c/blake3_sse41_x86-64_windows_msvc.asm");
-        build.file("c/blake3_avx2_x86-64_windows_msvc.asm");
-    } else if is_windows_gnu() {
-        build.file("c/blake3_sse41_x86-64_windows_gnu.S");
-        build.file("c/blake3_avx2_x86-64_windows_gnu.S");
+    if is_windows_target() {
+        if use_msvc_asm() {
+            build.file("c/blake3_sse41_x86-64_windows_msvc.asm");
+            build.file("c/blake3_avx2_x86-64_windows_msvc.asm");
+        } else {
+            build.file("c/blake3_sse41_x86-64_windows_gnu.S");
+            build.file("c/blake3_avx2_x86-64_windows_gnu.S");
+        }
     } else {
         // All non-Windows implementations are assumed to support
         // Linux-style assembly. These files do contain a small
@@ -150,7 +169,7 @@ fn build_sse41_avx2_assembly() {
 
 fn build_avx512_c_intrinsics() {
     // This is required on 32-bit x86 targets, since the assembly
-    // implementation doesn't support support those.
+    // implementation doesn't support those.
     println!("cargo:rustc-cfg=blake3_avx512_ffi");
     let mut build = new_build();
     build.file("c/blake3_avx512.c");
@@ -173,22 +192,25 @@ fn build_avx512_assembly() {
     assert!(is_x86_64());
     println!("cargo:rustc-cfg=blake3_avx512_ffi");
     let mut build = new_build();
-    if is_windows_msvc() {
-        build.file("c/blake3_avx512_x86-64_windows_msvc.asm");
-    } else {
-        if is_windows_gnu() {
-            build.file("c/blake3_avx512_x86-64_windows_gnu.S");
+    let mut is_msvc = false;
+    if is_windows_target() {
+        if use_msvc_asm() {
+            build.file("c/blake3_avx512_x86-64_windows_msvc.asm");
+            is_msvc = true;
         } else {
-            // All non-Windows implementations are assumed to support Linux-style
-            // assembly. These files do contain a small explicit workaround for
-            // macOS also.
-            build.file("c/blake3_avx512_x86-64_unix.S");
+            build.file("c/blake3_avx512_x86-64_windows_gnu.S");
         }
-        // Older versions of Clang require these flags, even for assembly. See
-        // https://github.com/BLAKE3-team/BLAKE3/issues/79.
+    } else {
+        build.file("c/blake3_avx512_x86-64_unix.S");
+    }
+
+    // Older versions of Clang require these flags, even for assembly. See
+    // https://github.com/BLAKE3-team/BLAKE3/issues/79.
+    if !is_msvc {
         build.flag("-mavx512f");
         build.flag("-mavx512vl");
     }
+
     build.compile("blake3_avx512_assembly");
 }
 
@@ -248,6 +270,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "cargo:rerun-if-changed={}",
             file?.path().to_str().expect("utf-8")
         );
+    }
+
+    // When compiling with clang-cl for windows, it adds .asm files to the root
+    // which we need to delete so cargo doesn't get angry
+    if is_windows_target() && !use_msvc_asm() {
+        let _ = std::fs::remove_file("blake3_avx2_x86-64_windows_gnu.asm");
+        let _ = std::fs::remove_file("blake3_avx512_x86-64_windows_gnu.asm");
+        let _ = std::fs::remove_file("blake3_sse41_x86-64_windows_gnu.asm");
     }
 
     Ok(())


### PR DESCRIPTION
When cross compiling with clang-cl for Windows, the build script was trying to use the Microsoft assembly files, which doesn't work with cc as it automatically assumes it can use the Microsoft assemblers. This just changes the logic to use the GAS files for Windows if we're targetting MSVC, but aren't actually on a Windows host.