### PR TITLE
fix the C implementation on big endian, and add CI coverage for that case

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,10 @@ jobs:
       if: startsWith(matrix.arch, 'armv7-') || startsWith(matrix.arch, 'aarch64-')
     # Test vectors. Note that this uses a hacky script due to path dependency limitations.
     - run: ./test_vectors/cross_test.sh --target ${{ matrix.arch }}
+    # C code. Same issue with the hacky script.
+    - run: ./c/blake3_c_rust_bindings/cross_test.sh --target ${{ matrix.arch }}
+    - run: ./c/blake3_c_rust_bindings/cross_test.sh --target ${{ matrix.arch }} --features=neon
+      if: startsWith(matrix.arch, 'armv7-') || startsWith(matrix.arch, 'aarch64-')
 
   # Currently only on x86.
   c_tests:

--- a/c/blake3.c
+++ b/c/blake3.c
@@ -81,7 +81,7 @@ INLINE void output_chaining_value(const output_t *self, uint8_t cv[32]) {
   memcpy(cv_words, self->input_cv, 32);
   blake3_compress_in_place(cv_words, self->block, self->block_len,
                            self->counter, self->flags);
-  memcpy(cv, cv_words, 32);
+  store_cv_words(cv, cv_words);
 }
 
 INLINE void output_root_bytes(const output_t *self, uint64_t seek, uint8_t *out,
@@ -367,7 +367,7 @@ void blake3_hasher_init_keyed(blake3_hasher *self,
   hasher_init_base(self, key_words, KEYED_HASH);
 }
 
-void blake3_hasher_init_derive_key_raw(blake3_hasher *self, const void *context, 
+void blake3_hasher_init_derive_key_raw(blake3_hasher *self, const void *context,
                                        size_t context_len) {
   blake3_hasher context_hasher;
   hasher_init_base(&context_hasher, IV, DERIVE_KEY_CONTEXT);

--- a/c/blake3_c_rust_bindings/build.rs
+++ b/c/blake3_c_rust_bindings/build.rs
@@ -48,11 +48,22 @@ fn new_build() -> cc::Build {
     build
 }
 
+fn c_dir_path(filename: &str) -> String {
+    // The `cross` tool doesn't support reading files in parent directories. As a hacky workaround
+    // in `cross_test.sh`, we move the c/ directory around and set BLAKE3_C_DIR_OVERRIDE. Regular
+    // building and testing doesn't require this.
+    if let Ok(c_dir_override) = env::var("BLAKE3_C_DIR_OVERRIDE") {
+        c_dir_override + "/" + filename
+    } else {
+        "../".to_string() + filename
+    }
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut base_build = new_build();
-    base_build.file("../blake3.c");
-    base_build.file("../blake3_dispatch.c");
-    base_build.file("../blake3_portable.c");
+    base_build.file(c_dir_path("blake3.c"));
+    base_build.file(c_dir_path("blake3_dispatch.c"));
+    base_build.file(c_dir_path("blake3_portable.c"));
     base_build.compile("blake3_base");
 
     if is_x86_64() && !defined("CARGO_FEATURE_PREFER_INTRINSICS") {
@@ -60,27 +71,27 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         // "prefer_intrinsics" feature is enabled.
         if is_windows_msvc() {
             let mut build = new_build();
-            build.file("../blake3_sse2_x86-64_windows_msvc.asm");
-            build.file("../blake3_sse41_x86-64_windows_msvc.asm");
-            build.file("../blake3_avx2_x86-64_windows_msvc.asm");
-            build.file("../blake3_avx512_x86-64_windows_msvc.asm");
+            build.file(c_dir_path("blake3_sse2_x86-64_windows_msvc.asm"));
+            build.file(c_dir_path("blake3_sse41_x86-64_windows_msvc.asm"));
+            build.file(c_dir_path("blake3_avx2_x86-64_windows_msvc.asm"));
+            build.file(c_dir_path("blake3_avx512_x86-64_windows_msvc.asm"));
             build.compile("blake3_asm");
         } else if is_windows_gnu() {
             let mut build = new_build();
-            build.file("../blake3_sse2_x86-64_windows_gnu.S");
-            build.file("../blake3_sse41_x86-64_windows_gnu.S");
-            build.file("../blake3_avx2_x86-64_windows_gnu.S");
-            build.file("../blake3_avx512_x86-64_windows_gnu.S");
+            build.file(c_dir_path("blake3_sse2_x86-64_windows_gnu.S"));
+            build.file(c_dir_path("blake3_sse41_x86-64_windows_gnu.S"));
+            build.file(c_dir_path("blake3_avx2_x86-64_windows_gnu.S"));
+            build.file(c_dir_path("blake3_avx512_x86-64_windows_gnu.S"));
             build.compile("blake3_asm");
         } else {
             // All non-Windows implementations are assumed to support
             // Linux-style assembly. These files do contain a small
             // explicit workaround for macOS also.
             let mut build = new_build();
-            build.file("../blake3_sse2_x86-64_unix.S");
-            build.file("../blake3_sse41_x86-64_unix.S");
-            build.file("../blake3_avx2_x86-64_unix.S");
-            build.file("../blake3_avx512_x86-64_unix.S");
+            build.file(c_dir_path("blake3_sse2_x86-64_unix.S"));
+            build.file(c_dir_path("blake3_sse41_x86-64_unix.S"));
+            build.file(c_dir_path("blake3_avx2_x86-64_unix.S"));
+            build.file(c_dir_path("blake3_avx512_x86-64_unix.S"));
             build.compile("blake3_asm");
         }
     } else if is_x86_64() || is_x86_32() {
@@ -91,7 +102,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         // extension explicitly enabled in the compiler.
 
         let mut sse2_build = new_build();
-        sse2_build.file("../blake3_sse2.c");
+        sse2_build.file(c_dir_path("blake3_sse2.c"));
         if is_windows_msvc() {
             // /arch:SSE2 is the default on x86 and undefined on x86_64:
             // https://docs.microsoft.com/en-us/cpp/build/reference/arch-x86
@@ -103,7 +114,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         sse2_build.compile("blake3_sse2");
 
         let mut sse41_build = new_build();
-        sse41_build.file("../blake3_sse41.c");
+        sse41_build.file(c_dir_path("blake3_sse41.c"));
         if is_windows_msvc() {
             // /arch:SSE2 is the default on x86 and undefined on x86_64:
             // https://docs.microsoft.com/en-us/cpp/build/reference/arch-x86
@@ -115,7 +126,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         sse41_build.compile("blake3_sse41");
 
         let mut avx2_build = new_build();
-        avx2_build.file("../blake3_avx2.c");
+        avx2_build.file(c_dir_path("blake3_avx2.c"));
         if is_windows_msvc() {
             avx2_build.flag("/arch:AVX2");
         } else {
@@ -124,7 +135,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         avx2_build.compile("blake3_avx2");
 
         let mut avx512_build = new_build();
-        avx512_build.file("../blake3_avx512.c");
+        avx512_build.file(c_dir_path("blake3_avx512.c"));
         if is_windows_msvc() {
             // Note that a lot of versions of MSVC don't support /arch:AVX512,
             // and they'll discard it with a warning, hopefully leading to a
@@ -142,7 +153,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // you build this crate by hand with the "neon" feature for some reason.
     if defined("CARGO_FEATURE_NEON") {
         let mut neon_build = new_build();
-        neon_build.file("../blake3_neon.c");
+        neon_build.file(c_dir_path("blake3_neon.c"));
         // ARMv7 platforms that support NEON generally need the following
         // flags. AArch64 supports NEON by default and does not support -mpfu.
         if is_armv7() {

--- a/c/blake3_c_rust_bindings/cross_test.sh
+++ b/c/blake3_c_rust_bindings/cross_test.sh
@@ -1,0 +1,31 @@
+#! /usr/bin/env bash
+
+# This hacky script works around the fact that `cross test` does not support
+# path dependencies. (It uses a docker shared folder to let the guest access
+# project files, so parent directories aren't available.) Solve this problem by
+# copying the entire project to a temp dir and rearranging paths to put "c" and
+# "reference_impl" underneath "blake3_c_rust_bindings", so that everything is
+# accessible. Hopefully this will just run on CI forever and no one will ever
+# read this and discover my deep shame.
+
+set -e -u -o pipefail
+
+project_root="$(realpath "$(dirname "$BASH_SOURCE")/../..")"
+tmpdir="$(mktemp -d)"
+echo "Running cross tests in $tmpdir"
+cd "$tmpdir"
+git clone "$project_root" blake3
+mv blake3/c/blake3_c_rust_bindings .
+mv blake3/reference_impl blake3_c_rust_bindings
+mv blake3/c blake3_c_rust_bindings
+cd blake3_c_rust_bindings
+sed -i 's|reference_impl = { path = "../../reference_impl" }|reference_impl = { path = "reference_impl" }|' Cargo.toml
+
+export BLAKE3_C_DIR_OVERRIDE="./c"
+cat > Cross.toml << EOF
+[build.env]
+passthrough = [
+    "BLAKE3_C_DIR_OVERRIDE",
+]
+EOF
+cross test "$@"

--- a/c/blake3_impl.h
+++ b/c/blake3_impl.h
@@ -146,6 +146,25 @@ INLINE void load_key_words(const uint8_t key[BLAKE3_KEY_LEN],
   key_words[7] = load32(&key[7 * 4]);
 }
 
+INLINE void store32(void *dst, uint32_t w) {
+  uint8_t *p = (uint8_t *)dst;
+  p[0] = (uint8_t)(w >> 0);
+  p[1] = (uint8_t)(w >> 8);
+  p[2] = (uint8_t)(w >> 16);
+  p[3] = (uint8_t)(w >> 24);
+}
+
+INLINE void store_cv_words(uint8_t bytes_out[32], uint32_t cv_words[8]) {
+  store32(&bytes_out[0 * 4], cv_words[0]);
+  store32(&bytes_out[1 * 4], cv_words[1]);
+  store32(&bytes_out[2 * 4], cv_words[2]);
+  store32(&bytes_out[3 * 4], cv_words[3]);
+  store32(&bytes_out[4 * 4], cv_words[4]);
+  store32(&bytes_out[5 * 4], cv_words[5]);
+  store32(&bytes_out[6 * 4], cv_words[6]);
+  store32(&bytes_out[7 * 4], cv_words[7]);
+}
+
 void blake3_compress_in_place(uint32_t cv[8],
                               const uint8_t block[BLAKE3_BLOCK_LEN],
                               uint8_t block_len, uint64_t counter,

--- a/c/blake3_portable.c
+++ b/c/blake3_portable.c
@@ -1,14 +1,6 @@
 #include "blake3_impl.h"
 #include <string.h>
 
-INLINE void store32(void *dst, uint32_t w) {
-  uint8_t *p = (uint8_t *)dst;
-  p[0] = (uint8_t)(w >> 0);
-  p[1] = (uint8_t)(w >> 8);
-  p[2] = (uint8_t)(w >> 16);
-  p[3] = (uint8_t)(w >> 24);
-}
-
 INLINE uint32_t rotr32(uint32_t w, uint32_t c) {
   return (w >> c) | (w << (32 - c));
 }
@@ -147,7 +139,7 @@ INLINE void hash_one_portable(const uint8_t *input, size_t blocks,
     blocks -= 1;
     block_flags = flags;
   }
-  memcpy(out, cv, 32);
+  store_cv_words(out, cv);
 }
 
 void blake3_hash_many_portable(const uint8_t *const *inputs, size_t num_inputs,


### PR DESCRIPTION
Previously we were covering the Rust implementation on big endian, but not C. With this change their testing stories will be pretty similar. (There's plenty of duplicated code in `blake3_c_rust_bindings` that I'm not excited to maintain, not to mention another hacky `cross_test.sh` script, but it works.)