### PR TITLE
Compute threaded checksums of chunks, iteratively

### DIFF
--- a/b3sum/src/main.rs
+++ b/b3sum/src/main.rs
@@ -219,7 +219,9 @@ impl Input {
             // multiple threads. This doesn't work on stdin, or on some files,
             // and it can also be disabled with --no-mmap.
             Self::Mmap(cursor) => {
-                hasher.update_rayon(cursor.get_ref());
+                for chunk in cursor.get_ref().chunks(4_194_304) {
+                    hasher.update_rayon(chunk);
+                }
             }
             // The slower paths, for stdin or files we didn't/couldn't mmap.
             // This is currently all single-threaded. Doing multi-threaded


### PR DESCRIPTION
This seems to improve performance slightly on SSDs, but more than doubles
performance on spinning hard disks.

The buffer size seems to make a noticeable difference. I found 4 megabytes works well on my computer, but it may depend on the number of CPU cores available. Advice would be appreciated unless this value is likely to work well in most cases.

Fixes #31.