### PR TITLE
blake3_dispatch: Fix race condition initializing g_cpu_features.

### DIFF
--- a/c/blake3_dispatch.c
+++ b/c/blake3_dispatch.c
@@ -6,12 +6,39 @@
 
 #if defined(IS_X86)
 #if defined(_MSC_VER)
+#include <Windows.h>
 #include <intrin.h>
 #elif defined(__GNUC__)
 #include <immintrin.h>
 #else
 #error "Unimplemented!"
 #endif
+#endif
+
+#if !defined(BLAKE3_ATOMICS)
+#if defined(__has_include)
+#if __has_include(<stdatomic.h>) && !defined(_MSC_VER)
+#define BLAKE3_ATOMICS 1
+#else
+#define BLAKE3_ATOMICS 0
+#endif /* __has_include(<stdatomic.h>) && !defined(_MSC_VER) */
+#else
+#define BLAKE3_ATOMICS 0
+#endif /* defined(__has_include) */
+#endif /* BLAKE3_ATOMICS */
+
+#if BLAKE3_ATOMICS
+#define ATOMIC_INT _Atomic int
+#define ATOMIC_LOAD(x) x
+#define ATOMIC_STORE(x, y) x = y
+#elif defined(_MSC_VER)
+#define ATOMIC_INT LONG
+#define ATOMIC_LOAD(x) InterlockedOr(&x, 0)
+#define ATOMIC_STORE(x, y) InterlockedExchange(&x, y)
+#else
+#define ATOMIC_INT int
+#define ATOMIC_LOAD(x) x
+#define ATOMIC_STORE(x, y) x = y
 #endif
 
 #define MAYBE_UNUSED(x) (void)((x))
@@ -76,7 +103,7 @@ enum cpu_feature {
 #if !defined(BLAKE3_TESTING)
 static /* Allow the variable to be controlled manually for testing */
 #endif
-    enum cpu_feature g_cpu_features = UNDEFINED;
+    ATOMIC_INT g_cpu_features = UNDEFINED;
 
 #if !defined(BLAKE3_TESTING)
 static
@@ -84,14 +111,16 @@ static
     enum cpu_feature
     get_cpu_features(void) {
 
-  if (g_cpu_features != UNDEFINED) {
-    return g_cpu_features;
+  /* If TSAN detects a data race here, try compiling with -DBLAKE3_ATOMICS=1 */
+  enum cpu_feature features = ATOMIC_LOAD(g_cpu_features);
+  if (features != UNDEFINED) {
+    return features;
   } else {
 #if defined(IS_X86)
     uint32_t regs[4] = {0};
     uint32_t *eax = &regs[0], *ebx = &regs[1], *ecx = &regs[2], *edx = &regs[3];
     (void)edx;
-    enum cpu_feature features = 0;
+    features = 0;
     cpuid(regs, 0);
     const int max_id = *eax;
     cpuid(regs, 1);
@@ -124,7 +153,7 @@ static
         }
       }
     }
-    g_cpu_features = features;
+    ATOMIC_STORE(g_cpu_features, features);
     return features;
 #else
     /* How to detect NEON? */


### PR DESCRIPTION
If multiple threads try to compute a hash simultaneously before the library has been used for the first time, the logic in `get_cpu_features` that detects CPU features will write to `g_cpu_features` without synchronization, which is a race condition, thus undefined behavior (and flagged by ThreadSanitizer).

This change marks `g_cpu_features` as an atomic variable to address the race condition. Since the C library is compiled with `-std=c11` this doesn't seem to introduce any compatibility issues.

I understand that the C library is not currently multithreaded (as documented [here](https://github.com/BLAKE3-team/BLAKE3/blob/master/c/README.md#multithreading)), but I understand that to mean that it doesn't support speeding up the hashing of a single buffer by using multiple threads, not that the library can't be used in a multithreaded application at all. Right now, despite this race condition being "benign" (all threads compute the same value, so the setting of `g_cpu_features` is idempotent), my understanding is that it does represent undefined behavior, so it's something that should be avoided. And it triggers ThreadSanitizer warnings, which can be suppressed but ideally would not occur at all.

Repro steps:

1. Create a file called `blake_tsan_error.c` at the root of the repo:

```c
#include <blake3.h>
#include <pthread.h>

void* thread_func(void* p) {
    uint8_t hash[BLAKE3_OUT_LEN];
    blake3_hasher hasher;
    blake3_hasher_init(&hasher);
    blake3_hasher_finalize(&hasher, hash, sizeof(hash));
    return NULL;
}

int main(int argc, char** argv) {
    pthread_t thread1;
    pthread_create(&thread1, NULL, &thread_func, NULL);
    pthread_t thread2;
    pthread_create(&thread2, NULL, &thread_func, NULL);
    pthread_join(thread1, NULL);
    pthread_join(thread2, NULL);
}
```

2. Build the code using Clang 15:

```shell
export CFLAGS="-O3 -std=c11 -pedantic -fstack-protector-strong -D_FORTIFY_SOURCE=2 -fPIE -fvisibility=hidden -fsanitize=thread -fno-omit-frame-pointer -fno-optimize-sibling-calls -DBLAKE3_NO_SSE2 -DBLAKE3_NO_SSE41 -DBLAKE3_NO_AVX2 -DBLAKE3_NO_AVX512"

clang $CFLAGS -c blake3.c -o blake3.o
clang $CFLAGS -c blake3_dispatch.c -o blake3_dispatch.o
clang $CFLAGS -c blake3_portable.c -o blake3_portable.o
clang $CFLAGS -I$PWD/c blake_tsan_error.c *.o -o blake_tsan_error
```

3. Run the code:

```shell
$ TSAN_OPTIONS=halt_on_error=1 ./blake_tsan_error
==================
WARNING: ThreadSanitizer: data race (pid=47788)
  Read of size 4 at 0x55981bb27c18 by thread T2:
    #0 blake3_compress_xof <null> (blake_tsan_error+0xece78)
    #1 blake3_hasher_finalize_seek <null> (blake_tsan_error+0xeb982)
    #2 blake3_hasher_finalize <null> (blake_tsan_error+0xeb6bb)
    #3 thread_func <null> (blake_tsan_error+0xe8481)

  Previous write of size 4 at 0x55981bb27c18 by thread T1:
    #0 blake3_compress_xof <null> (blake_tsan_error+0xecf16)
    #1 blake3_hasher_finalize_seek <null> (blake_tsan_error+0xeb982)
    #2 blake3_hasher_finalize <null> (blake_tsan_error+0xeb6bb)
    #3 thread_func <null> (blake_tsan_error+0xe8481)

  Location is global 'g_cpu_features' of size 4 at 0x55981bb27c18 (blake_tsan_error+0x12cc18)

  Thread T2 (tid=47791, running) created by main thread at:
    #0 pthread_create tsan_interceptors_posix.cpp:1022:3 (blake_tsan_error+0x5f933)
    #1 main <null> (blake_tsan_error+0xe84ff)

  Thread T1 (tid=47790, finished) created by main thread at:
    #0 pthread_create tsan_interceptors_posix.cpp:1022:3 (blake_tsan_error+0x5f933)
    #1 main <null> (blake_tsan_error+0xe84ec)

SUMMARY: ThreadSanitizer: data race (blake_tsan_error+0xece78) in blake3_compress_xof
==================
```