### PR TITLE
Draft: serde support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ rayon = { version = "1.2.1", optional = true }
 cfg-if = "0.1.10"
 digest = "0.9.0"
 crypto-mac = "0.8.0"
+serde = { features = ["derive"], version = "1.0.123", optional = true }
 
 [dev-dependencies]
 hex = "0.4.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ neon = []
 # --no-default-features, the only way to use the SIMD implementations in this
 # crate is to enable the corresponding instruction sets statically for the
 # entire build, with e.g. RUSTFLAGS="-C target-cpu=native".
-std = ["digest/std"]
+std = ["digest/std","serde?/std"]
 
 # The "rayon" feature (defined below as an optional dependency) enables the
 # join::RayonJoin type, which can be used with Hasher::update_with_join to
@@ -78,7 +78,7 @@ rayon = { version = "1.2.1", optional = true }
 cfg-if = "0.1.10"
 digest = "0.9.0"
 crypto-mac = "0.8.0"
-serde = { features = ["derive"], version = "1.0.123", optional = true }
+serde = { features = ["derive"], version = "1.0.123", optional = true, default-features = false }
 
 [dev-dependencies]
 hex = "0.4.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,9 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 #[cfg(test)]
 mod test;
 
@@ -205,6 +208,7 @@ fn counter_high(counter: u64) -> u32 {
 /// [`AsRef`]: https://doc.rust-lang.org/std/convert/trait.AsRef.html
 /// [`to_hex`]: #method.to_hex
 /// [`hex`]: https://crates.io/crates/hex
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Clone, Copy, Hash)]
 pub struct Hash([u8; OUT_LEN]);
 


### PR DESCRIPTION
- Implement optional ser/deserialize attribute for `Hash`
- serde?/std weak dependency reference: https://github.com/rust-lang/cargo/issues/8832
