### PR TITLE
Added CMake support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,3 +233,20 @@ jobs:
     - name: build b3sum
       run: cargo build --target aarch64-apple-darwin
       working-directory: ./b3sum
+
+  # CMake build test (Library only), current macOS/Linux only.
+  cmake_build:
+      name: CMake ${{ matrix.target.os }}
+      runs-on: ${{ matrix.target.os }}
+      strategy:
+        fail-fast: false
+        matrix:
+          os: ["ubuntu-latest", "macOS-latest"]
+      steps:
+      - uses: actions/checkout@v3
+      - name: CMake generation
+        run: cmake . -Bbuild
+        working-directory: ./c
+      - name: CMake build
+        run: cmake --build build/
+        working-directory: ./c

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,8 +236,8 @@ jobs:
 
   # CMake build test (Library only), current macOS/Linux only.
   cmake_build:
-      name: CMake ${{ matrix.target.os }}
-      runs-on: ${{ matrix.target.os }}
+      name: CMake ${{ matrix.os }}
+      runs-on: ${{ matrix.os }}
       strategy:
         fail-fast: false
         matrix:

--- a/c/.gitignore
+++ b/c/.gitignore
@@ -1,3 +1,4 @@
 blake3
 example
+build/
 *.o

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -15,22 +15,20 @@ if(CMAKE_SYSTEM_PROCESSOR STREQUAL x86_64)
   list(APPEND blake3_SOURCES
     blake3_avx2_x86-64_unix.S
     blake3_avx512_x86-64_unix.S
-    blake3_sse41_x86-64_unix.S
-    blake3_sse2_x86-64_unix.S)
+    blake3_sse41_x86-64_unix.S)
 elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL i686)
   list(APPEND blake3_SOURCES
     blake3_avx2.c
     blake3_avx512.c
-    blake3_sse41.c
-    blake3_sse2.c)
+    blake3_sse41.c)
   set_source_files_properties(blake3_avx2.c PROPERTIES COMPILE_FLAGS -mavx2)
   set_source_files_properties(blake3_avx512.c PROPERTIES COMPILE_FLAGS "-mavx512f -mavx512vl")
   set_source_files_properties(blake3_sse41.c PROPERTIES COMPILE_FLAGS -msse4.1)
 elseif((ANDROID_ABI STREQUAL armeabi-v7a) OR
-       (CMAKE_SYSTEM_PROCESSOR STREQUAL aarch64))
+       (CMAKE_SYSTEM_PROCESSOR STREQUAL aarch64) OR (CMAKE_SYSTEM_PROCESSOR STREQUAL arm64))
   list(APPEND blake3_SOURCES blake3_neon.c)
-  set_source_files_properties(blake3_neon.c PROPERTIES COMPILE_FLAGS -mfpu=neon)
   set_source_files_properties(blake3_dispatch.c PROPERTIES COMPILE_FLAGS -DBLAKE3_USE_NEON=1)
+  set_source_files_properties(blake3_neon.c PROPERTIES COMPILE_FLAGS -mfpu=neon)
 endif()
 
 configure_file(libblake3.pc.in libblake3.pc @ONLY)

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -5,6 +5,8 @@ enable_language(C ASM)
 
 include(GNUInstallDirs)
 
+option(BLAKE3_STATIC ON)
+
 set(blake3_SOURCES)
 list(APPEND blake3_SOURCES
   blake3.c
@@ -15,17 +17,24 @@ if(CMAKE_SYSTEM_PROCESSOR STREQUAL x86_64)
   list(APPEND blake3_SOURCES
     blake3_avx2_x86-64_unix.S
     blake3_avx512_x86-64_unix.S
+    blake3_sse2_x86-64_unix.S
     blake3_sse41_x86-64_unix.S)
+
 elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL i686)
   list(APPEND blake3_SOURCES
     blake3_avx2.c
     blake3_avx512.c
+    blake3_sse2.c
     blake3_sse41.c)
   set_source_files_properties(blake3_avx2.c PROPERTIES COMPILE_FLAGS -mavx2)
   set_source_files_properties(blake3_avx512.c PROPERTIES COMPILE_FLAGS "-mavx512f -mavx512vl")
+  set_source_files_properties(blake3_sse2.c PROPERTIES COMPILE_FLAGS -msse2)
   set_source_files_properties(blake3_sse41.c PROPERTIES COMPILE_FLAGS -msse4.1)
+
 elseif((ANDROID_ABI STREQUAL armeabi-v7a) OR
-       (CMAKE_SYSTEM_PROCESSOR STREQUAL aarch64) OR (CMAKE_SYSTEM_PROCESSOR STREQUAL arm64))
+       (CMAKE_SYSTEM_PROCESSOR STREQUAL aarch64) OR 
+       (CMAKE_SYSTEM_PROCESSOR STREQUAL arm64) # For M1 macs
+      )
   list(APPEND blake3_SOURCES blake3_neon.c)
   set_source_files_properties(blake3_dispatch.c PROPERTIES COMPILE_FLAGS -DBLAKE3_USE_NEON=1)
   set_source_files_properties(blake3_neon.c PROPERTIES COMPILE_FLAGS -mfpu=neon)
@@ -35,22 +44,31 @@ configure_file(libblake3.pc.in libblake3.pc @ONLY)
 install(FILES ${CMAKE_BINARY_DIR}/libblake3.pc
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 
-add_library(blake3-shared SHARED ${blake3_SOURCES})
-set_target_properties(blake3-shared PROPERTIES VERSION ${PROJECT_VERSION})
-set_target_properties(blake3-shared PROPERTIES SOVERSION 0)
-set_target_properties(blake3-shared PROPERTIES PUBLIC_HEADER blake3.h)
-target_include_directories(blake3-shared PUBLIC .)
-install(TARGETS blake3-shared
+if(BLAKE3_STATIC)
+  add_library(blake3-static STATIC ${blake3_SOURCES})
+  set_target_properties(blake3-static PROPERTIES OUTPUT_NAME blake3)
+  set_target_properties(blake3-static PROPERTIES VERSION ${PROJECT_VERSION})
+  set_target_properties(blake3-static PROPERTIES SOVERSION 0)
+  set_target_properties(blake3-static PROPERTIES PUBLIC_HEADER blake3.h)
+  set_target_properties(blake3-static PROPERTIES COMPILE_FLAGS -fPIC)
+  target_include_directories(blake3-static PUBLIC .)
+
+  install(TARGETS blake3-static
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
-add_library(blake3-static STATIC ${blake3_SOURCES})
-set_target_properties(blake3-static PROPERTIES OUTPUT_NAME blake3)
-set_target_properties(blake3-static PROPERTIES VERSION ${PROJECT_VERSION})
-set_target_properties(blake3-static PROPERTIES SOVERSION 0)
-set_target_properties(blake3-static PROPERTIES PUBLIC_HEADER blake3.h)
-set_target_properties(blake3-static PROPERTIES COMPILE_FLAGS -fPIC)
-target_include_directories(blake3-static PUBLIC .)
-install(TARGETS blake3-static
-  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+else()
+
+  add_library(blake3-shared SHARED ${blake3_SOURCES})
+  set_target_properties(blake3-shared PROPERTIES VERSION ${PROJECT_VERSION})
+  set_target_properties(blake3-shared PROPERTIES SOVERSION 0)
+  set_target_properties(blake3-shared PROPERTIES PUBLIC_HEADER blake3.h)
+  target_include_directories(blake3-shared PUBLIC .)
+  
+  install(TARGETS blake3-shared
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+endif(BLAKE3_STATIC)
+
+unset(BLAKE3_STATIC)

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -1,0 +1,56 @@
+cmake_minimum_required(VERSION 3.9)
+
+project(libblake3 VERSION 0.1.0 DESCRIPTION "BLAKE3 C implementation")
+enable_language(C ASM)
+
+include(GNUInstallDirs)
+
+set(blake3_SOURCES)
+list(APPEND blake3_SOURCES
+  blake3.c
+  blake3_dispatch.c
+  blake3_portable.c)
+
+if(CMAKE_SYSTEM_PROCESSOR STREQUAL x86_64)
+  list(APPEND blake3_SOURCES
+    blake3_avx2_x86-64_unix.S
+    blake3_avx512_x86-64_unix.S
+    blake3_sse41_x86-64_unix.S)
+elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL i686)
+  list(APPEND blake3_SOURCES
+    blake3_avx2.c
+    blake3_avx512.c
+    blake3_sse41.c)
+  set_source_files_properties(blake3_avx2.c PROPERTIES COMPILE_FLAGS -mavx2)
+  set_source_files_properties(blake3_avx512.c PROPERTIES COMPILE_FLAGS "-mavx512f -mavx512vl")
+  set_source_files_properties(blake3_sse41.c PROPERTIES COMPILE_FLAGS -msse4.1)
+elseif((ANDROID_ABI STREQUAL armeabi-v7a) OR
+       (CMAKE_SYSTEM_PROCESSOR STREQUAL aarch64))
+  list(APPEND blake3_SOURCES blake3_neon.c)
+  set_source_files_properties(blake3_neon.c PROPERTIES COMPILE_FLAGS -mfpu=neon)
+  set_source_files_properties(blake3_dispatch.c PROPERTIES COMPILE_FLAGS -DBLAKE3_USE_NEON=1)
+endif()
+
+configure_file(libblake3.pc.in libblake3.pc @ONLY)
+install(FILES ${CMAKE_BINARY_DIR}/libblake3.pc
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+
+add_library(blake3-shared SHARED ${blake3_SOURCES})
+set_target_properties(blake3-shared PROPERTIES VERSION ${PROJECT_VERSION})
+set_target_properties(blake3-shared PROPERTIES SOVERSION 0)
+set_target_properties(blake3-shared PROPERTIES PUBLIC_HEADER blake3.h)
+target_include_directories(blake3-shared PRIVATE .)
+install(TARGETS blake3-shared
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+add_library(blake3-static STATIC ${blake3_SOURCES})
+set_target_properties(blake3-static PROPERTIES OUTPUT_NAME blake3)
+set_target_properties(blake3-static PROPERTIES VERSION ${PROJECT_VERSION})
+set_target_properties(blake3-static PROPERTIES SOVERSION 0)
+set_target_properties(blake3-static PROPERTIES PUBLIC_HEADER blake3.h)
+set_target_properties(blake3-static PROPERTIES COMPILE_FLAGS -fPIC)
+target_include_directories(blake3-static PRIVATE .)
+install(TARGETS blake3-static
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -15,12 +15,14 @@ if(CMAKE_SYSTEM_PROCESSOR STREQUAL x86_64)
   list(APPEND blake3_SOURCES
     blake3_avx2_x86-64_unix.S
     blake3_avx512_x86-64_unix.S
-    blake3_sse41_x86-64_unix.S)
+    blake3_sse41_x86-64_unix.S
+    blake3_sse2_x86-64_unix.S)
 elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL i686)
   list(APPEND blake3_SOURCES
     blake3_avx2.c
     blake3_avx512.c
-    blake3_sse41.c)
+    blake3_sse41.c
+    blake3_sse2.c)
   set_source_files_properties(blake3_avx2.c PROPERTIES COMPILE_FLAGS -mavx2)
   set_source_files_properties(blake3_avx512.c PROPERTIES COMPILE_FLAGS "-mavx512f -mavx512vl")
   set_source_files_properties(blake3_sse41.c PROPERTIES COMPILE_FLAGS -msse4.1)
@@ -39,7 +41,7 @@ add_library(blake3-shared SHARED ${blake3_SOURCES})
 set_target_properties(blake3-shared PROPERTIES VERSION ${PROJECT_VERSION})
 set_target_properties(blake3-shared PROPERTIES SOVERSION 0)
 set_target_properties(blake3-shared PROPERTIES PUBLIC_HEADER blake3.h)
-target_include_directories(blake3-shared PRIVATE .)
+target_include_directories(blake3-shared PUBLIC .)
 install(TARGETS blake3-shared
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
@@ -50,7 +52,7 @@ set_target_properties(blake3-static PROPERTIES VERSION ${PROJECT_VERSION})
 set_target_properties(blake3-static PROPERTIES SOVERSION 0)
 set_target_properties(blake3-static PROPERTIES PUBLIC_HEADER blake3.h)
 set_target_properties(blake3-static PROPERTIES COMPILE_FLAGS -fPIC)
-target_include_directories(blake3-static PRIVATE .)
+target_include_directories(blake3-static PUBLIC .)
 install(TARGETS blake3-static
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/c/libblake3.pc.in
+++ b/c/libblake3.pc.in
@@ -1,0 +1,12 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=@CMAKE_INSTALL_PREFIX@
+libdir=@CMAKE_INSTALL_LIBDIR@
+includedir=@CMAKE_INSTALL_INCLUDEDIR@
+
+Name: @PROJECT_NAME@
+Description: @PROJECT_DESCRIPTION@
+Version: @PROJECT_VERSION@
+
+Requires:
+Libs: -L${libdir} -lblake3
+Cflags: -I${includedir}


### PR DESCRIPTION
I needed to use BLAKE3 as a CMake submodule and luckily someone had [done the work for me](https://github.com/BLAKE3-team/BLAKE3/issues/102).

This PR makes BLAKE3 usable as a CMake submodule and helps with rather easy compilation of the library across platforms too.