### PR TITLE
add in missing SSE2 detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,7 @@ jobs:
       fail-fast: false
       matrix:
         arch:
+          - i586-unknown-linux-musl
           - i686-unknown-linux-musl
           - armv7-unknown-linux-gnueabihf
           - aarch64-unknown-linux-gnu
@@ -137,7 +138,7 @@ jobs:
     - run: cross test --target ${{ matrix.arch }}
     # Test building for ancient i386 processors without guaranteed SSE2 support.
     - run: cross rustc --target ${{ matrix.arch }} -- -C target-cpu=i386
-      if: startsWith(matrix.arch, 'i686-')
+      if: startsWith(matrix.arch, 'i586-') || startsWith(matrix.arch, 'i686-')
     # Test the NEON implementation on ARM targets.
     - run: cross test --target ${{ matrix.arch }} --features=neon
       if: startsWith(matrix.arch, 'armv7-') || startsWith(matrix.arch, 'aarch64-')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,9 @@ jobs:
     - run: cargo install cross
     # Test the portable implementation on everything.
     - run: cross test --target ${{ matrix.arch }}
+    # Test building for ancient i386 processors without guaranteed SSE2 support.
+    - run: cross rustc --target ${{ matrix.arch }} -- -C target-cpu=i386
+      if: startsWith(matrix.arch, 'i686-')
     # Test the NEON implementation on ARM targets.
     - run: cross test --target ${{ matrix.arch }} --features=neon
       if: startsWith(matrix.arch, 'armv7-') || startsWith(matrix.arch, 'aarch64-')

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -403,6 +403,8 @@ pub fn sse2_detected() -> bool {
     {
         return true;
     }
+    #[allow(unreachable_code)]
+    false
 }
 
 #[inline(always)]

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -337,7 +337,7 @@ pub fn avx512_detected() -> bool {
     {
         return true;
     }
-    // Dyanmic check, if std is enabled.
+    // Dynamic check, if std is enabled.
     #[cfg(feature = "std")]
     {
         if is_x86_feature_detected!("avx512f") && is_x86_feature_detected!("avx512vl") {
@@ -359,7 +359,7 @@ pub fn avx2_detected() -> bool {
     {
         return true;
     }
-    // Dyanmic check, if std is enabled.
+    // Dynamic check, if std is enabled.
     #[cfg(feature = "std")]
     {
         if is_x86_feature_detected!("avx2") {
@@ -381,7 +381,7 @@ pub fn sse41_detected() -> bool {
     {
         return true;
     }
-    // Dyanmic check, if std is enabled.
+    // Dynamic check, if std is enabled.
     #[cfg(feature = "std")]
     {
         if is_x86_feature_detected!("sse4.1") {
@@ -393,6 +393,7 @@ pub fn sse41_detected() -> bool {
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[inline(always)]
+#[allow(unreachable_code)]
 pub fn sse2_detected() -> bool {
     // A testing-only short-circuit.
     if cfg!(feature = "no_sse2") {
@@ -403,7 +404,13 @@ pub fn sse2_detected() -> bool {
     {
         return true;
     }
-    #[allow(unreachable_code)]
+    // Dynamic check, if std is enabled.
+    #[cfg(feature = "std")]
+    {
+        if is_x86_feature_detected!("sse2") {
+            return true;
+        }
+    }
     false
 }
 


### PR DESCRIPTION
This is going to be very rarely triggered, but we should have it for completeness.