### PR TITLE
Use weak dependency feature for 'digest/std'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ neon = []
 # --no-default-features, the only way to use the SIMD implementations in this
 # crate is to enable the corresponding instruction sets statically for the
 # entire build, with e.g. RUSTFLAGS="-C target-cpu=native".
-std = ["digest/std"]
+std = ["digest?/std"]
 
 # The "rayon" feature (defined below as an optional dependency) enables the
 # `Hasher::update_rayon` method, for multithreaded hashing. However, even if


### PR DESCRIPTION
This is stable now as of Rust 1.60, not sure whether you want to have that as min-spec, though.

Fixes BLAKE3-team/BLAKE3/204