### PR TITLE
`cargo clippy` to fix Rust code style guidelines

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ license = "CC0-1.0 OR Apache-2.0"
 documentation = "https://docs.rs/blake3"
 readme = "README.md"
 edition = "2018"
+include = ["src/**/*", "LICENSE", "README.md", "c/*", "build.rs"]
 
 [features]
 default = ["std"]

--- a/b3sum/Cargo.toml
+++ b/b3sum/Cargo.toml
@@ -7,6 +7,7 @@ repository = "https://github.com/BLAKE3-team/BLAKE3"
 license = "CC0-1.0 OR Apache-2.0"
 readme = "README.md"
 edition = "2018"
+include = ["src/**/*", "README.md", "!**/*_tests.*"]
 
 [features]
 neon = ["blake3/neon"]

--- a/build.rs
+++ b/build.rs
@@ -22,7 +22,7 @@ fn is_ci() -> bool {
 }
 
 fn warn(warning: &str) {
-    assert!(!warning.contains("\n"));
+    assert!(!warning.contains('\n'));
     println!("cargo:warning={}", warning);
     if is_ci() {
         println!("cargo:warning=Warnings in CI are treated as errors. Build failed.");
@@ -32,7 +32,7 @@ fn warn(warning: &str) {
 
 fn target_components() -> Vec<String> {
     let target = env::var("TARGET").unwrap();
-    target.split("-").map(|s| s.to_string()).collect()
+    target.split('-').map(|s| s.to_string()).collect()
 }
 
 fn is_x86_64() -> bool {

--- a/src/guts.rs
+++ b/src/guts.rs
@@ -30,6 +30,11 @@ impl ChunkState {
     }
 
     #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    #[inline]
     pub fn update(&mut self, input: &[u8]) -> &mut Self {
         self.0.update(input);
         self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -437,6 +437,10 @@ impl ChunkState {
         BLOCK_LEN * self.blocks_compressed as usize + self.buf_len as usize
     }
 
+    fn is_empty(&self) -> bool {
+        self.blocks_compressed + self.buf_len == 0
+    }
+
     fn fill_buf(&mut self, input: &mut &[u8]) {
         let want = BLOCK_LEN - self.buf_len as usize;
         let take = cmp::min(want, input.len());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1115,7 +1115,7 @@ impl Hasher {
     fn update_with_join<J: join::Join>(&mut self, mut input: &[u8]) -> &mut Self {
         // If we have some partial chunk bytes in the internal chunk_state, we
         // need to finish that chunk first.
-        if self.chunk_state.len() > 0 {
+        if !self.chunk_state.is_empty() {
             let want = CHUNK_LEN - self.chunk_state.len();
             let take = cmp::min(want, input.len());
             self.chunk_state.update(&input[..take]);
@@ -1255,7 +1255,7 @@ impl Hasher {
         // the empty chunk is taken care of above.
         let mut output: Output;
         let mut num_cvs_remaining = self.cv_stack.len();
-        if self.chunk_state.len() > 0 {
+        if !self.chunk_state.is_empty() {
             debug_assert_eq!(
                 self.cv_stack.len(),
                 self.chunk_state.chunk_counter.count_ones() as usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -764,7 +764,7 @@ fn compress_subtree_to_parent_node<J: join::Join>(
     debug_assert!(input.len() > CHUNK_LEN);
     let mut cv_array = [0; MAX_SIMD_DEGREE_OR_2 * OUT_LEN];
     let mut num_cvs =
-        compress_subtree_wide::<J>(input, &key, chunk_counter, flags, platform, &mut cv_array);
+        compress_subtree_wide::<J>(input, key, chunk_counter, flags, platform, &mut cv_array);
     debug_assert!(num_cvs >= 2);
 
     // If MAX_SIMD_DEGREE is greater than 2 and there's enough input,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,7 +198,7 @@ fn counter_high(counter: u64) -> u32 {
 /// [`from_hex`]: #method.from_hex
 /// [`Display`]: https://doc.rust-lang.org/std/fmt/trait.Display.html
 /// [`FromStr`]: https://doc.rust-lang.org/std/str/trait.FromStr.html
-#[derive(Clone, Copy, Hash)]
+#[derive(Clone, Copy)]
 pub struct Hash([u8; OUT_LEN]);
 
 impl Hash {


### PR DESCRIPTION
* Using the `include` field in the `Cargo.toml` the crate is now 138Kb vs 155kB.
* Run `cargo clippy` to fix Rust styles:
  * Add the `is_empty()` method to the `ChunkState` struct. [Clippy warning](https://rust-lang.github.io/rust-clippy/master/index.html#len_without_is_empty)
  * Remove `Hash` derivation since `PartialEq` is explicitly implemented. [Clippy warning](https://rust-lang.github.io/rust-clippy/master/index.html#derive_hash_xor_eq)
  * Use `''` instead of `""` in `contains()` and `split()` [Clippy warning](https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern)
  * Remove `Hash` derivation in the `Hash` struct since `PartialEq` is implemented [Clippy warning](https://rust-lang.github.io/rust-clippy/master/index.html#derive_hash_xor_eq)
  * Remove a needless borrow since the `key` is going to be dereferenced immediately by the compiler [Clippy warning](https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow)