### PR TITLE
constant time Ord and PartialOrd implementations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -315,8 +315,8 @@ impl PartialOrd for Hash {
 impl Ord for Hash {
     #[inline]
     fn cmp(&self, other: &Hash) -> std::cmp::Ordering {
-        let self32: [u32; 8] = as_u32s(self);
-        let other32: [u32; 8] = as_u32s(other);
+        let self32: [u32; 8] = platform::words_from_be_bytes_32(&self.0);
+        let other32: [u32; 8] = platform::words_from_be_bytes_32(&other.0);
         let mut acc: i32 = 0;
         for i in 0..self32.len() {
             // the left shift keeps earlier comparisons more significant than later ones
@@ -324,15 +324,6 @@ impl Ord for Hash {
         }
         acc.cmp(&0)
     }
-}
-
-/// Interpret a Hash as an array of big endian 32 bit unsigned integers.
-fn as_u32s(hash: &Hash) -> [u32; 8] {
-    let mut arr: [u32; 8] = [0; 8];
-    for i in 0..8 {
-        arr[i] = u32::from_be_bytes(*(array_ref!(hash.0, 4*i, 4)));
-    }
-    arr
 }
 
 /// Compares two items and returns -1 if Less, 0 if Equal, or 1 if Greater.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -306,7 +306,7 @@ impl Eq for Hash {}
 
 /// This implementation is constant-time.
 impl PartialOrd for Hash {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
@@ -314,7 +314,7 @@ impl PartialOrd for Hash {
 /// This implementation is constant-time.
 impl Ord for Hash {
     #[inline]
-    fn cmp(&self, other: &Hash) -> std::cmp::Ordering {
+    fn cmp(&self, other: &Hash) -> cmp::Ordering {
         let self32: [u32; 8] = platform::words_from_be_bytes_32(&self.0);
         let other32: [u32; 8] = platform::words_from_be_bytes_32(&other.0);
         let mut acc: i32 = 0;
@@ -329,9 +329,9 @@ impl Ord for Hash {
 /// Compares two items and returns -1 if Less, 0 if Equal, or 1 if Greater.
 fn cmp_sign<T: Ord>(a: &T, b: &T) -> i32 {
     match a.cmp(b) {
-        std::cmp::Ordering::Less => -1,
-        std::cmp::Ordering::Equal => 0,
-        std::cmp::Ordering::Greater => 1,
+        cmp::Ordering::Less => -1,
+        cmp::Ordering::Equal => 0,
+        cmp::Ordering::Greater => 1,
     }
 }
 

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -415,6 +415,15 @@ pub fn sse2_detected() -> bool {
 }
 
 #[inline(always)]
+pub fn words_from_be_bytes_32(bytes: &[u8; 32]) -> [u32; 8] {
+    let mut out: [u32; 8] = [0; 8];
+    for i in 0..8 {
+        out[i] = u32::from_be_bytes(*(array_ref!(bytes, 4*i, 4)));
+    }
+    out
+}
+
+#[inline(always)]
 pub fn words_from_le_bytes_32(bytes: &[u8; 32]) -> [u32; 8] {
     let mut out = [0; 8];
     out[0] = u32::from_le_bytes(*array_ref!(bytes, 0 * 4, 4));

--- a/src/test.rs
+++ b/src/test.rs
@@ -594,3 +594,14 @@ fn test_issue_206_windows_sse2() {
         assert_eq!(crate::Hasher::new().update(input).finalize(), expected_hash);
     }
 }
+
+#[test]
+#[cfg(feature = "std")]
+fn test_order_match() {
+	let hashes = [[0], [1], [2], [3]].map(|a| reference_hash(&a));
+	for i in 0..hashes.len() {
+		for j in 0..hashes.len() {
+			assert_eq!(hashes[i].cmp(&hashes[j]), hashes[i].0.cmp(&hashes[j].0));
+		}
+	}
+}


### PR DESCRIPTION
Fixes #202.

This does not follow the recommended path of utilizing [subtle](https://docs.rs/subtle/latest/subtle/trait.ConstantTimeLess.html) as it does not provide any helpers to do constant time ordering on containers.

The overall method is to compare each u32 in the hashes, turn each of those into -1, 0, or 1, accumulate them into a single signed word, and then finally compare that word to 0.

The [optimized object code](https://github.com/BLAKE3-team/BLAKE3/files/9993917/disassembly.txt) on x86-64 is somewhat large but appears to be constant time - no jumps, early returns, or anything like that. This is, of course, not a guarantee that it will never face optimization in hardware or software in the future.