### PR TITLE
Proposal: make derive_key() return an array

### DIFF
--- a/b3sum/tests/cli_tests.rs
+++ b/b3sum/tests/cli_tests.rs
@@ -121,9 +121,7 @@ fn test_derive_key() {
     let f = tempfile::NamedTempFile::new().unwrap();
     f.as_file().write_all(b"key material").unwrap();
     f.as_file().flush().unwrap();
-    let mut derive_key_out = [0; blake3::OUT_LEN];
-    blake3::derive_key(context, b"key material", &mut derive_key_out);
-    let expected = hex::encode(&derive_key_out);
+    let expected = hex::encode(blake3::derive_key(context, b"key material"));
     let output = cmd!(b3sum_exe(), "--derive-key", context, "--no-names", f.path())
         .read()
         .unwrap();

--- a/src/test.rs
+++ b/src/test.rs
@@ -284,7 +284,7 @@ fn test_compare_reference_impl() {
 
             // all at once
             let test_out = crate::hash(input);
-            assert_eq!(test_out, *array_ref!(expected_out, 0, 32));
+            assert_eq!(test_out, expected_out[..32]);
             // incremental
             let mut hasher = crate::Hasher::new();
             hasher.update(input);
@@ -293,7 +293,7 @@ fn test_compare_reference_impl() {
             // xof
             let mut extended = [0; OUT];
             hasher.finalize_xof().fill(&mut extended);
-            assert_eq!(extended[..], expected_out[..]);
+            assert_eq!(extended, expected_out);
         }
 
         // keyed
@@ -305,7 +305,7 @@ fn test_compare_reference_impl() {
 
             // all at once
             let test_out = crate::keyed_hash(&TEST_KEY, input);
-            assert_eq!(test_out, *array_ref!(expected_out, 0, 32));
+            assert_eq!(test_out, expected_out[..32]);
             // incremental
             let mut hasher = crate::Hasher::new_keyed(&TEST_KEY);
             hasher.update(input);
@@ -314,7 +314,7 @@ fn test_compare_reference_impl() {
             // xof
             let mut extended = [0; OUT];
             hasher.finalize_xof().fill(&mut extended);
-            assert_eq!(extended[..], expected_out[..]);
+            assert_eq!(extended, expected_out);
         }
 
         // derive_key
@@ -326,9 +326,8 @@ fn test_compare_reference_impl() {
             reference_hasher.finalize(&mut expected_out);
 
             // all at once
-            let mut test_out = [0; OUT];
-            crate::derive_key(context, input, &mut test_out);
-            assert_eq!(test_out[..], expected_out[..]);
+            let test_out = crate::derive_key(context, input);
+            assert_eq!(test_out[..], expected_out[..32]);
             // incremental
             let mut hasher = crate::Hasher::new_derive_key(context);
             hasher.update(input);
@@ -337,7 +336,7 @@ fn test_compare_reference_impl() {
             // xof
             let mut extended = [0; OUT];
             hasher.finalize_xof().fill(&mut extended);
-            assert_eq!(extended[..], expected_out[..]);
+            assert_eq!(extended, expected_out);
         }
     }
 }
@@ -501,8 +500,7 @@ fn test_reset() {
     kdf.update(&[42; 3 * CHUNK_LEN + 7]);
     kdf.reset();
     kdf.update(&[42; CHUNK_LEN + 3]);
-    let mut expected = [0; crate::OUT_LEN];
-    crate::derive_key(context, &[42; CHUNK_LEN + 3], &mut expected);
+    let expected = crate::derive_key(context, &[42; CHUNK_LEN + 3]);
     assert_eq!(kdf.finalize(), expected);
 }
 

--- a/test_vectors/src/lib.rs
+++ b/test_vectors/src/lib.rs
@@ -276,11 +276,12 @@ mod tests {
         assert_eq!(&expected_hash[..32], blake3::hash(input).as_bytes());
         assert_eq!(
             &expected_keyed_hash[..32],
-            &blake3::keyed_hash(key, input).as_bytes()[..],
+            blake3::keyed_hash(key, input).as_bytes(),
         );
-        let mut derive_key_out = vec![0; expected_derive_key.len()];
-        blake3::derive_key(TEST_CONTEXT, input, &mut derive_key_out);
-        assert_eq!(expected_derive_key, &derive_key_out[..],);
+        assert_eq!(
+            expected_derive_key[..32],
+            blake3::derive_key(TEST_CONTEXT, input)
+        );
     }
 
     #[test]


### PR DESCRIPTION
Taking an output slice is awkward, and I've always wanted to change it before 1.0. With [some const generics features hitting stable Rust soon](https://blog.rust-lang.org/2021/02/26/const-generics-mvp-beta), I was experimenting with returning an array of variable size. Default const generic parameters aren't going to be stable in that release, though, so the caller would need to explicitly specify the return type in cases where the compiler can't infer it. [Playing with this](https://github.com/BLAKE3-team/BLAKE3/commit/ece17deb7420c6db177f00a3a4a191cc4133443f), it seemed to me like it makes more sense to just make the function return a regular 32-byte array for now. We'd have the option of moving this to a defaulted generic length in the future (same with the `Hash` wrapper type).