### PR TITLE
Implement PartialOrd and Ord for Hash in variable time.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,7 +198,7 @@ fn counter_high(counter: u64) -> u32 {
 /// [`from_hex`]: #method.from_hex
 /// [`Display`]: https://doc.rust-lang.org/std/fmt/trait.Display.html
 /// [`FromStr`]: https://doc.rust-lang.org/std/str/trait.FromStr.html
-#[derive(Clone, Copy, Hash)]
+#[derive(Clone, Copy, Hash, PartialOrd, Ord)]
 pub struct Hash([u8; OUT_LEN]);
 
 impl Hash {


### PR DESCRIPTION
Complementary PR for the trivial implementation for #202.

This PR may evolve into a constant-time order implementation if this is preferred.