### PR TITLE
Enable optimisation in Cargo.toml of b3sum

### DIFF
--- a/.github/workflows/build_b3sum.py
+++ b/.github/workflows/build_b3sum.py
@@ -9,7 +9,7 @@ import sys
 ROOT = Path(__file__).parent.parent.parent
 RUST_TARGET = sys.argv[1]
 
-subprocess.run(["cargo", "build", "--target", sys.argv[1], "--release"],
+subprocess.run(["cargo", "build", "--target", sys.argv[1], "--release", "--config", "strip=true"],
                cwd=ROOT / "b3sum")
 
 if platform.system() == "Windows":

--- a/b3sum/Cargo.toml
+++ b/b3sum/Cargo.toml
@@ -25,3 +25,8 @@ wild = "2.0.3"
 [dev-dependencies]
 duct = "0.13.3"
 tempfile = "3.1.0"
+
+[profile.release]
+strip = true
+lto = true
+opt-level = 3


### PR DESCRIPTION
Enable [stripping](https://doc.rust-lang.org/cargo/reference/profiles.html#strip), [link-time optimization](https://doc.rust-lang.org/cargo/reference/profiles.html#lto) and and all compiler [optimizations](https://doc.rust-lang.org/cargo/reference/profiles.html#opt-level). This should make executables considerably smaller (~800kB instead of >4MB for Linux, through stripping and lto, could be improved by setting `opt-level = "s"`, see [The Cargo Book](https://doc.rust-lang.org/cargo/reference/profiles.html?highlight=opt-level#opt-level)) and maybe faster (through lto and optimizations, although my dodgy tests didn't show any speed increase, could be because of a hard-drive bottleneck which would honestly be insane how fast this algorithm is).

I dun know yet how to exactly test performance of such performance-critical programs, the best I could to is make a sloppy test by writing like 10GiB of `/dev/urandom` to a file and then `time`ing the execution of `b3sum`, but I'm honestly super not trusting this method:
```bash
$ du test
10929668
$ time ./target/release/b3sum test
6edc4eb802feb666e4ee9fc388eab08c39906bc5d455ed14739ec6742017a47a  test
./target/release/b3sum test  2.18s user 4.83s system 187% cpu 3.735 total
$ c clean
$ c b --release
$ time ./target/release/b3sum test
6edc4eb802feb666e4ee9fc388eab08c39906bc5d455ed14739ec6742017a47a  test
./target/release/b3sum test  2.10s user 4.76s system 186% cpu 3.679 total
``` 

I also checked compile times, and they are staying very reasonable:
```
Before:
cargo b --release  51.84s user 3.73s system 562% cpu 9.883 total
After:
cargo b --release  36.13s user 3.18s system 300% cpu 13.088 total
```
Wait, why is it so much faster? I am- mildly confused...

Is there a reason this stuff hasn't been added yet?