### PR TITLE
How to access the hex inside the Hash()

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,11 @@ let mut output = [0; 1000];
 let mut output_reader = hasher.finalize_xof();
 output_reader.fill(&mut output);
 assert_eq!(&output[..32], hash1.as_bytes());
+
+// Extract hash as hex str
+let hash1_hex = &hash1.to_hex()[..];
+assert_eq!("c09afee0c9f361fb61e5ff28a7739893de766fb470c5fa82b4e5e31de27fbad4", hash1_hex);
+
 ```
 
 Besides `hash`, BLAKE3 provides two other modes, `keyed_hash` and


### PR DESCRIPTION
blake3::hash(b"str") -> Hash(`hex`)  and I want the `hex` stripped out from the Hash() as a str

This change saves time so that the next person doesn't have to read the source code to locate .to_hex()