### PR TITLE
Support portable build without intrinsics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,3 +233,17 @@ jobs:
     - name: build b3sum
       run: cargo build --target aarch64-apple-darwin
       working-directory: ./b3sum
+
+  build_tinycc:
+    name: build with the Tiny C Compiler
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: install TCC
+      run: apt-get install -y tcc
+    - name: compile
+      run: >
+        tcc -shared -O3 -o libblake3.so \
+          -DBLAKE3_NO_SSE2 -DBLAKE3_NO_SSE41 -DBLAKE3_NO_AVX2 -DBLAKE3_NO_AVX512 \
+          blake3.c blake3_dispatch.c blake3_portable.c
+      working-directory: ./c

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,7 +240,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: install TCC
-      run: apt-get install -y tcc
+      run: sudo apt-get install -y tcc
     - name: compile
       run: >
         tcc -shared -O3 -o libblake3.so \

--- a/c/blake3_dispatch.c
+++ b/c/blake3_dispatch.c
@@ -10,7 +10,7 @@
 #elif defined(__GNUC__)
 #include <immintrin.h>
 #else
-#error "Unimplemented!"
+#undef IS_X86 /* Unimplemented! */
 #endif
 #endif
 

--- a/c/blake3_impl.h
+++ b/c/blake3_impl.h
@@ -46,7 +46,6 @@ enum blake3_flags {
 #if defined(_MSC_VER)
 #include <intrin.h>
 #endif
-#include <immintrin.h>
 #endif
 
 #if !defined(BLAKE3_USE_NEON) 


### PR DESCRIPTION
It is impossible to build currently if you want to have a pure-portable build of the C code.
When we build rizin, we need to support TinyCC which does not have `immintrin.h` nor `intrin.h`.
This patch removes some dup declarations and defines the default values for the missing intrinsics.