### PR TITLE
Release 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blake3"
-version = "0.3.7"
+version = "1.0.0"
 authors = ["Jack O'Connor <oconnor663@gmail.com>"]
 description = "the BLAKE3 hash function"
 repository = "https://github.com/BLAKE3-team/BLAKE3"

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ output_reader.fill(&mut output);
 assert_eq!(&output[..32], hash1.as_bytes());
 
 // Print a hash as hex.
-println!("{}", hash1.to_hex());
+println!("{}", hash1);
 ```
 
 Besides `hash`, BLAKE3 provides two other modes, `keyed_hash` and
@@ -151,21 +151,18 @@ let mac2 = hasher.finalize();
 assert_eq!(mac1, mac2);
 ```
 
-The `derive_key` mode takes a context string of any length and key material of
-any length (not a password), and it outputs a derived key of any length. The
-context string should be hardcoded, globally unique, and application-specific.
-A good default format for the context string is `"[application] [commit
-timestamp] [purpose]"`:
+The `derive_key` mode takes a context string and some key material (not a
+password). The context string should be hardcoded, globally unique, and
+application-specific. A good default format for the context string is
+`"[application] [commit timestamp] [purpose]"`:
 
 ```rust
 // Derive a couple of subkeys for different purposes.
 const EMAIL_CONTEXT: &str = "BLAKE3 example 2020-01-07 17:10:44 email key";
 const API_CONTEXT: &str = "BLAKE3 example 2020-01-07 17:11:21 API key";
-let input_key_material = b"usually at least 32 random bytes, not a password!";
-let mut email_key = [0; 32];
-blake3::derive_key(EMAIL_CONTEXT, input_key_material, &mut email_key);
-let mut api_key = [0; 32];
-blake3::derive_key(API_CONTEXT, input_key_material, &mut api_key);
+let input_key_material = b"usually at least 32 random bytes, not a password";
+let email_key = blake3::derive_key(EMAIL_CONTEXT, input_key_material);
+let api_key = blake3::derive_key(API_CONTEXT, input_key_material);
 assert!(email_key != api_key);
 ```
 

--- a/b3sum/Cargo.toml
+++ b/b3sum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "b3sum"
-version = "0.3.7"
+version = "1.0.0"
 authors = ["Jack O'Connor <oconnor663@gmail.com>"]
 description = "a command line implementation of the BLAKE3 hash function"
 repository = "https://github.com/BLAKE3-team/BLAKE3"
@@ -15,7 +15,7 @@ pure = ["blake3/pure"]
 
 [dependencies]
 anyhow = "1.0.25"
-blake3 = { version = "0.3", path = "..", features = ["rayon"] }
+blake3 = { version = "1", path = "..", features = ["rayon"] }
 clap = "2.33.1"
 hex = "0.4.0"
 memmap = "0.7.0"

--- a/c/blake3.h
+++ b/c/blake3.h
@@ -8,7 +8,7 @@
 extern "C" {
 #endif
 
-#define BLAKE3_VERSION_STRING "0.3.7"
+#define BLAKE3_VERSION_STRING "1.0.0"
 #define BLAKE3_KEY_LEN 32
 #define BLAKE3_OUT_LEN 32
 #define BLAKE3_BLOCK_LEN 64

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 //! # }
 //!
 //! // Print a hash as hex.
-//! println!("{}", hash1.to_hex());
+//! println!("{}", hash1);
 //! # Ok(())
 //! # }
 //! ```


### PR DESCRIPTION
```
Changes since 0.3.7:
- Fix a build break under Visual Studio 2015:
  https://github.com/BLAKE3-team/BLAKE3/issues/142
- Add Hash::from_hex().
- Implement PartialEq<[u8]> for Hash, using constant_time_eq.
- Implement Display for Hash, equivalent to Hash::to_hex().
- Change derive_key() to return a 32-byte array. As with hash() and
  keyed_hash(), callers who want a non-default output length can use
  Hasher::finalize_xof().
- Replace Hasher::update_with_join() with Hasher::update_rayon(). The
  former was excessively generic, and the Join trait leaked
  implementation details. As part of this change, the Join trait is no
  longer public.
- Upgraded arrayvec to 0.7.0, which uses const generics. This bumps the
  minimum supported Rust compiler version to 1.51.
- Gate the digest and crypto-mac trait implementations behind an
  unstable feature, "traits-preview". As part of this change upgrade
  crypto-mac to 0.11.0.
```

The upgrade to arrayvec 0.7.0 involves a bunch of code changes, replacing the old hacky `arrayvec::Array` trait with nice new const generic paramters across a bunch of internal functions. But this is all just mechanical Rust type system stuff, no behavioral change.