### PR TITLE
fix disabled-optimization -Wall -Werror

### DIFF
--- a/c/blake3_dispatch.c
+++ b/c/blake3_dispatch.c
@@ -14,6 +14,8 @@
 #endif
 #endif
 
+#define MAYBE_UNUSED(x) (void)((x))
+
 #if defined(IS_X86)
 static uint64_t xgetbv() {
 #if defined(_MSC_VER)
@@ -137,6 +139,7 @@ void blake3_compress_in_place(uint32_t cv[8],
                               uint8_t flags) {
 #if defined(IS_X86)
   const enum cpu_feature features = get_cpu_features();
+  MAYBE_UNUSED(features);
 #if !defined(BLAKE3_NO_AVX512)
   if (features & AVX512VL) {
     blake3_compress_in_place_avx512(cv, block, block_len, counter, flags);
@@ -165,6 +168,7 @@ void blake3_compress_xof(const uint32_t cv[8],
                          uint8_t out[64]) {
 #if defined(IS_X86)
   const enum cpu_feature features = get_cpu_features();
+  MAYBE_UNUSED(features);
 #if !defined(BLAKE3_NO_AVX512)
   if (features & AVX512VL) {
     blake3_compress_xof_avx512(cv, block, block_len, counter, flags, out);
@@ -193,6 +197,7 @@ void blake3_hash_many(const uint8_t *const *inputs, size_t num_inputs,
                       uint8_t flags_start, uint8_t flags_end, uint8_t *out) {
 #if defined(IS_X86)
   const enum cpu_feature features = get_cpu_features();
+  MAYBE_UNUSED(features);
 #if !defined(BLAKE3_NO_AVX512)
   if ((features & (AVX512F|AVX512VL)) == (AVX512F|AVX512VL)) {
     blake3_hash_many_avx512(inputs, num_inputs, blocks, key, counter,
@@ -242,6 +247,7 @@ void blake3_hash_many(const uint8_t *const *inputs, size_t num_inputs,
 size_t blake3_simd_degree(void) {
 #if defined(IS_X86)
   const enum cpu_feature features = get_cpu_features();
+  MAYBE_UNUSED(features);
 #if !defined(BLAKE3_NO_AVX512)
   if ((features & (AVX512F|AVX512VL)) == (AVX512F|AVX512VL)) {
     return 16;


### PR DESCRIPTION
if you tried to compile c/blake3_dispatch.c with
-Wall -Werror -DBLAKE3_NO_SSE2 -DBLAKE3_NO_SSE41 -DBLAKE3_NO_AVX2 -DBLAKE3_NO_AVX512

something like this would happen:
```sh
hans@xDevAd:~/projects/BLAKE3/c$ gcc -O0 -o example example.c blake3.c blake3_dispatch.c blake3_portable.c     blake3_sse2_x86-64_unix.S blake3_sse41_x86-64_unix.S blake3_avx2_x86-64_unix.S blake3_avx512_x86-64_unix.S \ 
-DBLAKE3_NO_SSE2 -DBLAKE3_NO_SSE41 -DBLAKE3_NO_AVX2 -DBLAKE3_NO_AVX512 \
-Wall -Wextra -Wpedantic -Werror
blake3_dispatch.c: In function ‘blake3_compress_in_place’:
blake3_dispatch.c:139:26: error: unused variable ‘features’ [-Werror=unused-variable]
  139 |   const enum cpu_feature features = get_cpu_features();
      |                          ^~~~~~~~
blake3_dispatch.c: In function ‘blake3_compress_xof’:
blake3_dispatch.c:167:26: error: unused variable ‘features’ [-Werror=unused-variable]
  167 |   const enum cpu_feature features = get_cpu_features();
      |                          ^~~~~~~~
blake3_dispatch.c: In function ‘blake3_hash_many’:
blake3_dispatch.c:195:26: error: unused variable ‘features’ [-Werror=unused-variable]
  195 |   const enum cpu_feature features = get_cpu_features();
      |                          ^~~~~~~~
blake3_dispatch.c: In function ‘blake3_simd_degree’:
blake3_dispatch.c:244:26: error: unused variable ‘features’ [-Werror=unused-variable]
  244 |   const enum cpu_feature features = get_cpu_features();
      |                          ^~~~~~~~
cc1: all warnings being treated as errors
```