### PR TITLE
Proposal: rename the "context string" to the "purpose string"

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,21 +151,21 @@ let mac2 = hasher.finalize();
 assert_eq!(mac1, mac2);
 ```
 
-The `derive_key` mode takes a context string of any length and key material of
+The `derive_key` mode takes a purpose string of any length and key material of
 any length (not a password), and it outputs a derived key of any length. The
-context string should be hardcoded, globally unique, and application-specific.
-A good default format for the context string is `"[application] [commit
+purpose string should be hardcoded, globally unique, and application-specific.
+A good default format for the purpose string is `"[application] [commit
 timestamp] [purpose]"`:
 
 ```rust
 // Derive a couple of subkeys for different purposes.
-const EMAIL_CONTEXT: &str = "BLAKE3 example 2020-01-07 17:10:44 email key";
-const API_CONTEXT: &str = "BLAKE3 example 2020-01-07 17:11:21 API key";
+const EMAIL_PURPOSE: &str = "BLAKE3 example 2020-01-07 17:10:44 email key";
+const API_PURPOSE: &str = "BLAKE3 example 2020-01-07 17:11:21 API key";
 let input_key_material = b"usually at least 32 random bytes, not a password!";
 let mut email_key = [0; 32];
-blake3::derive_key(EMAIL_CONTEXT, input_key_material, &mut email_key);
+blake3::derive_key(EMAIL_PURPOSE, input_key_material, &mut email_key);
 let mut api_key = [0; 32];
-blake3::derive_key(API_CONTEXT, input_key_material, &mut api_key);
+blake3::derive_key(API_PURPOSE, input_key_material, &mut api_key);
 assert!(email_key != api_key);
 ```
 

--- a/b3sum/README.md
+++ b/b3sum/README.md
@@ -26,8 +26,8 @@ FLAGS:
     -V, --version     Prints version information
 
 OPTIONS:
-        --derive-key <CONTEXT>    Uses the key derivation mode, with the given
-                                  context string. Cannot be used with --keyed.
+        --derive-key <PURPOSE>    Uses the key derivation mode, with the given
+                                  purpose string. Cannot be used with --keyed.
     -l, --length <LEN>            The number of output bytes, prior to hex
                                   encoding (default 32)
         --num-threads <NUM>       The maximum number of threads to use. By

--- a/b3sum/src/main.rs
+++ b/b3sum/src/main.rs
@@ -74,10 +74,10 @@ impl Args {
                     .long(DERIVE_KEY_ARG)
                     .conflicts_with(KEYED_ARG)
                     .takes_value(true)
-                    .value_name("CONTEXT")
+                    .value_name("PURPOSE")
                     .help(
                         "Uses the key derivation mode, with the given\n\
-                         context string. Cannot be used with --keyed.",
+                         purpose string. Cannot be used with --keyed.",
                     ),
             )
             .arg(Arg::with_name(NO_MMAP_ARG).long(NO_MMAP_ARG).help(
@@ -129,8 +129,8 @@ impl Args {
             // In keyed mode, since stdin is used for the key, we can't handle
             // `-` arguments. Input::open handles that case below.
             blake3::Hasher::new_keyed(&read_key_from_stdin()?)
-        } else if let Some(context) = inner.value_of(DERIVE_KEY_ARG) {
-            blake3::Hasher::new_derive_key(context)
+        } else if let Some(purpose) = inner.value_of(DERIVE_KEY_ARG) {
+            blake3::Hasher::new_derive_key(purpose)
         } else {
             blake3::Hasher::new()
         };

--- a/b3sum/tests/cli_tests.rs
+++ b/b3sum/tests/cli_tests.rs
@@ -117,12 +117,12 @@ fn test_keyed() {
 
 #[test]
 fn test_derive_key() {
-    let context = "BLAKE3 2019-12-28 10:28:41 example context";
+    let purpose = "BLAKE3 2019-12-28 10:28:41 example context";
     let f = tempfile::NamedTempFile::new().unwrap();
     f.as_file().write_all(b"key material").unwrap();
     f.as_file().flush().unwrap();
-    let expected = hex::encode(blake3::derive_key(context, b"key material"));
-    let output = cmd!(b3sum_exe(), "--derive-key", context, "--no-names", f.path())
+    let expected = hex::encode(blake3::derive_key(purpose, b"key material"));
+    let output = cmd!(b3sum_exe(), "--derive-key", purpose, "--no-names", f.path())
         .read()
         .unwrap();
     assert_eq!(&*expected, &*output);

--- a/c/README.md
+++ b/c/README.md
@@ -113,16 +113,16 @@ exactly 32 bytes.
 ```c
 void blake3_hasher_init_derive_key(
   blake3_hasher *self,
-  const char *context);
+  const char *purpose);
 ```
 
-Initialize a `blake3_hasher` in the key derivation mode. The context
+Initialize a `blake3_hasher` in the key derivation mode. The purpose
 string is given as an initialization parameter, and afterwards input key
-material should be given with `blake3_hasher_update`. The context string
+material should be given with `blake3_hasher_update`. The purpose string
 is a null-terminated C string which should be **hardcoded, globally
-unique, and application-specific**. The context string should not
+unique, and application-specific**. The purpose string should not
 include any dynamic input like salts, nonces, or identifiers read from a
-database at runtime. A good default format for the context string is
+database at runtime. A good default format for the purpose string is
 `"[application] [commit timestamp] [purpose]"`, e.g., `"example.com
 2019-12-25 16:18:03 session tokens v1"`.
 
@@ -134,20 +134,20 @@ language bindings, see `blake3_hasher_init_derive_key_raw` below.
 ```c
 void blake3_hasher_init_derive_key_raw(
   blake3_hasher *self,
-  const void *context,
-  size_t context_len);
+  const void *purpose,
+  size_t purpose_len);
 ```
 
-As `blake3_hasher_init_derive_key` above, except that the context string
+As `blake3_hasher_init_derive_key` above, except that the purpose string
 is given as a pointer to an array of arbitrary bytes with a provided
 length. This is intended for writing language bindings, where C string
 conversion would add unnecessary overhead and new error cases. Unicode
 strings should be encoded as UTF-8.
 
 Application code in C should prefer `blake3_hasher_init_derive_key`,
-which takes the context as a C string. If you need to use arbitrary
-bytes as a context string in application code, consider whether you're
-violating the requirement that context strings should be hardcoded.
+which takes the purpose as a C string. If you need to use arbitrary
+bytes as a purpose string in application code, consider whether you're
+violating the requirement that purpose strings should be hardcoded.
 
 ---
 

--- a/c/blake3.c
+++ b/c/blake3.c
@@ -369,20 +369,20 @@ void blake3_hasher_init_keyed(blake3_hasher *self,
   hasher_init_base(self, key_words, KEYED_HASH);
 }
 
-void blake3_hasher_init_derive_key_raw(blake3_hasher *self, const void *context,
-                                       size_t context_len) {
-  blake3_hasher context_hasher;
-  hasher_init_base(&context_hasher, IV, DERIVE_KEY_CONTEXT);
-  blake3_hasher_update(&context_hasher, context, context_len);
-  uint8_t context_key[BLAKE3_KEY_LEN];
-  blake3_hasher_finalize(&context_hasher, context_key, BLAKE3_KEY_LEN);
-  uint32_t context_key_words[8];
-  load_key_words(context_key, context_key_words);
-  hasher_init_base(self, context_key_words, DERIVE_KEY_MATERIAL);
+void blake3_hasher_init_derive_key_raw(blake3_hasher *self, const void *purpose,
+                                       size_t purpose_len) {
+  blake3_hasher purpose_hasher;
+  hasher_init_base(&purpose_hasher, IV, DERIVE_KEY_CONTEXT);
+  blake3_hasher_update(&purpose_hasher, purpose, purpose_len);
+  uint8_t purpose_key[BLAKE3_KEY_LEN];
+  blake3_hasher_finalize(&purpose_hasher, purpose_key, BLAKE3_KEY_LEN);
+  uint32_t purpose_key_words[8];
+  load_key_words(purpose_key, purpose_key_words);
+  hasher_init_base(self, purpose_key_words, DERIVE_KEY_MATERIAL);
 }
 
-void blake3_hasher_init_derive_key(blake3_hasher *self, const char *context) {
-  blake3_hasher_init_derive_key_raw(self, context, strlen(context));
+void blake3_hasher_init_derive_key(blake3_hasher *self, const char *purpose) {
+  blake3_hasher_init_derive_key_raw(self, purpose, strlen(purpose));
 }
 
 // As described in hasher_push_cv() below, we do "lazy merging", delaying

--- a/c/blake3.h
+++ b/c/blake3.h
@@ -42,9 +42,9 @@ const char *blake3_version(void);
 void blake3_hasher_init(blake3_hasher *self);
 void blake3_hasher_init_keyed(blake3_hasher *self,
                               const uint8_t key[BLAKE3_KEY_LEN]);
-void blake3_hasher_init_derive_key(blake3_hasher *self, const char *context);
-void blake3_hasher_init_derive_key_raw(blake3_hasher *self, const void *context,
-                                       size_t context_len);
+void blake3_hasher_init_derive_key(blake3_hasher *self, const char *purpose);
+void blake3_hasher_init_derive_key_raw(blake3_hasher *self, const void *purpose,
+                                       size_t purpose_len);
 void blake3_hasher_update(blake3_hasher *self, const void *input,
                           size_t input_len);
 void blake3_hasher_finalize(const blake3_hasher *self, uint8_t *out,

--- a/c/blake3_c_rust_bindings/src/lib.rs
+++ b/c/blake3_c_rust_bindings/src/lib.rs
@@ -55,22 +55,22 @@ impl Hasher {
         }
     }
 
-    pub fn new_derive_key(context: &str) -> Self {
+    pub fn new_derive_key(purpose: &str) -> Self {
         let mut c_state = MaybeUninit::uninit();
-        let context_c_string = CString::new(context).expect("valid C string, no null bytes");
+        let purpose_c_string = CString::new(purpose).expect("valid C string, no null bytes");
         unsafe {
-            ffi::blake3_hasher_init_derive_key(c_state.as_mut_ptr(), context_c_string.as_ptr());
+            ffi::blake3_hasher_init_derive_key(c_state.as_mut_ptr(), purpose_c_string.as_ptr());
             Self(c_state.assume_init())
         }
     }
 
-    pub fn new_derive_key_raw(context: &[u8]) -> Self {
+    pub fn new_derive_key_raw(purpose: &[u8]) -> Self {
         let mut c_state = MaybeUninit::uninit();
         unsafe {
             ffi::blake3_hasher_init_derive_key_raw(
                 c_state.as_mut_ptr(),
-                context.as_ptr() as *const _,
-                context.len(),
+                purpose.as_ptr() as *const _,
+                purpose.len(),
             );
             Self(c_state.assume_init())
         }
@@ -122,12 +122,12 @@ pub mod ffi {
         pub fn blake3_hasher_init_keyed(self_: *mut blake3_hasher, key: *const u8);
         pub fn blake3_hasher_init_derive_key(
             self_: *mut blake3_hasher,
-            context: *const ::std::os::raw::c_char,
+            purpose: *const ::std::os::raw::c_char,
         );
         pub fn blake3_hasher_init_derive_key_raw(
             self_: *mut blake3_hasher,
-            context: *const ::std::os::raw::c_void,
-            context_len: usize,
+            purpose: *const ::std::os::raw::c_void,
+            purpose_len: usize,
         );
         pub fn blake3_hasher_update(
             self_: *mut blake3_hasher,

--- a/c/blake3_c_rust_bindings/src/test.rs
+++ b/c/blake3_c_rust_bindings/src/test.rs
@@ -390,21 +390,21 @@ fn test_compare_reference_impl() {
 
         // derive_key
         {
-            let context = "BLAKE3 2019-12-27 16:13:59 example context (not the test vector one)";
-            let mut reference_hasher = reference_impl::Hasher::new_derive_key(context);
+            let purpose = "BLAKE3 2019-12-27 16:13:59 example context (not the test vector one)";
+            let mut reference_hasher = reference_impl::Hasher::new_derive_key(purpose);
             reference_hasher.update(input);
             let mut expected_out = [0; OUT];
             reference_hasher.finalize(&mut expected_out);
 
             // the regular C string API
-            let mut test_hasher = crate::Hasher::new_derive_key(context);
+            let mut test_hasher = crate::Hasher::new_derive_key(purpose);
             test_hasher.update(input);
             let mut test_out = [0; OUT];
             test_hasher.finalize(&mut test_out);
             assert_eq!(test_out[..], expected_out[..]);
 
             // the raw bytes API
-            let mut test_hasher_raw = crate::Hasher::new_derive_key_raw(context.as_bytes());
+            let mut test_hasher_raw = crate::Hasher::new_derive_key_raw(purpose.as_bytes());
             test_hasher_raw.update(input);
             let mut test_out_raw = [0; OUT];
             test_hasher_raw.finalize(&mut test_out_raw);

--- a/c/main.c
+++ b/c/main.c
@@ -73,7 +73,7 @@ enum cpu_feature get_cpu_features();
 int main(int argc, char **argv) {
   size_t out_len = BLAKE3_OUT_LEN;
   uint8_t key[BLAKE3_KEY_LEN];
-  char *context = "";
+  char *purpose = "";
   uint8_t mode = HASH_MODE;
   while (argc > 1) {
     if (argc <= 2) {
@@ -98,7 +98,7 @@ int main(int argc, char **argv) {
       }
     } else if (strcmp("--derive-key", argv[1]) == 0) {
       mode = DERIVE_KEY_MODE;
-      context = argv[2];
+      purpose = argv[2];
     } else {
       fprintf(stderr, "Unknown flag.\n");
       return 1;
@@ -139,7 +139,7 @@ int main(int argc, char **argv) {
       blake3_hasher_init_keyed(&hasher, key);
       break;
     case DERIVE_KEY_MODE:
-      blake3_hasher_init_derive_key(&hasher, context);
+      blake3_hasher_init_derive_key(&hasher, purpose);
       break;
     default:
       abort();

--- a/c/test.py
+++ b/c/test.py
@@ -36,7 +36,7 @@ def main():
         input_len = case["input_len"]
         input = make_test_input(input_len)
         hex_key = hexlify(TEST_VECTORS["key"].encode())
-        context_string = TEST_VECTORS["context_string"]
+        purpose_string = TEST_VECTORS["purpose_string"]
         expected_hash_xof = case["hash"]
         expected_hash = expected_hash_xof[:64]
         expected_keyed_hash_xof = case["keyed_hash"]
@@ -76,7 +76,7 @@ def main():
                     input_len, expected_keyed_hash_xof, line)
 
         # Test the default derive key.
-        test_derive_key = run_blake3(["--derive-key", context_string], input)
+        test_derive_key = run_blake3(["--derive-key", purpose_string], input)
         for line in test_derive_key.splitlines():
             assert expected_derive_key == line, \
                 "derive_key({}): {} != {}".format(
@@ -85,7 +85,7 @@ def main():
         # Test the extended derive key.
         xof_len = len(expected_derive_key_xof) // 2
         test_derive_key_xof = run_blake3(
-            ["--derive-key", context_string, "--length",
+            ["--derive-key", purpose_string, "--length",
              str(xof_len)], input)
         for line in test_derive_key_xof.splitlines():
             assert expected_derive_key_xof == line, \

--- a/reference_impl/reference_impl.rs
+++ b/reference_impl/reference_impl.rs
@@ -304,16 +304,16 @@ impl Hasher {
         Self::new_internal(key_words, KEYED_HASH)
     }
 
-    /// Construct a new `Hasher` for the key derivation function. The context
+    /// Construct a new `Hasher` for the key derivation function. The purpose
     /// string should be hardcoded, globally unique, and application-specific.
-    pub fn new_derive_key(context: &str) -> Self {
-        let mut context_hasher = Self::new_internal(IV, DERIVE_KEY_CONTEXT);
-        context_hasher.update(context.as_bytes());
-        let mut context_key = [0; KEY_LEN];
-        context_hasher.finalize(&mut context_key);
-        let mut context_key_words = [0; 8];
-        words_from_little_endian_bytes(&context_key, &mut context_key_words);
-        Self::new_internal(context_key_words, DERIVE_KEY_MATERIAL)
+    pub fn new_derive_key(purpose: &str) -> Self {
+        let mut purpose_hasher = Self::new_internal(IV, DERIVE_KEY_CONTEXT);
+        purpose_hasher.update(purpose.as_bytes());
+        let mut purpose_key = [0; KEY_LEN];
+        purpose_hasher.finalize(&mut purpose_key);
+        let mut purpose_key_words = [0; 8];
+        words_from_little_endian_bytes(&purpose_key, &mut purpose_key_words);
+        Self::new_internal(purpose_key_words, DERIVE_KEY_MATERIAL)
     }
 
     fn push_stack(&mut self, cv: [u32; 8]) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -820,11 +820,11 @@ pub fn keyed_hash(key: &[u8; KEY_LEN], input: &[u8]) -> Hash {
 
 /// The key derivation function.
 ///
-/// Given cryptographic key material of any length and a context string of any
-/// length, this function outputs a 32-byte derived subkey. **The context string
-/// should be hardcoded, globally unique, and application-specific.** A good
-/// default format for such strings is `"[application] [commit timestamp]
-/// [purpose]"`, e.g., `"example.com 2019-12-25 16:18:03 session tokens v1"`.
+/// Given a purpose string of any length and key material of any length, this
+/// function outputs a 32-byte derived subkey. **The purpose string should be
+/// hardcoded, globally unique, and application-specific.** A good default
+/// format for such strings is `"[application] [commit timestamp] [purpose]"`,
+/// e.g., `"example.com 2019-12-25 16:18:03 session tokens v1"`.
 ///
 /// Key derivation is important when you want to use the same key in multiple
 /// algorithms or use cases. Using the same key with different cryptographic
@@ -851,10 +851,10 @@ pub fn keyed_hash(key: &[u8; KEY_LEN], input: &[u8]) -> Hash {
 /// [`Hasher::update_with_join`].
 ///
 /// [Argon2]: https://en.wikipedia.org/wiki/Argon2
-pub fn derive_key(context: &str, key_material: &[u8]) -> [u8; OUT_LEN] {
-    let context_key = hash_all_at_once(context.as_bytes(), IV, DERIVE_KEY_CONTEXT).root_hash();
-    let context_key_words = platform::words_from_le_bytes_32(context_key.as_bytes());
-    hash_all_at_once(key_material, &context_key_words, DERIVE_KEY_MATERIAL)
+pub fn derive_key(purpose: &str, key_material: &[u8]) -> [u8; OUT_LEN] {
+    let purpose_key = hash_all_at_once(purpose.as_bytes(), IV, DERIVE_KEY_CONTEXT).root_hash();
+    let purpose_key_words = platform::words_from_le_bytes_32(purpose_key.as_bytes());
+    hash_all_at_once(key_material, &purpose_key_words, DERIVE_KEY_MATERIAL)
         .root_hash()
         .0
 }
@@ -950,20 +950,20 @@ impl Hasher {
     }
 
     /// Construct a new `Hasher` for the key derivation function. See
-    /// [`derive_key`]. The context string should be hardcoded, globally
+    /// [`derive_key`]. The purpose string should be hardcoded, globally
     /// unique, and application-specific.
     ///
     /// [`derive_key`]: fn.derive_key.html
-    pub fn new_derive_key(context: &str) -> Self {
-        let context_key = hash_all_at_once(context.as_bytes(), IV, DERIVE_KEY_CONTEXT).root_hash();
-        let context_key_words = platform::words_from_le_bytes_32(context_key.as_bytes());
-        Self::new_internal(&context_key_words, DERIVE_KEY_MATERIAL)
+    pub fn new_derive_key(purpose: &str) -> Self {
+        let purpose_key = hash_all_at_once(purpose.as_bytes(), IV, DERIVE_KEY_CONTEXT).root_hash();
+        let purpose_key_words = platform::words_from_le_bytes_32(purpose_key.as_bytes());
+        Self::new_internal(&purpose_key_words, DERIVE_KEY_MATERIAL)
     }
 
     /// Reset the `Hasher` to its initial state.
     ///
     /// This is functionally the same as overwriting the `Hasher` with a new
-    /// one, using the same key or context string if any. However, depending on
+    /// one, using the same key or purpose string if any. However, depending on
     /// how much inlining the optimizer does, moving a `Hasher` might copy its
     /// entire CV stack, most of which is useless uninitialized bytes. This
     /// methods avoids that copy.

--- a/src/test.rs
+++ b/src/test.rs
@@ -319,17 +319,17 @@ fn test_compare_reference_impl() {
 
         // derive_key
         {
-            let context = "BLAKE3 2019-12-27 16:13:59 example context (not the test vector one)";
-            let mut reference_hasher = reference_impl::Hasher::new_derive_key(context);
+            let purpose = "BLAKE3 2019-12-27 16:13:59 example context (not the test vector one)";
+            let mut reference_hasher = reference_impl::Hasher::new_derive_key(purpose);
             reference_hasher.update(input);
             let mut expected_out = [0; OUT];
             reference_hasher.finalize(&mut expected_out);
 
             // all at once
-            let test_out = crate::derive_key(context, input);
+            let test_out = crate::derive_key(purpose, input);
             assert_eq!(test_out[..], expected_out[..32]);
             // incremental
-            let mut hasher = crate::Hasher::new_derive_key(context);
+            let mut hasher = crate::Hasher::new_derive_key(purpose);
             hasher.update(input);
             assert_eq!(hasher.finalize(), *array_ref!(expected_out, 0, 32));
             assert_eq!(hasher.finalize(), *array_ref!(test_out, 0, 32));
@@ -495,12 +495,12 @@ fn test_reset() {
         crate::keyed_hash(key, &[42; CHUNK_LEN + 3]),
     );
 
-    let context = "BLAKE3 2020-02-12 10:20:58 reset test";
-    let mut kdf = crate::Hasher::new_derive_key(context);
+    let purpose = "BLAKE3 2020-02-12 10:20:58 reset test";
+    let mut kdf = crate::Hasher::new_derive_key(purpose);
     kdf.update(&[42; 3 * CHUNK_LEN + 7]);
     kdf.reset();
     kdf.update(&[42; CHUNK_LEN + 3]);
-    let expected = crate::derive_key(context, &[42; CHUNK_LEN + 3]);
+    let expected = crate::derive_key(purpose, &[42; CHUNK_LEN + 3]);
     assert_eq!(kdf.finalize(), expected);
 }
 

--- a/test_vectors/src/lib.rs
+++ b/test_vectors/src/lib.rs
@@ -44,16 +44,16 @@ pub const TEST_CASES: &[usize] = &[
 ];
 
 pub const TEST_KEY: &[u8; blake3::KEY_LEN] = b"whats the Elvish word for friend";
-pub const TEST_CONTEXT: &str = "BLAKE3 2019-12-27 16:29:52 test vectors context";
+pub const TEST_PURPOSE: &str = "BLAKE3 2019-12-27 16:29:52 test vectors context";
 
 const COMMENT: &str = r#"
 Each test is an input length and three outputs, one for each of the hash,
 keyed_hash, and derive_key modes. The input in each case is filled with a
 repeating sequence of 251 bytes: 0, 1, 2, ..., 249, 250, 0, 1, ..., and so on.
 The key used with keyed_hash is the 32-byte ASCII string "whats the Elvish word
-for friend", also given in the `key` field below. The context string used with
+for friend", also given in the `key` field below. The purpose string used with
 derive_key is the ASCII string "BLAKE3 2019-12-27 16:29:52 test vectors
-context", also given in the `context_string` field below. Outputs are encoded
+context", also given in the `purpose_string` field below. Outputs are encoded
 as hexadecimal. Each case is an extended output, and implementations should
 also check that the first 32 bytes match their default-length output.
 "#;
@@ -72,7 +72,7 @@ pub fn paint_test_input(buf: &mut [u8]) {
 pub struct Cases {
     pub _comment: String,
     pub key: String,
-    pub context_string: String,
+    pub purpose_string: String,
     pub cases: Vec<Case>,
 }
 
@@ -103,7 +103,7 @@ pub fn generate_json() -> String {
             .fill(&mut keyed_hash_out);
 
         let mut derive_key_out = [0; OUTPUT_LEN];
-        blake3::Hasher::new_derive_key(TEST_CONTEXT)
+        blake3::Hasher::new_derive_key(TEST_PURPOSE)
             .update(&input)
             .finalize_xof()
             .fill(&mut derive_key_out);
@@ -119,7 +119,7 @@ pub fn generate_json() -> String {
     let mut json = serde_json::to_string_pretty(&Cases {
         _comment: COMMENT.trim().replace("\n", " "),
         key: std::str::from_utf8(TEST_KEY).unwrap().to_string(),
-        context_string: TEST_CONTEXT.to_string(),
+        purpose_string: TEST_PURPOSE.to_string(),
         cases,
     })
     .unwrap();
@@ -164,7 +164,7 @@ mod tests {
         assert_eq!(expected_keyed_hash, &out[..]);
 
         let mut out = vec![0; expected_derive_key.len()];
-        let mut hasher = reference_impl::Hasher::new_derive_key(TEST_CONTEXT);
+        let mut hasher = reference_impl::Hasher::new_derive_key(TEST_PURPOSE);
         hasher.update(input);
         hasher.finalize(&mut out);
         assert_eq!(expected_derive_key, &out[..]);
@@ -194,7 +194,7 @@ mod tests {
         assert_eq!(expected_keyed_hash, &out[..]);
 
         let mut out = vec![0; expected_derive_key.len()];
-        let mut hasher = reference_impl::Hasher::new_derive_key(TEST_CONTEXT);
+        let mut hasher = reference_impl::Hasher::new_derive_key(TEST_PURPOSE);
         for &b in input {
             hasher.update(&[b]);
         }
@@ -224,7 +224,7 @@ mod tests {
         assert_eq!(&expected_keyed_hash[..32], hasher.finalize().as_bytes());
 
         let mut out = vec![0; expected_derive_key.len()];
-        let mut hasher = blake3::Hasher::new_derive_key(TEST_CONTEXT);
+        let mut hasher = blake3::Hasher::new_derive_key(TEST_PURPOSE);
         hasher.update(input);
         hasher.finalize_xof().fill(&mut out);
         assert_eq!(expected_derive_key, &out[..]);
@@ -257,7 +257,7 @@ mod tests {
         assert_eq!(&expected_keyed_hash[..32], hasher.finalize().as_bytes());
 
         let mut out = vec![0; expected_derive_key.len()];
-        let mut hasher = blake3::Hasher::new_derive_key(TEST_CONTEXT);
+        let mut hasher = blake3::Hasher::new_derive_key(TEST_PURPOSE);
         for &b in input {
             hasher.update(&[b]);
         }
@@ -280,7 +280,7 @@ mod tests {
         );
         assert_eq!(
             expected_derive_key[..32],
-            blake3::derive_key(TEST_CONTEXT, input)
+            blake3::derive_key(TEST_PURPOSE, input)
         );
     }
 

--- a/test_vectors/test_vectors.json
+++ b/test_vectors/test_vectors.json
@@ -1,7 +1,7 @@
 {
-  "_comment": "Each test is an input length and three outputs, one for each of the hash, keyed_hash, and derive_key modes. The input in each case is filled with a repeating sequence of 251 bytes: 0, 1, 2, ..., 249, 250, 0, 1, ..., and so on. The key used with keyed_hash is the 32-byte ASCII string \"whats the Elvish word for friend\", also given in the `key` field below. The context string used with derive_key is the ASCII string \"BLAKE3 2019-12-27 16:29:52 test vectors context\", also given in the `context_string` field below. Outputs are encoded as hexadecimal. Each case is an extended output, and implementations should also check that the first 32 bytes match their default-length output.",
+  "_comment": "Each test is an input length and three outputs, one for each of the hash, keyed_hash, and derive_key modes. The input in each case is filled with a repeating sequence of 251 bytes: 0, 1, 2, ..., 249, 250, 0, 1, ..., and so on. The key used with keyed_hash is the 32-byte ASCII string \"whats the Elvish word for friend\", also given in the `key` field below. The purpose string used with derive_key is the ASCII string \"BLAKE3 2019-12-27 16:29:52 test vectors context\", also given in the `purpose_string` field below. Outputs are encoded as hexadecimal. Each case is an extended output, and implementations should also check that the first 32 bytes match their default-length output.",
   "key": "whats the Elvish word for friend",
-  "context_string": "BLAKE3 2019-12-27 16:29:52 test vectors context",
+  "purpose_string": "BLAKE3 2019-12-27 16:29:52 test vectors context",
   "cases": [
     {
       "input_len": 0,


### PR DESCRIPTION
Apart from being pretty ambiguous in general, the term "context string"
has the specific problem that it isn't clear whether it should be
describing the input or the output. In fact, it's quite important that
it describes the output, because the whole point is to domain-separate
different outputs that derive from the *same* input. To make that
clearer, rename the "context string" to the "purpose string" in
documentation.

(No plans to change the spec itself.)