### PR TITLE
Check output length argument size

### DIFF
--- a/c/main.c
+++ b/c/main.c
@@ -84,7 +84,7 @@ int main(int argc, char **argv) {
       char *endptr = NULL;
       errno = 0;
       unsigned long long out_len_ll = strtoull(argv[2], &endptr, 10);
-      if (errno != 0 || out_len > SIZE_MAX || endptr == argv[2] ||
+      if (errno != 0 || out_len_ll > SIZE_MAX || endptr == argv[2] ||
           *endptr != 0) {
         fprintf(stderr, "Bad length argument.\n");
         return 1;


### PR DESCRIPTION
Currently, we check `out_len` against SIZE_MAX, but we haven't updated out_len yet. Instead, we should check the user provided argument `out_len_ll`