### PR TITLE
clarify README - BLAKE3 is a feature of OpenZFS now

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Here's a (non-exhaustive) list of protocols and software that use BLAKE3:
 * [IPFS](https://github.com/ipfs/go-verifcid/issues/13)
 * [LLVM](https://reviews.llvm.org/D121510)
 * [Nym](https://github.com/nymtech/nym/blob/59056a22c5e6b01a38da2124662bd1fa3c8abef2/common/nymsphinx/params/src/lib.rs#L5)
-* [OpenZFS](https://github.com/openzfs/zfs/pull/11897)
+* [OpenZFS](https://github.com/openzfs/zfs/)
 * [Redox](https://www.redox-os.org/news/pkgar-introduction/)
 * [Skale](https://github.com/skalenetwork/skale-consensus/pull/284)
 * [Solana](https://docs.rs/solana-program/1.9.5/solana_program/blake3/index.html)


### PR DESCRIPTION
Hello,

just a small update for your README - BLAKE3 is in OpenZFS now ;-)
