### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,18 @@ time openssl sha256 /tmp/bigfile
 time b3sum /tmp/bigfile
 ```
 
+### Installing from vcpkg
+
+You can download and install `blake3` using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+```sh
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+./bootstrap-vcpkg.sh #.\bootstrap-vcpkg.bat(for windows)
+./vcpkg integrate install
+./vcpkg install blake3
+```
+The `blake3` port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull   request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ### The `blake3` crate [![docs.rs](https://docs.rs/blake3/badge.svg)](https://docs.rs/blake3)
 
 To use BLAKE3 from Rust code, add a dependency on the `blake3` crate to

--- a/README.md
+++ b/README.md
@@ -111,18 +111,6 @@ time openssl sha256 /tmp/bigfile
 time b3sum /tmp/bigfile
 ```
 
-### Installing from vcpkg
-
-You can download and install `blake3` using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
-```sh
-git clone https://github.com/Microsoft/vcpkg.git
-cd vcpkg
-./bootstrap-vcpkg.sh #.\bootstrap-vcpkg.bat(for windows)
-./vcpkg integrate install
-./vcpkg install blake3
-```
-The `blake3` port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull   request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
-
 ### The `blake3` crate [![docs.rs](https://docs.rs/blake3/badge.svg)](https://docs.rs/blake3)
 
 To use BLAKE3 from Rust code, add a dependency on the `blake3` crate to

--- a/c/README.md
+++ b/c/README.md
@@ -309,6 +309,18 @@ example:
 gcc -shared -O3 -o libblake3.so blake3.c blake3_dispatch.c blake3_portable.c
 ```
 
+## Installing from vcpkg
+
+You can download and install `blake3` using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+```sh
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+./bootstrap-vcpkg.sh #.\bootstrap-vcpkg.bat(for windows)
+./vcpkg integrate install
+./vcpkg install blake3
+```
+The `blake3` port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull   request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 # Multithreading
 
 Unlike the Rust implementation, the C implementation doesn't currently support

--- a/c/README.md
+++ b/c/README.md
@@ -319,7 +319,7 @@ cd vcpkg
 ./vcpkg integrate install
 ./vcpkg install blake3
 ```
-The `blake3` port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull   request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+The `blake3` port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 
 # Multithreading
 


### PR DESCRIPTION
`blake3` available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for `blake3` and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build `blake3`, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/blake3/portfile.cmake). We try to keep the library maintained as close as possible to the original library.