### PR TITLE
add prototypes to fix -Wstrict-prototypes warnings

### DIFF
--- a/c/README.md
+++ b/c/README.md
@@ -13,7 +13,7 @@ result:
 #include <string.h>
 #include <unistd.h>
 
-int main() {
+int main(void) {
   // Initialize the hasher.
   blake3_hasher hasher;
   blake3_hasher_init(&hasher);

--- a/c/blake3_dispatch.c
+++ b/c/blake3_dispatch.c
@@ -17,7 +17,7 @@
 #define MAYBE_UNUSED(x) (void)((x))
 
 #if defined(IS_X86)
-static uint64_t xgetbv() {
+static uint64_t xgetbv(void) {
 #if defined(_MSC_VER)
   return _xgetbv(0);
 #else
@@ -82,7 +82,7 @@ static /* Allow the variable to be controlled manually for testing */
 static
 #endif
     enum cpu_feature
-    get_cpu_features() {
+    get_cpu_features(void) {
 
   if (g_cpu_features != UNDEFINED) {
     return g_cpu_features;

--- a/c/example.c
+++ b/c/example.c
@@ -5,7 +5,7 @@
 #include <string.h>
 #include <unistd.h>
 
-int main() {
+int main(void) {
   // Initialize the hasher.
   blake3_hasher hasher;
   blake3_hasher_init(&hasher);


### PR DESCRIPTION
---
BLAKE3 has been imported into llvm-project. This patch fixes warnings when llvm-project is compiled by recent Clang which enables `-Wstrict-prototypes` under (the default) `-pedantic`. In case of an upgrade, llvm-project can avoid the local patch: https://github.com/llvm/llvm-project/commit/7b0dad9a0204604bd72a5af4c94ba31c5133f71f