### PR TITLE
Proposal: privatize the Join trait and expose *_rayon methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,10 +25,9 @@ neon = []
 # entire build, with e.g. RUSTFLAGS="-C target-cpu=native".
 std = ["digest/std"]
 
-# The "rayon" feature (defined below as an optional dependency) enables the
-# join::RayonJoin type, which can be used with Hasher::update_with_join to
-# perform multi-threaded hashing. However, even if this feature is enabled, all
-# other APIs remain single-threaded.
+# The "rayon" feature (defined below as an optional dependency) enables API
+# functions like `hash_rayon` and `update_rayon`. However, even if this feature
+# is enabled, all other APIs remain single-threaded.
 
 # ---------- Features below this line are for internal testing only. ----------
 

--- a/b3sum/src/main.rs
+++ b/b3sum/src/main.rs
@@ -219,7 +219,7 @@ impl Input {
             // multiple threads. This doesn't work on stdin, or on some files,
             // and it can also be disabled with --no-mmap.
             Self::Mmap(cursor) => {
-                hasher.update_with_join::<blake3::join::RayonJoin>(cursor.get_ref());
+                hasher.update_rayon(cursor.get_ref());
             }
             // The slower paths, for stdin or files we didn't/couldn't mmap.
             // This is currently all single-threaded. Doing multi-threaded

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -421,11 +421,7 @@ fn bench_reference_1024_kib(b: &mut Bencher) {
 #[cfg(feature = "rayon")]
 fn bench_rayon(b: &mut Bencher, len: usize) {
     let mut input = RandomInput::new(b, len);
-    b.iter(|| {
-        blake3::Hasher::new()
-            .update_with_join::<blake3::join::RayonJoin>(input.get())
-            .finalize()
-    });
+    b.iter(|| blake3::hash_rayon(input.get()));
 }
 
 #[bench]

--- a/src/join.rs
+++ b/src/join.rs
@@ -8,47 +8,18 @@
 //! [`hash`] and [`Hasher::update`], always use `SerialJoin` internally.
 //!
 //! The `Join` trait is an almost exact copy of the [`rayon::join`] API, and
-//! `RayonJoin` is the only non-trivial implementation provided. The only
-//! difference between the function signature in the `Join` trait and the
-//! underlying one in Rayon, is that the trait method includes two length
-//! parameters. This gives an implementation the option of e.g. setting a
-//! subtree size threshold below which it keeps splits on the same thread.
-//! However, neither of the two provided implementations currently makes use of
-//! those parameters. Note that in Rayon, the very first `join` call is more
-//! expensive than subsequent calls, because it moves work from the calling
-//! thread into the thread pool. That makes a coarse-grained input length
-//! threshold in the caller more effective than a fine-grained subtree size
-//! threshold after the implementation has already started recursing.
+//! `RayonJoin` is the only non-trivial implementation. Previously this trait
+//! was public, but currently it's been re-privatized, as it's both 1) of no
+//! value to most callers and 2) a pretty big implementation detail to commit
+//! to.
 //!
-//! # Example
-//!
-//! ```
-//! // Hash a large input using multi-threading. Note that multi-threading
-//! // comes with some overhead, and it can actually hurt performance for small
-//! // inputs. The meaning of "small" varies, however, depending on the
-//! // platform and the number of threads. (On x86_64, the cutoff tends to be
-//! // around 128 KiB.) You should benchmark your own use case to see whether
-//! // multi-threading helps.
-//! # #[cfg(feature = "rayon")]
-//! # {
-//! # fn some_large_input() -> &'static [u8] { b"foo" }
-//! let input: &[u8] = some_large_input();
-//! let mut hasher = blake3::Hasher::new();
-//! hasher.update_with_join::<blake3::join::RayonJoin>(input);
-//! let hash = hasher.finalize();
-//! # }
-//! ```
-//!
-//! [`Hasher::update_with_join`]: ../struct.Hasher.html#method.update_with_join
-//! [`Hasher::update`]: ../struct.Hasher.html#method.update
-//! [`hash`]: ../fn.hash.html
 //! [`rayon::join`]: https://docs.rs/rayon/1.3.0/rayon/fn.join.html
 
 /// The trait that abstracts over single-threaded and multi-threaded recursion.
 ///
 /// See the [`join` module docs](index.html) for more details.
 pub trait Join {
-    fn join<A, B, RA, RB>(oper_a: A, oper_b: B, len_a: usize, len_b: usize) -> (RA, RB)
+    fn join<A, B, RA, RB>(oper_a: A, oper_b: B) -> (RA, RB)
     where
         A: FnOnce() -> RA + Send,
         B: FnOnce() -> RB + Send,
@@ -66,7 +37,7 @@ pub enum SerialJoin {}
 
 impl Join for SerialJoin {
     #[inline]
-    fn join<A, B, RA, RB>(oper_a: A, oper_b: B, _len_a: usize, _len_b: usize) -> (RA, RB)
+    fn join<A, B, RA, RB>(oper_a: A, oper_b: B) -> (RA, RB)
     where
         A: FnOnce() -> RA + Send,
         B: FnOnce() -> RB + Send,
@@ -88,7 +59,7 @@ pub enum RayonJoin {}
 #[cfg(feature = "rayon")]
 impl Join for RayonJoin {
     #[inline]
-    fn join<A, B, RA, RB>(oper_a: A, oper_b: B, _len_a: usize, _len_b: usize) -> (RA, RB)
+    fn join<A, B, RA, RB>(oper_a: A, oper_b: B) -> (RA, RB)
     where
         A: FnOnce() -> RA + Send,
         B: FnOnce() -> RB + Send,
@@ -107,7 +78,7 @@ mod test {
     fn test_serial_join() {
         let oper_a = || 1 + 1;
         let oper_b = || 2 + 2;
-        assert_eq!((2, 4), SerialJoin::join(oper_a, oper_b, 3, 4));
+        assert_eq!((2, 4), SerialJoin::join(oper_a, oper_b));
     }
 
     #[test]
@@ -115,6 +86,6 @@ mod test {
     fn test_rayon_join() {
         let oper_a = || 1 + 1;
         let oper_b = || 2 + 2;
-        assert_eq!((2, 4), RayonJoin::join(oper_a, oper_b, 3, 4));
+        assert_eq!((2, 4), RayonJoin::join(oper_a, oper_b));
     }
 }

--- a/src/join.rs
+++ b/src/join.rs
@@ -1,11 +1,12 @@
-//! The multi-threading abstractions used by [`Hasher::update_with_join`].
+//! The multi-threading abstractions used by `Hasher::update_with_join`.
 //!
 //! Different implementations of the `Join` trait determine whether
-//! [`Hasher::update_with_join`] performs multi-threading on sufficiently large
+//! `Hasher::update_with_join` performs multi-threading on sufficiently large
 //! inputs. The `SerialJoin` implementation is single-threaded, and the
-//! `RayonJoin` implementation (gated by the `rayon` feature) is
-//! multi-threaded. Interfaces other than [`Hasher::update_with_join`], like
-//! [`hash`] and [`Hasher::update`], always use `SerialJoin` internally.
+//! `RayonJoin` implementation (gated by the `rayon` feature) is multi-threaded.
+//! Interfaces other than `Hasher::update_with_join`, like [`hash`](crate::hash)
+//! and [`Hasher::update`](crate::Hasher::update), always use `SerialJoin`
+//! internally.
 //!
 //! The `Join` trait is an almost exact copy of the [`rayon::join`] API, and
 //! `RayonJoin` is the only non-trivial implementation. Previously this trait

--- a/src/test.rs
+++ b/src/test.rs
@@ -283,12 +283,26 @@ fn test_compare_reference_impl() {
 
             // all at once
             let test_out = crate::hash(input);
-            assert_eq!(test_out, expected_out[..32]);
+            assert_eq!(test_out, *array_ref!(expected_out, 0, 32));
+            // all at once (rayon)
+            #[cfg(feature = "rayon")]
+            {
+                let test_out = crate::hash_rayon(input);
+                assert_eq!(test_out, *array_ref!(expected_out, 0, 32));
+            }
             // incremental
             let mut hasher = crate::Hasher::new();
             hasher.update(input);
             assert_eq!(hasher.finalize(), *array_ref!(expected_out, 0, 32));
             assert_eq!(hasher.finalize(), test_out);
+            // incremental (rayon)
+            #[cfg(feature = "rayon")]
+            {
+                let mut hasher = crate::Hasher::new();
+                hasher.update_rayon(input);
+                assert_eq!(hasher.finalize(), *array_ref!(expected_out, 0, 32));
+                assert_eq!(hasher.finalize(), test_out);
+            }
             // xof
             let mut extended = [0; OUT];
             hasher.finalize_xof().fill(&mut extended);
@@ -304,12 +318,26 @@ fn test_compare_reference_impl() {
 
             // all at once
             let test_out = crate::keyed_hash(&TEST_KEY, input);
-            assert_eq!(test_out, expected_out[..32]);
+            assert_eq!(test_out, *array_ref!(expected_out, 0, 32));
+            // all at once (rayon)
+            #[cfg(feature = "rayon")]
+            {
+                let test_out = crate::keyed_hash_rayon(&TEST_KEY, input);
+                assert_eq!(test_out, *array_ref!(expected_out, 0, 32));
+            }
             // incremental
             let mut hasher = crate::Hasher::new_keyed(&TEST_KEY);
             hasher.update(input);
             assert_eq!(hasher.finalize(), *array_ref!(expected_out, 0, 32));
             assert_eq!(hasher.finalize(), test_out);
+            // incremental (rayon)
+            #[cfg(feature = "rayon")]
+            {
+                let mut hasher = crate::Hasher::new_keyed(&TEST_KEY);
+                hasher.update_rayon(input);
+                assert_eq!(hasher.finalize(), *array_ref!(expected_out, 0, 32));
+                assert_eq!(hasher.finalize(), test_out);
+            }
             // xof
             let mut extended = [0; OUT];
             hasher.finalize_xof().fill(&mut extended);
@@ -326,12 +354,26 @@ fn test_compare_reference_impl() {
 
             // all at once
             let test_out = crate::derive_key(context, input);
-            assert_eq!(test_out[..], expected_out[..32]);
+            assert_eq!(test_out, expected_out[..32]);
+            // all at once (rayon)
+            #[cfg(feature = "rayon")]
+            {
+                let test_out = crate::derive_key_rayon(context, input);
+                assert_eq!(test_out, expected_out[..32]);
+            }
             // incremental
             let mut hasher = crate::Hasher::new_derive_key(context);
             hasher.update(input);
             assert_eq!(hasher.finalize(), *array_ref!(expected_out, 0, 32));
             assert_eq!(hasher.finalize(), *array_ref!(test_out, 0, 32));
+            // incremental (rayon)
+            #[cfg(feature = "rayon")]
+            {
+                let mut hasher = crate::Hasher::new_derive_key(context);
+                hasher.update_rayon(input);
+                assert_eq!(hasher.finalize(), *array_ref!(expected_out, 0, 32));
+                assert_eq!(hasher.finalize(), *array_ref!(test_out, 0, 32));
+            }
             // xof
             let mut extended = [0; OUT];
             hasher.finalize_xof().fill(&mut extended);
@@ -501,17 +543,6 @@ fn test_reset() {
     kdf.update(&[42; CHUNK_LEN + 3]);
     let expected = crate::derive_key(context, &[42; CHUNK_LEN + 3]);
     assert_eq!(kdf.finalize(), expected);
-}
-
-#[test]
-#[cfg(feature = "rayon")]
-fn test_update_with_rayon_join() {
-    let mut input = [0; TEST_CASES_MAX];
-    paint_test_input(&mut input);
-    let rayon_hash = crate::Hasher::new()
-        .update_with_join::<crate::join::RayonJoin>(&input)
-        .finalize();
-    assert_eq!(crate::hash(&input), rayon_hash);
 }
 
 #[test]


### PR DESCRIPTION
The `Join` trait is 1) pretty difficult to understand in the first place, 2) pretty unlikely to ever be used by anyone directly, and 3) a pretty big exposure of implementation details. I don't think we want to stabilize it in 1.0. My current proposal (this PR) is to un-`pub` it and to instead expose a collection of `*_rayon` functions: `hash_rayon()`, `Hasher::update_rayon()`, etc.