### PR TITLE
Update digest crate to 0.10 for traits-preview feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ std = ["digest/std"]
 # who use it should expect breaking changes between patch versions of this
 # crate. (The "*-preview" feature name follows the conventions of the RustCrypto
 # "signature" crate.)
-traits-preview = ["digest", "crypto-mac"]
+traits-preview = ["digest"]
 
 # ---------- Features below this line are for internal testing only. ----------
 
@@ -85,8 +85,7 @@ arrayvec = { version = "0.7.0", default-features = false }
 constant_time_eq = "0.1.5"
 rayon = { version = "1.2.1", optional = true }
 cfg-if = "1.0.0"
-digest = { version = "0.9.0", optional = true }
-crypto-mac = { version = "0.11.0", optional = true }
+digest = { version = "0.10.1", features = [ "mac" ], optional = true }
 
 [dev-dependencies]
 hex = "0.4.2"

--- a/b3sum/Cargo.lock
+++ b/b3sum/Cargo.lock
@@ -81,6 +81,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1d36a02058e76b040de25a4464ba1c80935655595b661505c8b39b664828b95"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -158,12 +167,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "digest"
-version = "0.9.0"
+name = "crypto-common"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+checksum = "683d6b536309245c849479fba3da410962a43ed8e51c26b729208ec0ac2798d0"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b697d66081d42af4fba142d56918a3cb21dc8eb63372c6b85d14f44fb9c5979b"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "generic-array",
+ "subtle",
 ]
 
 [[package]]
@@ -393,6 +414,12 @@ name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "tempfile"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,13 +49,12 @@
 //! without NEON support.
 //!
 //! The `traits-preview` feature enables implementations of traits from the
-//! RustCrypto [`digest`] and [`crypto-mac`] crates, and re-exports those crates
-//! as `traits::digest` and `traits::crypto_mac`. However, the traits aren't
-//! stable, and they're expected to change in incompatible ways before those
-//! crates reach 1.0. For that reason, this crate makes no SemVer guarantees for
-//! this feature, and callers who use it should expect breaking changes between
-//! patch versions. (The "-preview" feature name follows the conventions of the
-//! RustCrypto [`signature`] crate.)
+//! RustCrypto [`digest`] crate, and re-exports those crates as
+//! `traits::digest`. However, the traits aren't stable, and they're expected to
+//! change in incompatible ways before those crates reach 1.0. For that reason,
+//! this crate makes no SemVer guarantees for this feature, and callers who use
+//! it should expect breaking changes between patch versions. (The "-preview"
+//! feature name follows the conventions of the RustCrypto [`signature`] crate.)
 //!
 //! [`Hasher::update_rayon`]: struct.Hasher.html#method.update_rayon
 //! [BLAKE3]: https://blake3.io
@@ -64,7 +63,6 @@
 //! [`Write`]: https://doc.rust-lang.org/std/io/trait.Write.html
 //! [`Seek`]: https://doc.rust-lang.org/std/io/trait.Seek.html
 //! [`digest`]: https://crates.io/crates/digest
-//! [`crypto-mac`]: https://crates.io/crates/crypto-mac
 //! [`signature`]: https://crates.io/crates/signature
 
 #![cfg_attr(not(feature = "std"), no_std)]
@@ -901,8 +899,7 @@ fn parent_node_output(
 ///
 /// When the `traits-preview` Cargo feature is enabled, this type implements
 /// several commonly used traits from the
-/// [`digest`](https://crates.io/crates/digest) and
-/// [`crypto_mac`](https://crates.io/crates/crypto-mac) crates. However, those
+/// [`digest`](https://crates.io/crates/digest) crate. However, those
 /// traits aren't stable, and they're expected to change in incompatible ways
 /// before those crates reach 1.0. For that reason, this crate makes no SemVer
 /// guarantees for this feature, and callers who use it should expect breaking

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,24 +1,18 @@
-//! Implementations of commonly used traits like
-//! [`digest::Digest`](https://crates.io/crates/digest) and
-//! [`crypto_mac::Mac`](https://crates.io/crates/crypto-mac).
+//! Implementations of commonly used traits like `Digest` and `Mac` from the
+//! [`digest`](https://crates.io/crates/digest) crate.
 
-pub use crypto_mac;
 pub use digest;
 
 use crate::{Hasher, OutputReader};
-use digest::generic_array::{
-    typenum::{U32, U64},
-    GenericArray,
-};
+use digest::crypto_common;
+use digest::generic_array::{typenum::U32, GenericArray};
 
-impl digest::BlockInput for Hasher {
-    type BlockSize = U64;
-}
+impl digest::HashMarker for Hasher {}
 
 impl digest::Update for Hasher {
     #[inline]
-    fn update(&mut self, data: impl AsRef<[u8]>) {
-        self.update(data.as_ref());
+    fn update(&mut self, data: &[u8]) {
+        self.update(data);
     }
 }
 
@@ -29,14 +23,18 @@ impl digest::Reset for Hasher {
     }
 }
 
-impl digest::FixedOutput for Hasher {
+impl digest::OutputSizeUser for Hasher {
     type OutputSize = U32;
+}
 
+impl digest::FixedOutput for Hasher {
     #[inline]
     fn finalize_into(self, out: &mut GenericArray<u8, Self::OutputSize>) {
         out.copy_from_slice(self.finalize().as_bytes());
     }
+}
 
+impl digest::FixedOutputReset for Hasher {
     #[inline]
     fn finalize_into_reset(&mut self, out: &mut GenericArray<u8, Self::OutputSize>) {
         out.copy_from_slice(self.finalize().as_bytes());
@@ -51,7 +49,9 @@ impl digest::ExtendableOutput for Hasher {
     fn finalize_xof(self) -> Self::Reader {
         Hasher::finalize_xof(&self)
     }
+}
 
+impl digest::ExtendableOutputReset for Hasher {
     #[inline]
     fn finalize_xof_reset(&mut self) -> Self::Reader {
         let reader = Hasher::finalize_xof(self);
@@ -67,32 +67,17 @@ impl digest::XofReader for OutputReader {
     }
 }
 
-impl crypto_mac::NewMac for Hasher {
+impl crypto_common::KeySizeUser for Hasher {
     type KeySize = U32;
-
-    #[inline]
-    fn new(key: &crypto_mac::Key<Self>) -> Self {
-        let key_bytes: [u8; 32] = (*key).into();
-        Hasher::new_keyed(&key_bytes)
-    }
 }
 
-impl crypto_mac::Mac for Hasher {
-    type OutputSize = U32;
+impl digest::MacMarker for Hasher {}
 
+impl digest::KeyInit for Hasher {
     #[inline]
-    fn update(&mut self, data: &[u8]) {
-        self.update(data);
-    }
-
-    #[inline]
-    fn reset(&mut self) {
-        self.reset();
-    }
-
-    #[inline]
-    fn finalize(self) -> crypto_mac::Output<Self> {
-        crypto_mac::Output::new(digest::Digest::finalize(self))
+    fn new(key: &digest::Key<Self>) -> Self {
+        let key_bytes: [u8; 32] = (*key).into();
+        Hasher::new_keyed(&key_bytes)
     }
 }
 
@@ -132,26 +117,26 @@ mod test {
         let mut hasher3: crate::Hasher = digest::Digest::new();
         digest::Digest::update(&mut hasher3, b"foobarbaz");
         let mut out3 = [0; 32];
-        digest::FixedOutput::finalize_into_reset(
+        digest::FixedOutputReset::finalize_into_reset(
             &mut hasher3,
             GenericArray::from_mut_slice(&mut out3),
         );
         digest::Digest::update(&mut hasher3, b"foobarbaz");
         let mut out4 = [0; 32];
-        digest::FixedOutput::finalize_into_reset(
+        digest::FixedOutputReset::finalize_into_reset(
             &mut hasher3,
             GenericArray::from_mut_slice(&mut out4),
         );
         digest::Digest::update(&mut hasher3, b"foobarbaz");
         let mut xof3 = [0; 301];
         digest::XofReader::read(
-            &mut digest::ExtendableOutput::finalize_xof_reset(&mut hasher3),
+            &mut digest::ExtendableOutputReset::finalize_xof_reset(&mut hasher3),
             &mut xof3,
         );
         digest::Digest::update(&mut hasher3, b"foobarbaz");
         let mut xof4 = [0; 301];
         digest::XofReader::read(
-            &mut digest::ExtendableOutput::finalize_xof_reset(&mut hasher3),
+            &mut digest::ExtendableOutputReset::finalize_xof_reset(&mut hasher3),
             &mut xof4,
         );
         assert_eq!(out1.as_bytes(), &out3[..]);
@@ -172,13 +157,13 @@ mod test {
 
         // Trait implementation.
         let generic_key = (*key).into();
-        let mut hasher2: crate::Hasher = crypto_mac::NewMac::new(&generic_key);
-        crypto_mac::Mac::update(&mut hasher2, b"xxx");
-        crypto_mac::Mac::reset(&mut hasher2);
-        crypto_mac::Mac::update(&mut hasher2, b"foo");
-        crypto_mac::Mac::update(&mut hasher2, b"bar");
-        crypto_mac::Mac::update(&mut hasher2, b"baz");
-        let out2 = crypto_mac::Mac::finalize(hasher2);
+        let mut hasher2: crate::Hasher = digest::Mac::new(&generic_key);
+        digest::Mac::update(&mut hasher2, b"xxx");
+        digest::Mac::reset(&mut hasher2);
+        digest::Mac::update(&mut hasher2, b"foo");
+        digest::Mac::update(&mut hasher2, b"bar");
+        digest::Mac::update(&mut hasher2, b"baz");
+        let out2 = digest::Mac::finalize(hasher2);
         assert_eq!(out1.as_bytes(), out2.into_bytes().as_slice());
     }
 }


### PR DESCRIPTION
Adjust to the following changes that happened in digest:

- The crypto-mac crate has been merged into digest (with "mac" feature
  enabled)
- Various traits have been split up
- The Digest and Mac traits now share their update/finalize/reset
  implementations
- The BlockInput trait was dropped without replacement apparently (as
  long as the low-level core API is not used)

Related issue: #212 (not marked as closed by this PR, as discussion regarding the use the low-level API is still ongoing)