### PR TITLE
Use global_asm to include the sse/avx impls

### DIFF
--- a/c/blake3_avx2_x86-64_windows_gnu.S
+++ b/c/blake3_avx2_x86-64_windows_gnu.S
@@ -36,15 +36,15 @@ blake3_hash_many_avx2:
         vmovd   xmm0, r9d
         vpbroadcastd ymm0, xmm0
         vmovdqa ymmword ptr [rsp+0x260], ymm0
-        vpand   ymm1, ymm0, ymmword ptr [ADD0+rip]
-        vpand   ymm2, ymm0, ymmword ptr [ADD1+rip]
+        vpand   ymm1, ymm0, ymmword ptr [AVX2_ADD0+rip]
+        vpand   ymm2, ymm0, ymmword ptr [AVX2_ADD1+rip]
         vmovdqa ymmword ptr [rsp+0x2A0], ymm2
         vmovd   xmm2, r8d
         vpbroadcastd ymm2, xmm2
         vpaddd  ymm2, ymm2, ymm1
         vmovdqa ymmword ptr [rsp+0x220], ymm2
-        vpxor   ymm1, ymm1, ymmword ptr [CMP_MSB_MASK+rip]
-        vpxor   ymm2, ymm2, ymmword ptr [CMP_MSB_MASK+rip]
+        vpxor   ymm1, ymm1, ymmword ptr [AVX2_CMP_MSB_MASK+rip]
+        vpxor   ymm2, ymm2, ymmword ptr [AVX2_CMP_MSB_MASK+rip]
         vpcmpgtd ymm2, ymm1, ymm2
         shr     r8, 32
         vmovd   xmm3, r8d
@@ -183,17 +183,17 @@ blake3_hash_many_avx2:
         vpaddd  ymm3, ymm3, ymm7
         vpxor   ymm12, ymm0, ymmword ptr [rsp+0x220]
         vpxor   ymm13, ymm1, ymmword ptr [rsp+0x240]
-        vpxor   ymm14, ymm2, ymmword ptr [BLAKE3_BLOCK_LEN+rip]
+        vpxor   ymm14, ymm2, ymmword ptr [AVX2_BLAKE3_BLOCK_LEN+rip]
         vpxor   ymm15, ymm3, ymm15
-        vbroadcasti128 ymm8, xmmword ptr [ROT16+rip]
+        vbroadcasti128 ymm8, xmmword ptr [AVX2_ROT16+rip]
         vpshufb ymm12, ymm12, ymm8
         vpshufb ymm13, ymm13, ymm8
         vpshufb ymm14, ymm14, ymm8
         vpshufb ymm15, ymm15, ymm8
-        vpaddd  ymm8, ymm12, ymmword ptr [BLAKE3_IV_0+rip]
-        vpaddd  ymm9, ymm13, ymmword ptr [BLAKE3_IV_1+rip]
-        vpaddd  ymm10, ymm14, ymmword ptr [BLAKE3_IV_2+rip]
-        vpaddd  ymm11, ymm15, ymmword ptr [BLAKE3_IV_3+rip]
+        vpaddd  ymm8, ymm12, ymmword ptr [AVX2_BLAKE3_IV_0+rip]
+        vpaddd  ymm9, ymm13, ymmword ptr [AVX2_BLAKE3_IV_1+rip]
+        vpaddd  ymm10, ymm14, ymmword ptr [AVX2_BLAKE3_IV_2+rip]
+        vpaddd  ymm11, ymm15, ymmword ptr [AVX2_BLAKE3_IV_3+rip]
         vpxor   ymm4, ymm4, ymm8
         vpxor   ymm5, ymm5, ymm9
         vpxor   ymm6, ymm6, ymm10
@@ -223,7 +223,7 @@ blake3_hash_many_avx2:
         vpxor   ymm13, ymm13, ymm1
         vpxor   ymm14, ymm14, ymm2
         vpxor   ymm15, ymm15, ymm3
-        vbroadcasti128 ymm8, xmmword ptr [ROT8+rip]
+        vbroadcasti128 ymm8, xmmword ptr [AVX2_ROT8+rip]
         vpshufb ymm12, ymm12, ymm8
         vpshufb ymm13, ymm13, ymm8
         vpshufb ymm14, ymm14, ymm8
@@ -261,7 +261,7 @@ blake3_hash_many_avx2:
         vpxor   ymm12, ymm12, ymm1
         vpxor   ymm13, ymm13, ymm2
         vpxor   ymm14, ymm14, ymm3
-        vbroadcasti128 ymm8, xmmword ptr [ROT16+rip]
+        vbroadcasti128 ymm8, xmmword ptr [AVX2_ROT16+rip]
         vpshufb ymm15, ymm15, ymm8
         vpshufb ymm12, ymm12, ymm8
         vpshufb ymm13, ymm13, ymm8
@@ -299,7 +299,7 @@ blake3_hash_many_avx2:
         vpxor   ymm12, ymm12, ymm1
         vpxor   ymm13, ymm13, ymm2
         vpxor   ymm14, ymm14, ymm3
-        vbroadcasti128 ymm8, xmmword ptr [ROT8+rip]
+        vbroadcasti128 ymm8, xmmword ptr [AVX2_ROT8+rip]
         vpshufb ymm15, ymm15, ymm8
         vpshufb ymm12, ymm12, ymm8
         vpshufb ymm13, ymm13, ymm8
@@ -337,7 +337,7 @@ blake3_hash_many_avx2:
         vpxor   ymm13, ymm13, ymm1
         vpxor   ymm14, ymm14, ymm2
         vpxor   ymm15, ymm15, ymm3
-        vbroadcasti128 ymm8, xmmword ptr [ROT16+rip]
+        vbroadcasti128 ymm8, xmmword ptr [AVX2_ROT16+rip]
         vpshufb ymm12, ymm12, ymm8
         vpshufb ymm13, ymm13, ymm8
         vpshufb ymm14, ymm14, ymm8
@@ -375,7 +375,7 @@ blake3_hash_many_avx2:
         vpxor   ymm13, ymm13, ymm1
         vpxor   ymm14, ymm14, ymm2
         vpxor   ymm15, ymm15, ymm3
-        vbroadcasti128 ymm8, xmmword ptr [ROT8+rip]
+        vbroadcasti128 ymm8, xmmword ptr [AVX2_ROT8+rip]
         vpshufb ymm12, ymm12, ymm8
         vpshufb ymm13, ymm13, ymm8
         vpshufb ymm14, ymm14, ymm8
@@ -413,7 +413,7 @@ blake3_hash_many_avx2:
         vpxor   ymm12, ymm12, ymm1
         vpxor   ymm13, ymm13, ymm2
         vpxor   ymm14, ymm14, ymm3
-        vbroadcasti128 ymm8, xmmword ptr [ROT16+rip]
+        vbroadcasti128 ymm8, xmmword ptr [AVX2_ROT16+rip]
         vpshufb ymm15, ymm15, ymm8
         vpshufb ymm12, ymm12, ymm8
         vpshufb ymm13, ymm13, ymm8
@@ -451,7 +451,7 @@ blake3_hash_many_avx2:
         vpxor   ymm12, ymm12, ymm1
         vpxor   ymm13, ymm13, ymm2
         vpxor   ymm14, ymm14, ymm3
-        vbroadcasti128 ymm8, xmmword ptr [ROT8+rip]
+        vbroadcasti128 ymm8, xmmword ptr [AVX2_ROT8+rip]
         vpshufb ymm15, ymm15, ymm8
         vpshufb ymm12, ymm12, ymm8
         vpshufb ymm13, ymm13, ymm8
@@ -489,7 +489,7 @@ blake3_hash_many_avx2:
         vpxor   ymm13, ymm13, ymm1
         vpxor   ymm14, ymm14, ymm2
         vpxor   ymm15, ymm15, ymm3
-        vbroadcasti128 ymm8, xmmword ptr [ROT16+rip]
+        vbroadcasti128 ymm8, xmmword ptr [AVX2_ROT16+rip]
         vpshufb ymm12, ymm12, ymm8
         vpshufb ymm13, ymm13, ymm8
         vpshufb ymm14, ymm14, ymm8
@@ -527,7 +527,7 @@ blake3_hash_many_avx2:
         vpxor   ymm13, ymm13, ymm1
         vpxor   ymm14, ymm14, ymm2
         vpxor   ymm15, ymm15, ymm3
-        vbroadcasti128 ymm8, xmmword ptr [ROT8+rip]
+        vbroadcasti128 ymm8, xmmword ptr [AVX2_ROT8+rip]
         vpshufb ymm12, ymm12, ymm8
         vpshufb ymm13, ymm13, ymm8
         vpshufb ymm14, ymm14, ymm8
@@ -565,7 +565,7 @@ blake3_hash_many_avx2:
         vpxor   ymm12, ymm12, ymm1
         vpxor   ymm13, ymm13, ymm2
         vpxor   ymm14, ymm14, ymm3
-        vbroadcasti128 ymm8, xmmword ptr [ROT16+rip]
+        vbroadcasti128 ymm8, xmmword ptr [AVX2_ROT16+rip]
         vpshufb ymm15, ymm15, ymm8
         vpshufb ymm12, ymm12, ymm8
         vpshufb ymm13, ymm13, ymm8
@@ -603,7 +603,7 @@ blake3_hash_many_avx2:
         vpxor   ymm12, ymm12, ymm1
         vpxor   ymm13, ymm13, ymm2
         vpxor   ymm14, ymm14, ymm3
-        vbroadcasti128 ymm8, xmmword ptr [ROT8+rip]
+        vbroadcasti128 ymm8, xmmword ptr [AVX2_ROT8+rip]
         vpshufb ymm15, ymm15, ymm8
         vpshufb ymm12, ymm12, ymm8
         vpshufb ymm13, ymm13, ymm8
@@ -641,7 +641,7 @@ blake3_hash_many_avx2:
         vpxor   ymm13, ymm13, ymm1
         vpxor   ymm14, ymm14, ymm2
         vpxor   ymm15, ymm15, ymm3
-        vbroadcasti128 ymm8, xmmword ptr [ROT16+rip]
+        vbroadcasti128 ymm8, xmmword ptr [AVX2_ROT16+rip]
         vpshufb ymm12, ymm12, ymm8
         vpshufb ymm13, ymm13, ymm8
         vpshufb ymm14, ymm14, ymm8
@@ -679,7 +679,7 @@ blake3_hash_many_avx2:
         vpxor   ymm13, ymm13, ymm1
         vpxor   ymm14, ymm14, ymm2
         vpxor   ymm15, ymm15, ymm3
-        vbroadcasti128 ymm8, xmmword ptr [ROT8+rip]
+        vbroadcasti128 ymm8, xmmword ptr [AVX2_ROT8+rip]
         vpshufb ymm12, ymm12, ymm8
         vpshufb ymm13, ymm13, ymm8
         vpshufb ymm14, ymm14, ymm8
@@ -717,7 +717,7 @@ blake3_hash_many_avx2:
         vpxor   ymm12, ymm12, ymm1
         vpxor   ymm13, ymm13, ymm2
         vpxor   ymm14, ymm14, ymm3
-        vbroadcasti128 ymm8, xmmword ptr [ROT16+rip]
+        vbroadcasti128 ymm8, xmmword ptr [AVX2_ROT16+rip]
         vpshufb ymm15, ymm15, ymm8
         vpshufb ymm12, ymm12, ymm8
         vpshufb ymm13, ymm13, ymm8
@@ -755,7 +755,7 @@ blake3_hash_many_avx2:
         vpxor   ymm12, ymm12, ymm1
         vpxor   ymm13, ymm13, ymm2
         vpxor   ymm14, ymm14, ymm3
-        vbroadcasti128 ymm8, xmmword ptr [ROT8+rip]
+        vbroadcasti128 ymm8, xmmword ptr [AVX2_ROT8+rip]
         vpshufb ymm15, ymm15, ymm8
         vpshufb ymm12, ymm12, ymm8
         vpshufb ymm13, ymm13, ymm8
@@ -793,7 +793,7 @@ blake3_hash_many_avx2:
         vpxor   ymm13, ymm13, ymm1
         vpxor   ymm14, ymm14, ymm2
         vpxor   ymm15, ymm15, ymm3
-        vbroadcasti128 ymm8, xmmword ptr [ROT16+rip]
+        vbroadcasti128 ymm8, xmmword ptr [AVX2_ROT16+rip]
         vpshufb ymm12, ymm12, ymm8
         vpshufb ymm13, ymm13, ymm8
         vpshufb ymm14, ymm14, ymm8
@@ -831,7 +831,7 @@ blake3_hash_many_avx2:
         vpxor   ymm13, ymm13, ymm1
         vpxor   ymm14, ymm14, ymm2
         vpxor   ymm15, ymm15, ymm3
-        vbroadcasti128 ymm8, xmmword ptr [ROT8+rip]
+        vbroadcasti128 ymm8, xmmword ptr [AVX2_ROT8+rip]
         vpshufb ymm12, ymm12, ymm8
         vpshufb ymm13, ymm13, ymm8
         vpshufb ymm14, ymm14, ymm8
@@ -869,7 +869,7 @@ blake3_hash_many_avx2:
         vpxor   ymm12, ymm12, ymm1
         vpxor   ymm13, ymm13, ymm2
         vpxor   ymm14, ymm14, ymm3
-        vbroadcasti128 ymm8, xmmword ptr [ROT16+rip]
+        vbroadcasti128 ymm8, xmmword ptr [AVX2_ROT16+rip]
         vpshufb ymm15, ymm15, ymm8
         vpshufb ymm12, ymm12, ymm8
         vpshufb ymm13, ymm13, ymm8
@@ -907,7 +907,7 @@ blake3_hash_many_avx2:
         vpxor   ymm12, ymm12, ymm1
         vpxor   ymm13, ymm13, ymm2
         vpxor   ymm14, ymm14, ymm3
-        vbroadcasti128 ymm8, xmmword ptr [ROT8+rip]
+        vbroadcasti128 ymm8, xmmword ptr [AVX2_ROT8+rip]
         vpshufb ymm15, ymm15, ymm8
         vpshufb ymm12, ymm12, ymm8
         vpshufb ymm13, ymm13, ymm8
@@ -945,7 +945,7 @@ blake3_hash_many_avx2:
         vpxor   ymm13, ymm13, ymm1
         vpxor   ymm14, ymm14, ymm2
         vpxor   ymm15, ymm15, ymm3
-        vbroadcasti128 ymm8, xmmword ptr [ROT16+rip]
+        vbroadcasti128 ymm8, xmmword ptr [AVX2_ROT16+rip]
         vpshufb ymm12, ymm12, ymm8
         vpshufb ymm13, ymm13, ymm8
         vpshufb ymm14, ymm14, ymm8
@@ -983,7 +983,7 @@ blake3_hash_many_avx2:
         vpxor   ymm13, ymm13, ymm1
         vpxor   ymm14, ymm14, ymm2
         vpxor   ymm15, ymm15, ymm3
-        vbroadcasti128 ymm8, xmmword ptr [ROT8+rip]
+        vbroadcasti128 ymm8, xmmword ptr [AVX2_ROT8+rip]
         vpshufb ymm12, ymm12, ymm8
         vpshufb ymm13, ymm13, ymm8
         vpshufb ymm14, ymm14, ymm8
@@ -1021,7 +1021,7 @@ blake3_hash_many_avx2:
         vpxor   ymm12, ymm12, ymm1
         vpxor   ymm13, ymm13, ymm2
         vpxor   ymm14, ymm14, ymm3
-        vbroadcasti128 ymm8, xmmword ptr [ROT16+rip]
+        vbroadcasti128 ymm8, xmmword ptr [AVX2_ROT16+rip]
         vpshufb ymm15, ymm15, ymm8
         vpshufb ymm12, ymm12, ymm8
         vpshufb ymm13, ymm13, ymm8
@@ -1059,7 +1059,7 @@ blake3_hash_many_avx2:
         vpxor   ymm12, ymm12, ymm1
         vpxor   ymm13, ymm13, ymm2
         vpxor   ymm14, ymm14, ymm3
-        vbroadcasti128 ymm8, xmmword ptr [ROT8+rip]
+        vbroadcasti128 ymm8, xmmword ptr [AVX2_ROT8+rip]
         vpshufb ymm15, ymm15, ymm8
         vpshufb ymm12, ymm12, ymm8
         vpshufb ymm13, ymm13, ymm8
@@ -1097,7 +1097,7 @@ blake3_hash_many_avx2:
         vpxor   ymm13, ymm13, ymm1
         vpxor   ymm14, ymm14, ymm2
         vpxor   ymm15, ymm15, ymm3
-        vbroadcasti128 ymm8, xmmword ptr [ROT16+rip]
+        vbroadcasti128 ymm8, xmmword ptr [AVX2_ROT16+rip]
         vpshufb ymm12, ymm12, ymm8
         vpshufb ymm13, ymm13, ymm8
         vpshufb ymm14, ymm14, ymm8
@@ -1135,7 +1135,7 @@ blake3_hash_many_avx2:
         vpxor   ymm13, ymm13, ymm1
         vpxor   ymm14, ymm14, ymm2
         vpxor   ymm15, ymm15, ymm3
-        vbroadcasti128 ymm8, xmmword ptr [ROT8+rip]
+        vbroadcasti128 ymm8, xmmword ptr [AVX2_ROT8+rip]
         vpshufb ymm12, ymm12, ymm8
         vpshufb ymm13, ymm13, ymm8
         vpshufb ymm14, ymm14, ymm8
@@ -1173,7 +1173,7 @@ blake3_hash_many_avx2:
         vpxor   ymm12, ymm12, ymm1
         vpxor   ymm13, ymm13, ymm2
         vpxor   ymm14, ymm14, ymm3
-        vbroadcasti128 ymm8, xmmword ptr [ROT16+rip]
+        vbroadcasti128 ymm8, xmmword ptr [AVX2_ROT16+rip]
         vpshufb ymm15, ymm15, ymm8
         vpshufb ymm12, ymm12, ymm8
         vpshufb ymm13, ymm13, ymm8
@@ -1211,7 +1211,7 @@ blake3_hash_many_avx2:
         vpxor   ymm12, ymm12, ymm1
         vpxor   ymm13, ymm13, ymm2
         vpxor   ymm14, ymm14, ymm3
-        vbroadcasti128 ymm8, xmmword ptr [ROT8+rip]
+        vbroadcasti128 ymm8, xmmword ptr [AVX2_ROT8+rip]
         vpshufb ymm15, ymm15, ymm8
         vpshufb ymm12, ymm12, ymm8
         vpshufb ymm13, ymm13, ymm8
@@ -1286,8 +1286,8 @@ blake3_hash_many_avx2:
         vmovdqa ymm0, ymmword ptr [rsp+0x2A0]
         vpaddd  ymm1, ymm0, ymmword ptr [rsp+0x220]
         vmovdqa ymmword ptr [rsp+0x220], ymm1
-        vpxor   ymm0, ymm0, ymmword ptr [CMP_MSB_MASK+rip]
-        vpxor   ymm2, ymm1, ymmword ptr [CMP_MSB_MASK+rip]
+        vpxor   ymm0, ymm0, ymmword ptr [AVX2_CMP_MSB_MASK+rip]
+        vpxor   ymm2, ymm1, ymmword ptr [AVX2_CMP_MSB_MASK+rip]
         vpcmpgtd ymm2, ymm0, ymm2
         vmovdqa ymm0, ymmword ptr [rsp+0x240]
         vpsubd  ymm2, ymm0, ymm2
@@ -1340,7 +1340,7 @@ blake3_hash_many_avx2:
         vpunpckhdq ymm15, ymm12, ymm13
         vpermq  ymm14, ymm14, 0x50
         vpermq  ymm15, ymm15, 0x50
-        vbroadcasti128 ymm12, xmmword ptr [BLAKE3_BLOCK_LEN+rip]
+        vbroadcasti128 ymm12, xmmword ptr [AVX2_BLAKE3_BLOCK_LEN+rip]
         vpblendd ymm14, ymm14, ymm12, 0x44
         vpblendd ymm15, ymm15, ymm12, 0x44
         vmovdqa ymmword ptr [rsp], ymm14
@@ -1393,7 +1393,7 @@ blake3_hash_many_avx2:
         vmovdqa ymm11, ymmword ptr [rsp+0x20]
         vpblendd ymm3, ymm3, ymm2, 0x88
         vpblendd ymm11, ymm11, ymm2, 0x88
-        vbroadcasti128 ymm2, xmmword ptr [BLAKE3_IV+rip]
+        vbroadcasti128 ymm2, xmmword ptr [AVX2_BLAKE3_IV+rip]
         vmovdqa ymm10, ymm2
         mov     al, 7
 9:
@@ -1407,7 +1407,7 @@ blake3_hash_many_avx2:
         vpaddd  ymm8, ymm8, ymm9
         vpxor   ymm3, ymm3, ymm0
         vpxor   ymm11, ymm11, ymm8
-        vbroadcasti128 ymm4, xmmword ptr [ROT16+rip]
+        vbroadcasti128 ymm4, xmmword ptr [AVX2_ROT16+rip]
         vpshufb ymm3, ymm3, ymm4
         vpshufb ymm11, ymm11, ymm4
         vpaddd  ymm2, ymm2, ymm3
@@ -1428,7 +1428,7 @@ blake3_hash_many_avx2:
         vmovdqa ymmword ptr [rsp+0xA0], ymm13
         vpxor   ymm3, ymm3, ymm0
         vpxor   ymm11, ymm11, ymm8
-        vbroadcasti128 ymm4, xmmword ptr [ROT8+rip]
+        vbroadcasti128 ymm4, xmmword ptr [AVX2_ROT8+rip]
         vpshufb ymm3, ymm3, ymm4
         vpshufb ymm11, ymm11, ymm4
         vpaddd  ymm2, ymm2, ymm3
@@ -1453,7 +1453,7 @@ blake3_hash_many_avx2:
         vpaddd  ymm8, ymm8, ymm9
         vpxor   ymm3, ymm3, ymm0
         vpxor   ymm11, ymm11, ymm8
-        vbroadcasti128 ymm4, xmmword ptr [ROT16+rip]
+        vbroadcasti128 ymm4, xmmword ptr [AVX2_ROT16+rip]
         vpshufb ymm3, ymm3, ymm4
         vpshufb ymm11, ymm11, ymm4
         vpaddd  ymm2, ymm2, ymm3
@@ -1472,7 +1472,7 @@ blake3_hash_many_avx2:
         vpaddd  ymm8, ymm8, ymm9
         vpxor   ymm3, ymm3, ymm0
         vpxor   ymm11, ymm11, ymm8
-        vbroadcasti128 ymm4, xmmword ptr [ROT8+rip]
+        vbroadcasti128 ymm4, xmmword ptr [AVX2_ROT8+rip]
         vpshufb ymm3, ymm3, ymm4
         vpshufb ymm11, ymm11, ymm4
         vpaddd  ymm2, ymm2, ymm3
@@ -1561,13 +1561,13 @@ blake3_hash_many_avx2:
         vbroadcasti128 ymm1, xmmword ptr [rcx+0x10]
         vmovd   xmm13, dword ptr [rsp+0x220]
         vpinsrd xmm13, xmm13, dword ptr [rsp+0x240], 1
-        vpinsrd xmm13, xmm13, dword ptr [BLAKE3_BLOCK_LEN+rip], 2
+        vpinsrd xmm13, xmm13, dword ptr [AVX2_BLAKE3_BLOCK_LEN+rip], 2
         vmovd   xmm14, dword ptr [rsp+0x224]
         vpinsrd xmm14, xmm14, dword ptr [rsp+0x244], 1
-        vpinsrd xmm14, xmm14, dword ptr [BLAKE3_BLOCK_LEN+rip], 2
+        vpinsrd xmm14, xmm14, dword ptr [AVX2_BLAKE3_BLOCK_LEN+rip], 2
         vinserti128 ymm13, ymm13, xmm14, 0x01
-        vbroadcasti128 ymm14, xmmword ptr [ROT16+rip]
-        vbroadcasti128 ymm15, xmmword ptr [ROT8+rip]
+        vbroadcasti128 ymm14, xmmword ptr [AVX2_ROT16+rip]
+        vbroadcasti128 ymm15, xmmword ptr [AVX2_ROT8+rip]
         mov     r8, qword ptr [rdi]
         mov     r9, qword ptr [rdi+0x8]
         movzx   eax, byte ptr [rbp+0x80]
@@ -1581,7 +1581,7 @@ blake3_hash_many_avx2:
         cmp     rdx, r15
         cmovne  eax, r14d
         mov     dword ptr [rsp+0x200], eax
-        vbroadcasti128 ymm2, xmmword ptr [BLAKE3_IV+rip]
+        vbroadcasti128 ymm2, xmmword ptr [AVX2_BLAKE3_IV+rip]
         vpbroadcastd ymm8, dword ptr [rsp+0x200]
         vpblendd ymm3, ymm13, ymm8, 0x88
         vmovups ymm8, ymmword ptr [r8+rdx-0x40]
@@ -1687,9 +1687,9 @@ blake3_hash_many_avx2:
         vmovdqu xmm1, xmmword ptr [rcx+0x10]
         vmovd   xmm3, dword ptr [rsp+0x220]
         vpinsrd xmm3, xmm3, dword ptr [rsp+0x240], 1
-        vpinsrd xmm13, xmm3, dword ptr [BLAKE3_BLOCK_LEN+rip], 2
-        vmovdqa xmm14, xmmword ptr [ROT16+rip]
-        vmovdqa xmm15, xmmword ptr [ROT8+rip]
+        vpinsrd xmm13, xmm3, dword ptr [AVX2_BLAKE3_BLOCK_LEN+rip], 2
+        vmovdqa xmm14, xmmword ptr [AVX2_ROT16+rip]
+        vmovdqa xmm15, xmmword ptr [AVX2_ROT8+rip]
         mov     r8, qword ptr [rdi]
         movzx   eax, byte ptr [rbp+0x80]
         or      eax, r13d
@@ -1701,7 +1701,7 @@ blake3_hash_many_avx2:
         add     rdx, 64
         cmp     rdx, r15
         cmovne  eax, r14d
-        vmovdqa xmm2, xmmword ptr [BLAKE3_IV+rip]
+        vmovdqa xmm2, xmmword ptr [AVX2_BLAKE3_IV+rip]
         vmovdqa xmm3, xmm13
         vpinsrd xmm3, xmm3, eax, 3
         vmovups xmm8, xmmword ptr [r8+rdx-0x40]
@@ -1786,32 +1786,32 @@ blake3_hash_many_avx2:
 
 .section .rodata
 .p2align  6
-ADD0:
+AVX2_ADD0:
         .long  0, 1, 2, 3, 4, 5, 6, 7
-ADD1:
+AVX2_ADD1:
         .long  8, 8, 8, 8, 8, 8, 8, 8
-BLAKE3_IV_0:
+AVX2_BLAKE3_IV_0:
         .long  0x6A09E667, 0x6A09E667, 0x6A09E667, 0x6A09E667
         .long  0x6A09E667, 0x6A09E667, 0x6A09E667, 0x6A09E667
-BLAKE3_IV_1:
+AVX2_BLAKE3_IV_1:
         .long  0xBB67AE85, 0xBB67AE85, 0xBB67AE85, 0xBB67AE85
         .long  0xBB67AE85, 0xBB67AE85, 0xBB67AE85, 0xBB67AE85
-BLAKE3_IV_2:
+AVX2_BLAKE3_IV_2:
         .long  0x3C6EF372, 0x3C6EF372, 0x3C6EF372, 0x3C6EF372
         .long  0x3C6EF372, 0x3C6EF372, 0x3C6EF372, 0x3C6EF372
-BLAKE3_IV_3:
+AVX2_BLAKE3_IV_3:
         .long  0xA54FF53A, 0xA54FF53A, 0xA54FF53A, 0xA54FF53A
         .long  0xA54FF53A, 0xA54FF53A, 0xA54FF53A, 0xA54FF53A
-BLAKE3_BLOCK_LEN:
+AVX2_BLAKE3_BLOCK_LEN:
         .long  0x00000040, 0x00000040, 0x00000040, 0x00000040
         .long  0x00000040, 0x00000040, 0x00000040, 0x00000040
-ROT16:
+AVX2_ROT16:
         .byte  2, 3, 0, 1, 6, 7, 4, 5, 10, 11, 8, 9, 14, 15, 12, 13
-ROT8:
+AVX2_ROT8:
         .byte  1, 2, 3, 0, 5, 6, 7, 4, 9, 10, 11, 8, 13, 14, 15, 12
-CMP_MSB_MASK:
+AVX2_CMP_MSB_MASK:
         .long  0x80000000, 0x80000000, 0x80000000, 0x80000000
         .long  0x80000000, 0x80000000, 0x80000000, 0x80000000
-BLAKE3_IV:
+AVX2_BLAKE3_IV:
         .long  0x6A09E667, 0xBB67AE85, 0x3C6EF372, 0xA54FF53A
 

--- a/c/blake3_avx512_x86-64_windows_gnu.S
+++ b/c/blake3_avx512_x86-64_windows_gnu.S
@@ -47,12 +47,12 @@ blake3_hash_many_avx512:
         vpbroadcastd ymm1, xmm1
         vmovdqa ymm4, ymm1
         vmovdqa ymm5, ymm1
-        vpaddd  ymm2, ymm0, ymmword ptr [ADD0+rip]
-        vpaddd  ymm3, ymm0, ymmword ptr [ADD0+32+rip]
+        vpaddd  ymm2, ymm0, ymmword ptr [AVX512_ADD0+rip]
+        vpaddd  ymm3, ymm0, ymmword ptr [AVX512_ADD0+32+rip]
         vpcmpltud k2, ymm2, ymm0
         vpcmpltud k3, ymm3, ymm0
-        vpaddd  ymm4 {k2}, ymm4, dword ptr [ADD1+rip] {1to8}
-        vpaddd  ymm5 {k3}, ymm5, dword ptr [ADD1+rip] {1to8}
+        vpaddd  ymm4 {k2}, ymm4, dword ptr [AVX512_ADD1+rip] {1to8}
+        vpaddd  ymm5 {k3}, ymm5, dword ptr [AVX512_ADD1+rip] {1to8}
         knotw   k2, k1
         vmovdqa32 ymm2 {k2}, ymm0
         vmovdqa32 ymm3 {k2}, ymm0
@@ -127,8 +127,8 @@ blake3_hash_many_avx512:
         vinserti64x4 zmm19, zmm19, ymmword ptr [rdx+r15-0x2*0x20], 0x01
         vpunpcklqdq zmm14, zmm18, zmm19
         vpunpckhqdq zmm15, zmm18, zmm19
-        vmovdqa32 zmm27, zmmword ptr [INDEX0+rip]
-        vmovdqa32 zmm31, zmmword ptr [INDEX1+rip]
+        vmovdqa32 zmm27, zmmword ptr [AVX512_INDEX0+rip]
+        vmovdqa32 zmm31, zmmword ptr [AVX512_INDEX1+rip]
         vshufps zmm16, zmm8, zmm10, 136
         vshufps zmm17, zmm12, zmm14, 136
         vmovdqa32 zmm20, zmm16
@@ -224,13 +224,13 @@ blake3_hash_many_avx512:
         vshufps zmm10, zmm13, zmm15, 221
         vpermi2d zmm27, zmm8, zmm10
         vpermi2d zmm31, zmm8, zmm10
-        vpbroadcastd zmm8, dword ptr [BLAKE3_IV_0+rip]
-        vpbroadcastd zmm9, dword ptr [BLAKE3_IV_1+rip]
-        vpbroadcastd zmm10, dword ptr [BLAKE3_IV_2+rip]
-        vpbroadcastd zmm11, dword ptr [BLAKE3_IV_3+rip]
+        vpbroadcastd zmm8, dword ptr [AVX512_BLAKE3_IV_0+rip]
+        vpbroadcastd zmm9, dword ptr [AVX512_BLAKE3_IV_1+rip]
+        vpbroadcastd zmm10, dword ptr [AVX512_BLAKE3_IV_2+rip]
+        vpbroadcastd zmm11, dword ptr [AVX512_BLAKE3_IV_3+rip]
         vmovdqa32 zmm12, zmmword ptr [rsp]
         vmovdqa32 zmm13, zmmword ptr [rsp+0x1*0x40]
-        vpbroadcastd zmm14, dword ptr [BLAKE3_BLOCK_LEN+rip]
+        vpbroadcastd zmm14, dword ptr [AVX512_BLAKE3_BLOCK_LEN+rip]
         vpbroadcastd zmm15, dword ptr [rsp+0x22*0x4]
         vpaddd  zmm0, zmm0, zmm16
         vpaddd  zmm1, zmm1, zmm18
@@ -1070,9 +1070,9 @@ blake3_hash_many_avx512:
         vmovdqa32 zmm0, zmmword ptr [rsp]
         vmovdqa32 zmm1, zmmword ptr [rsp+0x1*0x40]
         vmovdqa32 zmm2, zmm0
-        vpaddd  zmm2{k1}, zmm0, dword ptr [ADD16+rip] {1to16}
+        vpaddd  zmm2{k1}, zmm0, dword ptr [AVX512_ADD16+rip] {1to16}
         vpcmpltud k2, zmm2, zmm0
-        vpaddd  zmm1 {k2}, zmm1, dword ptr [ADD1+rip] {1to16}
+        vpaddd  zmm1 {k2}, zmm1, dword ptr [AVX512_ADD1+rip] {1to16}
         vmovdqa32 zmmword ptr [rsp], zmm2
         vmovdqa32 zmmword ptr [rsp+0x1*0x40], zmm1
         add     rdi, 128
@@ -1200,13 +1200,13 @@ blake3_hash_many_avx512:
         vshufps ymm29, ymm12, ymm14, 221
         vshufps ymm30, ymm13, ymm15, 136
         vshufps ymm31, ymm13, ymm15, 221
-        vpbroadcastd ymm8, dword ptr [BLAKE3_IV_0+rip]
-        vpbroadcastd ymm9, dword ptr [BLAKE3_IV_1+rip]
-        vpbroadcastd ymm10, dword ptr [BLAKE3_IV_2+rip]
-        vpbroadcastd ymm11, dword ptr [BLAKE3_IV_3+rip]
+        vpbroadcastd ymm8, dword ptr [AVX512_BLAKE3_IV_0+rip]
+        vpbroadcastd ymm9, dword ptr [AVX512_BLAKE3_IV_1+rip]
+        vpbroadcastd ymm10, dword ptr [AVX512_BLAKE3_IV_2+rip]
+        vpbroadcastd ymm11, dword ptr [AVX512_BLAKE3_IV_3+rip]
         vmovdqa ymm12, ymmword ptr [rsp]
         vmovdqa ymm13, ymmword ptr [rsp+0x40]
-        vpbroadcastd ymm14, dword ptr [BLAKE3_BLOCK_LEN+rip]
+        vpbroadcastd ymm14, dword ptr [AVX512_BLAKE3_BLOCK_LEN+rip]
         vpbroadcastd ymm15, dword ptr [rsp+0x88]
         vpaddd  ymm0, ymm0, ymm16
         vpaddd  ymm1, ymm1, ymm18
@@ -2064,12 +2064,12 @@ blake3_hash_many_avx512:
         vpunpckhdq xmm15, xmm12, xmm13
         vpermq  ymm14, ymm14, 0xDC
         vpermq  ymm15, ymm15, 0xDC
-        vpbroadcastd zmm12, dword ptr [BLAKE3_BLOCK_LEN+rip]
+        vpbroadcastd zmm12, dword ptr [AVX512_BLAKE3_BLOCK_LEN+rip]
         vinserti64x4 zmm13, zmm14, ymm15, 0x01
         mov     eax, 17476
         kmovw   k2, eax
         vpblendmd zmm13 {k2}, zmm13, zmm12
-        vbroadcasti32x4 zmm15, xmmword ptr [BLAKE3_IV+rip]
+        vbroadcasti32x4 zmm15, xmmword ptr [AVX512_BLAKE3_IV+rip]
         mov     r8, qword ptr [rdi]
         mov     r9, qword ptr [rdi+0x8]
         mov     r10, qword ptr [rdi+0x10]
@@ -2196,10 +2196,10 @@ blake3_hash_many_avx512:
         vbroadcasti128 ymm1, xmmword ptr [rcx+0x10]
         vmovd   xmm13, dword ptr [rsp]
         vpinsrd xmm13, xmm13, dword ptr [rsp+0x40], 1
-        vpinsrd xmm13, xmm13, dword ptr [BLAKE3_BLOCK_LEN+rip], 2
+        vpinsrd xmm13, xmm13, dword ptr [AVX512_BLAKE3_BLOCK_LEN+rip], 2
         vmovd   xmm14, dword ptr [rsp+0x4]
         vpinsrd xmm14, xmm14, dword ptr [rsp+0x44], 1
-        vpinsrd xmm14, xmm14, dword ptr [BLAKE3_BLOCK_LEN+rip], 2
+        vpinsrd xmm14, xmm14, dword ptr [AVX512_BLAKE3_BLOCK_LEN+rip], 2
         vinserti128 ymm13, ymm13, xmm14, 0x01
         mov     r8, qword ptr [rdi]
         mov     r9, qword ptr [rdi+0x8]
@@ -2214,7 +2214,7 @@ blake3_hash_many_avx512:
         cmp     rdx, r15
         cmovne  eax, r14d
         mov     dword ptr [rsp+0x88], eax
-        vbroadcasti128 ymm2, xmmword ptr [BLAKE3_IV+rip]
+        vbroadcasti128 ymm2, xmmword ptr [AVX512_BLAKE3_IV+rip]
         vpbroadcastd ymm8, dword ptr [rsp+0x88]
         vpblendd ymm3, ymm13, ymm8, 0x88
         vmovups ymm8, ymmword ptr [r8+rdx-0x40]
@@ -2309,8 +2309,8 @@ blake3_hash_many_avx512:
         vmovdqu xmm1, xmmword ptr [rcx+0x10]
         vmovd   xmm14, dword ptr [rsp]
         vpinsrd xmm14, xmm14, dword ptr [rsp+0x40], 1
-        vpinsrd xmm14, xmm14, dword ptr [BLAKE3_BLOCK_LEN+rip], 2
-        vmovdqa xmm15, xmmword ptr [BLAKE3_IV+rip]
+        vpinsrd xmm14, xmm14, dword ptr [AVX512_BLAKE3_BLOCK_LEN+rip], 2
+        vmovdqa xmm15, xmmword ptr [AVX512_BLAKE3_IV+rip]
         mov     r8, qword ptr [rdi]
         movzx   eax, byte ptr [rbp+0x80]
         or      eax, r13d
@@ -2414,7 +2414,7 @@ blake3_compress_in_place_avx512:
         vmovq   xmm3, r9
         vmovq   xmm4, r8
         vpunpcklqdq xmm3, xmm3, xmm4
-        vmovaps xmm2, xmmword ptr [BLAKE3_IV+rip]
+        vmovaps xmm2, xmmword ptr [AVX512_BLAKE3_IV+rip]
         vmovups xmm8, xmmword ptr [rdx]
         vmovups xmm9, xmmword ptr [rdx+0x10]
         vshufps xmm4, xmm8, xmm9, 136
@@ -2508,7 +2508,7 @@ blake3_compress_xof_avx512:
         vmovq   xmm3, r9
         vmovq   xmm4, r8
         vpunpcklqdq xmm3, xmm3, xmm4
-        vmovaps xmm2, xmmword ptr [BLAKE3_IV+rip]
+        vmovaps xmm2, xmmword ptr [AVX512_BLAKE3_IV+rip]
         vmovups xmm8, xmmword ptr [rdx]
         vmovups xmm9, xmmword ptr [rdx+0x10]
         vshufps xmm4, xmm8, xmm9, 136
@@ -2589,27 +2589,27 @@ blake3_compress_xof_avx512:
 
 .section .rodata
 .p2align  6
-INDEX0:
+AVX512_INDEX0:
         .long    0,  1,  2,  3, 16, 17, 18, 19
         .long    8,  9, 10, 11, 24, 25, 26, 27
-INDEX1:
+AVX512_INDEX1:
         .long    4,  5,  6,  7, 20, 21, 22, 23
         .long   12, 13, 14, 15, 28, 29, 30, 31
-ADD0:
+AVX512_ADD0:
         .long    0,  1,  2,  3,  4,  5,  6,  7
         .long    8,  9, 10, 11, 12, 13, 14, 15
-ADD1:   .long    1
+AVX512_ADD1:   .long    1
 
-ADD16:  .long   16
-BLAKE3_BLOCK_LEN:
+AVX512_ADD16:  .long   16
+AVX512_BLAKE3_BLOCK_LEN:
         .long   64
 .p2align 6
-BLAKE3_IV:
-BLAKE3_IV_0:
+AVX512_BLAKE3_IV:
+AVX512_BLAKE3_IV_0:
         .long   0x6A09E667
-BLAKE3_IV_1:
+AVX512_BLAKE3_IV_1:
         .long   0xBB67AE85
-BLAKE3_IV_2:
+AVX512_BLAKE3_IV_2:
         .long   0x3C6EF372
-BLAKE3_IV_3:
+AVX512_BLAKE3_IV_3:
         .long   0xA54FF53A

--- a/c/blake3_sse2_x86-64_windows_gnu.S
+++ b/c/blake3_sse2_x86-64_windows_gnu.S
@@ -41,15 +41,15 @@ blake3_hash_many_sse2:
         pshufd  xmm0, xmm0, 0x00
         movdqa  xmmword ptr [rsp+0x130], xmm0
         movdqa  xmm1, xmm0
-        pand    xmm1, xmmword ptr [ADD0+rip]
-        pand    xmm0, xmmword ptr [ADD1+rip]
+        pand    xmm1, xmmword ptr [SSE2_ADD0+rip]
+        pand    xmm0, xmmword ptr [SSE2_ADD1+rip]
         movdqa  xmmword ptr [rsp+0x150], xmm0
         movd    xmm0, r8d
         pshufd  xmm0, xmm0, 0x00
         paddd   xmm0, xmm1
         movdqa  xmmword ptr [rsp+0x110], xmm0
-        pxor    xmm0, xmmword ptr [CMP_MSB_MASK+rip]
-        pxor    xmm1, xmmword ptr [CMP_MSB_MASK+rip]
+        pxor    xmm0, xmmword ptr [SSE2_CMP_MSB_MASK+rip]
+        pxor    xmm1, xmmword ptr [SSE2_CMP_MSB_MASK+rip]
         pcmpgtd xmm1, xmm0
         shr     r8, 32
         movd    xmm2, r8d
@@ -167,12 +167,12 @@ blake3_hash_many_sse2:
         movdqa  xmmword ptr [rsp+0xD0], xmm9
         movdqa  xmmword ptr [rsp+0xE0], xmm12
         movdqa  xmmword ptr [rsp+0xF0], xmm13
-        movdqa  xmm9, xmmword ptr [BLAKE3_IV_1+rip]
-        movdqa  xmm10, xmmword ptr [BLAKE3_IV_2+rip]
-        movdqa  xmm11, xmmword ptr [BLAKE3_IV_3+rip]
+        movdqa  xmm9, xmmword ptr [SSE2_BLAKE3_IV_1+rip]
+        movdqa  xmm10, xmmword ptr [SSE2_BLAKE3_IV_2+rip]
+        movdqa  xmm11, xmmword ptr [SSE2_BLAKE3_IV_3+rip]
         movdqa  xmm12, xmmword ptr [rsp+0x110]
         movdqa  xmm13, xmmword ptr [rsp+0x120]
-        movdqa  xmm14, xmmword ptr [BLAKE3_BLOCK_LEN+rip]
+        movdqa  xmm14, xmmword ptr [SSE2_BLAKE3_BLOCK_LEN+rip]
         movd    xmm15, eax
         pshufd  xmm15, xmm15, 0x00
         prefetcht0 [r8+rdx+0x80]
@@ -199,7 +199,7 @@ blake3_hash_many_sse2:
         pshufhw xmm14, xmm14, 0xB1
         pshuflw xmm15, xmm15, 0xB1
         pshufhw xmm15, xmm15, 0xB1
-        movdqa  xmm8, xmmword ptr [BLAKE3_IV_0+rip]
+        movdqa  xmm8, xmmword ptr [SSE2_BLAKE3_IV_0+rip]
         paddd   xmm8, xmm12
         paddd   xmm9, xmm13
         paddd   xmm10, xmm14
@@ -1624,8 +1624,8 @@ blake3_hash_many_sse2:
         movdqa  xmm0, xmm1
         paddd   xmm1, xmmword ptr [rsp+0x150]
         movdqa  xmmword ptr [rsp+0x110], xmm1
-        pxor    xmm0, xmmword ptr [CMP_MSB_MASK+rip]
-        pxor    xmm1, xmmword ptr [CMP_MSB_MASK+rip]
+        pxor    xmm0, xmmword ptr [SSE2_CMP_MSB_MASK+rip]
+        pxor    xmm1, xmmword ptr [SSE2_CMP_MSB_MASK+rip]
         pcmpgtd xmm0, xmm1
         movdqa  xmm1, xmmword ptr [rsp+0x120]
         psubd   xmm1, xmm0
@@ -1685,7 +1685,7 @@ blake3_hash_many_sse2:
         add     rdx, 64
         cmp     rdx, r15
         cmovne  eax, r14d
-        movaps  xmm2, xmmword ptr [BLAKE3_IV+rip]
+        movaps  xmm2, xmmword ptr [SSE2_BLAKE3_IV+rip]
         movaps  xmm10, xmm2
         movups  xmm4, xmmword ptr [r8+rdx-0x40]
         movups  xmm5, xmmword ptr [r8+rdx-0x30]
@@ -1844,15 +1844,15 @@ blake3_hash_many_sse2:
         pshufd  xmm4, xmm12, 0x39
         movdqa  xmm12, xmm6
         shufps  xmm12, xmm7, 250
-        pand    xmm13, xmmword ptr [PBLENDW_0x33_MASK+rip]
-        pand    xmm12, xmmword ptr [PBLENDW_0xCC_MASK+rip]
+        pand    xmm13, xmmword ptr [SSE2_PBLENDW_0x33_MASK+rip]
+        pand    xmm12, xmmword ptr [SSE2_PBLENDW_0xCC_MASK+rip]
         por     xmm13, xmm12
         movdqa  xmmword ptr [rsp+0x20], xmm13
         movdqa  xmm12, xmm7
         punpcklqdq xmm12, xmm5
         movdqa  xmm13, xmm6
-        pand    xmm12, xmmword ptr [PBLENDW_0x3F_MASK+rip]
-        pand    xmm13, xmmword ptr [PBLENDW_0xC0_MASK+rip]
+        pand    xmm12, xmmword ptr [SSE2_PBLENDW_0x3F_MASK+rip]
+        pand    xmm13, xmmword ptr [SSE2_PBLENDW_0xC0_MASK+rip]
         por     xmm12, xmm13
         pshufd  xmm12, xmm12, 0x78
         punpckhdq xmm5, xmm7
@@ -1866,15 +1866,15 @@ blake3_hash_many_sse2:
         pshufd  xmm12, xmm5, 0x39
         movdqa  xmm5, xmm14
         shufps  xmm5, xmm15, 250
-        pand    xmm6, xmmword ptr [PBLENDW_0x33_MASK+rip]
-        pand    xmm5, xmmword ptr [PBLENDW_0xCC_MASK+rip]
+        pand    xmm6, xmmword ptr [SSE2_PBLENDW_0x33_MASK+rip]
+        pand    xmm5, xmmword ptr [SSE2_PBLENDW_0xCC_MASK+rip]
         por     xmm6, xmm5
         movdqa  xmm5, xmm15
         punpcklqdq xmm5, xmm13
         movdqa  xmmword ptr [rsp+0x30], xmm2
         movdqa  xmm2, xmm14
-        pand    xmm5, xmmword ptr [PBLENDW_0x3F_MASK+rip]
-        pand    xmm2, xmmword ptr [PBLENDW_0xC0_MASK+rip]
+        pand    xmm5, xmmword ptr [SSE2_PBLENDW_0x3F_MASK+rip]
+        pand    xmm2, xmmword ptr [SSE2_PBLENDW_0xC0_MASK+rip]
         por     xmm5, xmm2
         movdqa  xmm2, xmmword ptr [rsp+0x30]
         pshufd  xmm5, xmm5, 0x78
@@ -1925,7 +1925,7 @@ blake3_hash_many_sse2:
         add     rdx, 64
         cmp     rdx, r15
         cmovne  eax, r14d
-        movaps  xmm2, xmmword ptr [BLAKE3_IV+rip]
+        movaps  xmm2, xmmword ptr [SSE2_BLAKE3_IV+rip]
         shl     rax, 32
         or      rax, 64
         movq    xmm12, rax
@@ -2008,14 +2008,14 @@ blake3_hash_many_sse2:
         pshufd  xmm4, xmm8, 0x39
         movdqa  xmm8, xmm6
         shufps  xmm8, xmm7, 250
-        pand    xmm9, xmmword ptr [PBLENDW_0x33_MASK+rip]
-        pand    xmm8, xmmword ptr [PBLENDW_0xCC_MASK+rip]
+        pand    xmm9, xmmword ptr [SSE2_PBLENDW_0x33_MASK+rip]
+        pand    xmm8, xmmword ptr [SSE2_PBLENDW_0xCC_MASK+rip]
         por     xmm9, xmm8
         movdqa  xmm8, xmm7
         punpcklqdq xmm8, xmm5
         movdqa  xmm10, xmm6
-        pand    xmm8, xmmword ptr [PBLENDW_0x3F_MASK+rip]
-        pand    xmm10, xmmword ptr [PBLENDW_0xC0_MASK+rip]
+        pand    xmm8, xmmword ptr [SSE2_PBLENDW_0x3F_MASK+rip]
+        pand    xmm10, xmmword ptr [SSE2_PBLENDW_0xC0_MASK+rip]
         por     xmm8, xmm10
         pshufd  xmm8, xmm8, 0x78
         punpckhdq xmm5, xmm7
@@ -2047,7 +2047,7 @@ _blake3_compress_in_place_sse2:
         movdqa  xmmword ptr [rsp+0x60], xmm15
         movups  xmm0, xmmword ptr [rcx]
         movups  xmm1, xmmword ptr [rcx+0x10]
-        movaps  xmm2, xmmword ptr [BLAKE3_IV+rip]
+        movaps  xmm2, xmmword ptr [SSE2_BLAKE3_IV+rip]
         movzx   eax, byte ptr [rsp+0xA0]
         movzx   r8d, r8b
         shl     rax, 32
@@ -2132,14 +2132,14 @@ _blake3_compress_in_place_sse2:
         pshufd  xmm4, xmm8, 0x39
         movdqa  xmm8, xmm6
         shufps  xmm8, xmm7, 250
-        pand    xmm9, xmmword ptr [PBLENDW_0x33_MASK+rip]
-        pand    xmm8, xmmword ptr [PBLENDW_0xCC_MASK+rip]
+        pand    xmm9, xmmword ptr [SSE2_PBLENDW_0x33_MASK+rip]
+        pand    xmm8, xmmword ptr [SSE2_PBLENDW_0xCC_MASK+rip]
         por     xmm9, xmm8
         movdqa  xmm8, xmm7
         punpcklqdq xmm8, xmm5
         movdqa  xmm14, xmm6
-        pand    xmm8, xmmword ptr [PBLENDW_0x3F_MASK+rip]
-        pand    xmm14, xmmword ptr [PBLENDW_0xC0_MASK+rip]
+        pand    xmm8, xmmword ptr [SSE2_PBLENDW_0x3F_MASK+rip]
+        pand    xmm14, xmmword ptr [SSE2_PBLENDW_0xC0_MASK+rip]
         por     xmm8, xmm14
         pshufd  xmm8, xmm8, 0x78
         punpckhdq xmm5, xmm7
@@ -2177,7 +2177,7 @@ blake3_compress_xof_sse2:
         movdqa  xmmword ptr [rsp+0x60], xmm15
         movups  xmm0, xmmword ptr [rcx]
         movups  xmm1, xmmword ptr [rcx+0x10]
-        movaps  xmm2, xmmword ptr [BLAKE3_IV+rip]
+        movaps  xmm2, xmmword ptr [SSE2_BLAKE3_IV+rip]
         movzx   eax, byte ptr [rsp+0xA0]
         movzx   r8d, r8b
         mov     r10, qword ptr [rsp+0xA8]
@@ -2263,14 +2263,14 @@ blake3_compress_xof_sse2:
         pshufd  xmm4, xmm8, 0x39
         movdqa  xmm8, xmm6
         shufps  xmm8, xmm7, 250
-        pand    xmm9, xmmword ptr [PBLENDW_0x33_MASK+rip]
-        pand    xmm8, xmmword ptr [PBLENDW_0xCC_MASK+rip]
+        pand    xmm9, xmmword ptr [SSE2_PBLENDW_0x33_MASK+rip]
+        pand    xmm8, xmmword ptr [SSE2_PBLENDW_0xCC_MASK+rip]
         por     xmm9, xmm8
         movdqa  xmm8, xmm7
         punpcklqdq xmm8, xmm5
         movdqa  xmm14, xmm6
-        pand    xmm8, xmmword ptr [PBLENDW_0x3F_MASK+rip]
-        pand    xmm14, xmmword ptr [PBLENDW_0xC0_MASK+rip]
+        pand    xmm8, xmmword ptr [SSE2_PBLENDW_0x3F_MASK+rip]
+        pand    xmm14, xmmword ptr [SSE2_PBLENDW_0xC0_MASK+rip]
         por     xmm8, xmm14
         pshufd  xmm8, xmm8, 0x78
         punpckhdq xmm5, xmm7
@@ -2303,30 +2303,30 @@ blake3_compress_xof_sse2:
 
 .section .rodata
 .p2align  6
-BLAKE3_IV:
+SSE2_BLAKE3_IV:
         .long  0x6A09E667, 0xBB67AE85
         .long  0x3C6EF372, 0xA54FF53A
-ADD0:   
+SSE2_ADD0:   
         .long  0, 1, 2, 3
-ADD1:
+SSE2_ADD1:
         .long  4, 4, 4, 4
-BLAKE3_IV_0:
+SSE2_BLAKE3_IV_0:
         .long  0x6A09E667, 0x6A09E667, 0x6A09E667, 0x6A09E667
-BLAKE3_IV_1:
+SSE2_BLAKE3_IV_1:
         .long  0xBB67AE85, 0xBB67AE85, 0xBB67AE85, 0xBB67AE85
-BLAKE3_IV_2:
+SSE2_BLAKE3_IV_2:
         .long  0x3C6EF372, 0x3C6EF372, 0x3C6EF372, 0x3C6EF372
-BLAKE3_IV_3:
+SSE2_BLAKE3_IV_3:
         .long  0xA54FF53A, 0xA54FF53A, 0xA54FF53A, 0xA54FF53A
-BLAKE3_BLOCK_LEN:
+SSE2_BLAKE3_BLOCK_LEN:
         .long  64, 64, 64, 64
-CMP_MSB_MASK:
+SSE2_CMP_MSB_MASK:
         .long  0x80000000, 0x80000000, 0x80000000, 0x80000000
-PBLENDW_0x33_MASK:
+SSE2_PBLENDW_0x33_MASK:
         .long  0xFFFFFFFF, 0x00000000, 0xFFFFFFFF, 0x00000000
-PBLENDW_0xCC_MASK:
+SSE2_PBLENDW_0xCC_MASK:
         .long  0x00000000, 0xFFFFFFFF, 0x00000000, 0xFFFFFFFF
-PBLENDW_0x3F_MASK:
+SSE2_PBLENDW_0x3F_MASK:
         .long  0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0x00000000
-PBLENDW_0xC0_MASK:
+SSE2_PBLENDW_0xC0_MASK:
         .long  0x00000000, 0x00000000, 0x00000000, 0xFFFFFFFF

--- a/c/blake3_sse41_x86-64_windows_gnu.S
+++ b/c/blake3_sse41_x86-64_windows_gnu.S
@@ -41,15 +41,15 @@ blake3_hash_many_sse41:
         pshufd  xmm0, xmm0, 0x00
         movdqa  xmmword ptr [rsp+0x130], xmm0
         movdqa  xmm1, xmm0
-        pand    xmm1, xmmword ptr [ADD0+rip]
-        pand    xmm0, xmmword ptr [ADD1+rip]
+        pand    xmm1, xmmword ptr [SSE41_ADD0+rip]
+        pand    xmm0, xmmword ptr [SSE41_ADD1+rip]
         movdqa  xmmword ptr [rsp+0x150], xmm0
         movd    xmm0, r8d
         pshufd  xmm0, xmm0, 0x00
         paddd   xmm0, xmm1
         movdqa  xmmword ptr [rsp+0x110], xmm0
-        pxor    xmm0, xmmword ptr [CMP_MSB_MASK+rip]
-        pxor    xmm1, xmmword ptr [CMP_MSB_MASK+rip]
+        pxor    xmm0, xmmword ptr [SSE41_CMP_MSB_MASK+rip]
+        pxor    xmm1, xmmword ptr [SSE41_CMP_MSB_MASK+rip]
         pcmpgtd xmm1, xmm0
         shr     r8, 32
         movd    xmm2, r8d
@@ -167,12 +167,12 @@ blake3_hash_many_sse41:
         movdqa  xmmword ptr [rsp+0xD0], xmm9
         movdqa  xmmword ptr [rsp+0xE0], xmm12
         movdqa  xmmword ptr [rsp+0xF0], xmm13
-        movdqa  xmm9, xmmword ptr [BLAKE3_IV_1+rip]
-        movdqa  xmm10, xmmword ptr [BLAKE3_IV_2+rip]
-        movdqa  xmm11, xmmword ptr [BLAKE3_IV_3+rip]
+        movdqa  xmm9, xmmword ptr [SSE41_BLAKE3_IV_1+rip]
+        movdqa  xmm10, xmmword ptr [SSE41_BLAKE3_IV_2+rip]
+        movdqa  xmm11, xmmword ptr [SSE41_BLAKE3_IV_3+rip]
         movdqa  xmm12, xmmword ptr [rsp+0x110]
         movdqa  xmm13, xmmword ptr [rsp+0x120]
-        movdqa  xmm14, xmmword ptr [BLAKE3_BLOCK_LEN+rip]
+        movdqa  xmm14, xmmword ptr [SSE41_BLAKE3_BLOCK_LEN+rip]
         movd    xmm15, eax
         pshufd  xmm15, xmm15, 0x00
         prefetcht0 [r8+rdx+0x80]
@@ -191,12 +191,12 @@ blake3_hash_many_sse41:
         pxor    xmm13, xmm1
         pxor    xmm14, xmm2
         pxor    xmm15, xmm3
-        movdqa  xmm8, xmmword ptr [ROT16+rip]
+        movdqa  xmm8, xmmword ptr [SSE41_ROT16+rip]
         pshufb  xmm12, xmm8
         pshufb  xmm13, xmm8
         pshufb  xmm14, xmm8
         pshufb  xmm15, xmm8
-        movdqa  xmm8, xmmword ptr [BLAKE3_IV_0+rip]
+        movdqa  xmm8, xmmword ptr [SSE41_BLAKE3_IV_0+rip]
         paddd   xmm8, xmm12
         paddd   xmm9, xmm13
         paddd   xmm10, xmm14
@@ -234,7 +234,7 @@ blake3_hash_many_sse41:
         pxor    xmm13, xmm1
         pxor    xmm14, xmm2
         pxor    xmm15, xmm3
-        movdqa  xmm8, xmmword ptr [ROT8+rip]
+        movdqa  xmm8, xmmword ptr [SSE41_ROT8+rip]
         pshufb  xmm12, xmm8
         pshufb  xmm13, xmm8
         pshufb  xmm14, xmm8
@@ -277,7 +277,7 @@ blake3_hash_many_sse41:
         pxor    xmm12, xmm1
         pxor    xmm13, xmm2
         pxor    xmm14, xmm3
-        movdqa  xmm8, xmmword ptr [ROT16+rip]
+        movdqa  xmm8, xmmword ptr [SSE41_ROT16+rip]
         pshufb  xmm15, xmm8
         pshufb  xmm12, xmm8
         pshufb  xmm13, xmm8
@@ -320,7 +320,7 @@ blake3_hash_many_sse41:
         pxor    xmm12, xmm1
         pxor    xmm13, xmm2
         pxor    xmm14, xmm3
-        movdqa  xmm8, xmmword ptr [ROT8+rip]
+        movdqa  xmm8, xmmword ptr [SSE41_ROT8+rip]
         pshufb  xmm15, xmm8
         pshufb  xmm12, xmm8
         pshufb  xmm13, xmm8
@@ -363,7 +363,7 @@ blake3_hash_many_sse41:
         pxor    xmm13, xmm1
         pxor    xmm14, xmm2
         pxor    xmm15, xmm3
-        movdqa  xmm8, xmmword ptr [ROT16+rip]
+        movdqa  xmm8, xmmword ptr [SSE41_ROT16+rip]
         pshufb  xmm12, xmm8
         pshufb  xmm13, xmm8
         pshufb  xmm14, xmm8
@@ -406,7 +406,7 @@ blake3_hash_many_sse41:
         pxor    xmm13, xmm1
         pxor    xmm14, xmm2
         pxor    xmm15, xmm3
-        movdqa  xmm8, xmmword ptr [ROT8+rip]
+        movdqa  xmm8, xmmword ptr [SSE41_ROT8+rip]
         pshufb  xmm12, xmm8
         pshufb  xmm13, xmm8
         pshufb  xmm14, xmm8
@@ -449,7 +449,7 @@ blake3_hash_many_sse41:
         pxor    xmm12, xmm1
         pxor    xmm13, xmm2
         pxor    xmm14, xmm3
-        movdqa  xmm8, xmmword ptr [ROT16+rip]
+        movdqa  xmm8, xmmword ptr [SSE41_ROT16+rip]
         pshufb  xmm15, xmm8
         pshufb  xmm12, xmm8
         pshufb  xmm13, xmm8
@@ -492,7 +492,7 @@ blake3_hash_many_sse41:
         pxor    xmm12, xmm1
         pxor    xmm13, xmm2
         pxor    xmm14, xmm3
-        movdqa  xmm8, xmmword ptr [ROT8+rip]
+        movdqa  xmm8, xmmword ptr [SSE41_ROT8+rip]
         pshufb  xmm15, xmm8
         pshufb  xmm12, xmm8
         pshufb  xmm13, xmm8
@@ -535,7 +535,7 @@ blake3_hash_many_sse41:
         pxor    xmm13, xmm1
         pxor    xmm14, xmm2
         pxor    xmm15, xmm3
-        movdqa  xmm8, xmmword ptr [ROT16+rip]
+        movdqa  xmm8, xmmword ptr [SSE41_ROT16+rip]
         pshufb  xmm12, xmm8
         pshufb  xmm13, xmm8
         pshufb  xmm14, xmm8
@@ -578,7 +578,7 @@ blake3_hash_many_sse41:
         pxor    xmm13, xmm1
         pxor    xmm14, xmm2
         pxor    xmm15, xmm3
-        movdqa  xmm8, xmmword ptr [ROT8+rip]
+        movdqa  xmm8, xmmword ptr [SSE41_ROT8+rip]
         pshufb  xmm12, xmm8
         pshufb  xmm13, xmm8
         pshufb  xmm14, xmm8
@@ -621,7 +621,7 @@ blake3_hash_many_sse41:
         pxor    xmm12, xmm1
         pxor    xmm13, xmm2
         pxor    xmm14, xmm3
-        movdqa  xmm8, xmmword ptr [ROT16+rip]
+        movdqa  xmm8, xmmword ptr [SSE41_ROT16+rip]
         pshufb  xmm15, xmm8
         pshufb  xmm12, xmm8
         pshufb  xmm13, xmm8
@@ -664,7 +664,7 @@ blake3_hash_many_sse41:
         pxor    xmm12, xmm1
         pxor    xmm13, xmm2
         pxor    xmm14, xmm3
-        movdqa  xmm8, xmmword ptr [ROT8+rip]
+        movdqa  xmm8, xmmword ptr [SSE41_ROT8+rip]
         pshufb  xmm15, xmm8
         pshufb  xmm12, xmm8
         pshufb  xmm13, xmm8
@@ -707,7 +707,7 @@ blake3_hash_many_sse41:
         pxor    xmm13, xmm1
         pxor    xmm14, xmm2
         pxor    xmm15, xmm3
-        movdqa  xmm8, xmmword ptr [ROT16+rip]
+        movdqa  xmm8, xmmword ptr [SSE41_ROT16+rip]
         pshufb  xmm12, xmm8
         pshufb  xmm13, xmm8
         pshufb  xmm14, xmm8
@@ -750,7 +750,7 @@ blake3_hash_many_sse41:
         pxor    xmm13, xmm1
         pxor    xmm14, xmm2
         pxor    xmm15, xmm3
-        movdqa  xmm8, xmmword ptr [ROT8+rip]
+        movdqa  xmm8, xmmword ptr [SSE41_ROT8+rip]
         pshufb  xmm12, xmm8
         pshufb  xmm13, xmm8
         pshufb  xmm14, xmm8
@@ -793,7 +793,7 @@ blake3_hash_many_sse41:
         pxor    xmm12, xmm1
         pxor    xmm13, xmm2
         pxor    xmm14, xmm3
-        movdqa  xmm8, xmmword ptr [ROT16+rip]
+        movdqa  xmm8, xmmword ptr [SSE41_ROT16+rip]
         pshufb  xmm15, xmm8
         pshufb  xmm12, xmm8
         pshufb  xmm13, xmm8
@@ -836,7 +836,7 @@ blake3_hash_many_sse41:
         pxor    xmm12, xmm1
         pxor    xmm13, xmm2
         pxor    xmm14, xmm3
-        movdqa  xmm8, xmmword ptr [ROT8+rip]
+        movdqa  xmm8, xmmword ptr [SSE41_ROT8+rip]
         pshufb  xmm15, xmm8
         pshufb  xmm12, xmm8
         pshufb  xmm13, xmm8
@@ -879,7 +879,7 @@ blake3_hash_many_sse41:
         pxor    xmm13, xmm1
         pxor    xmm14, xmm2
         pxor    xmm15, xmm3
-        movdqa  xmm8, xmmword ptr [ROT16+rip]
+        movdqa  xmm8, xmmword ptr [SSE41_ROT16+rip]
         pshufb  xmm12, xmm8
         pshufb  xmm13, xmm8
         pshufb  xmm14, xmm8
@@ -922,7 +922,7 @@ blake3_hash_many_sse41:
         pxor    xmm13, xmm1
         pxor    xmm14, xmm2
         pxor    xmm15, xmm3
-        movdqa  xmm8, xmmword ptr [ROT8+rip]
+        movdqa  xmm8, xmmword ptr [SSE41_ROT8+rip]
         pshufb  xmm12, xmm8
         pshufb  xmm13, xmm8
         pshufb  xmm14, xmm8
@@ -965,7 +965,7 @@ blake3_hash_many_sse41:
         pxor    xmm12, xmm1
         pxor    xmm13, xmm2
         pxor    xmm14, xmm3
-        movdqa  xmm8, xmmword ptr [ROT16+rip]
+        movdqa  xmm8, xmmword ptr [SSE41_ROT16+rip]
         pshufb  xmm15, xmm8
         pshufb  xmm12, xmm8
         pshufb  xmm13, xmm8
@@ -1008,7 +1008,7 @@ blake3_hash_many_sse41:
         pxor    xmm12, xmm1
         pxor    xmm13, xmm2
         pxor    xmm14, xmm3
-        movdqa  xmm8, xmmword ptr [ROT8+rip]
+        movdqa  xmm8, xmmword ptr [SSE41_ROT8+rip]
         pshufb  xmm15, xmm8
         pshufb  xmm12, xmm8
         pshufb  xmm13, xmm8
@@ -1051,7 +1051,7 @@ blake3_hash_many_sse41:
         pxor    xmm13, xmm1
         pxor    xmm14, xmm2
         pxor    xmm15, xmm3
-        movdqa  xmm8, xmmword ptr [ROT16+rip]
+        movdqa  xmm8, xmmword ptr [SSE41_ROT16+rip]
         pshufb  xmm12, xmm8
         pshufb  xmm13, xmm8
         pshufb  xmm14, xmm8
@@ -1094,7 +1094,7 @@ blake3_hash_many_sse41:
         pxor    xmm13, xmm1
         pxor    xmm14, xmm2
         pxor    xmm15, xmm3
-        movdqa  xmm8, xmmword ptr [ROT8+rip]
+        movdqa  xmm8, xmmword ptr [SSE41_ROT8+rip]
         pshufb  xmm12, xmm8
         pshufb  xmm13, xmm8
         pshufb  xmm14, xmm8
@@ -1137,7 +1137,7 @@ blake3_hash_many_sse41:
         pxor    xmm12, xmm1
         pxor    xmm13, xmm2
         pxor    xmm14, xmm3
-        movdqa  xmm8, xmmword ptr [ROT16+rip]
+        movdqa  xmm8, xmmword ptr [SSE41_ROT16+rip]
         pshufb  xmm15, xmm8
         pshufb  xmm12, xmm8
         pshufb  xmm13, xmm8
@@ -1180,7 +1180,7 @@ blake3_hash_many_sse41:
         pxor    xmm12, xmm1
         pxor    xmm13, xmm2
         pxor    xmm14, xmm3
-        movdqa  xmm8, xmmword ptr [ROT8+rip]
+        movdqa  xmm8, xmmword ptr [SSE41_ROT8+rip]
         pshufb  xmm15, xmm8
         pshufb  xmm12, xmm8
         pshufb  xmm13, xmm8
@@ -1223,7 +1223,7 @@ blake3_hash_many_sse41:
         pxor    xmm13, xmm1
         pxor    xmm14, xmm2
         pxor    xmm15, xmm3
-        movdqa  xmm8, xmmword ptr [ROT16+rip]
+        movdqa  xmm8, xmmword ptr [SSE41_ROT16+rip]
         pshufb  xmm12, xmm8
         pshufb  xmm13, xmm8
         pshufb  xmm14, xmm8
@@ -1266,7 +1266,7 @@ blake3_hash_many_sse41:
         pxor    xmm13, xmm1
         pxor    xmm14, xmm2
         pxor    xmm15, xmm3
-        movdqa  xmm8, xmmword ptr [ROT8+rip]
+        movdqa  xmm8, xmmword ptr [SSE41_ROT8+rip]
         pshufb  xmm12, xmm8
         pshufb  xmm13, xmm8
         pshufb  xmm14, xmm8
@@ -1309,7 +1309,7 @@ blake3_hash_many_sse41:
         pxor    xmm12, xmm1
         pxor    xmm13, xmm2
         pxor    xmm14, xmm3
-        movdqa  xmm8, xmmword ptr [ROT16+rip]
+        movdqa  xmm8, xmmword ptr [SSE41_ROT16+rip]
         pshufb  xmm15, xmm8
         pshufb  xmm12, xmm8
         pshufb  xmm13, xmm8
@@ -1352,7 +1352,7 @@ blake3_hash_many_sse41:
         pxor    xmm12, xmm1
         pxor    xmm13, xmm2
         pxor    xmm14, xmm3
-        movdqa  xmm8, xmmword ptr [ROT8+rip]
+        movdqa  xmm8, xmmword ptr [SSE41_ROT8+rip]
         pshufb  xmm15, xmm8
         pshufb  xmm12, xmm8
         pshufb  xmm13, xmm8
@@ -1428,8 +1428,8 @@ blake3_hash_many_sse41:
         movdqa  xmm0, xmm1
         paddd   xmm1, xmmword ptr [rsp+0x150]
         movdqa  xmmword ptr [rsp+0x110], xmm1
-        pxor    xmm0, xmmword ptr [CMP_MSB_MASK+rip]
-        pxor    xmm1, xmmword ptr [CMP_MSB_MASK+rip]
+        pxor    xmm0, xmmword ptr [SSE41_CMP_MSB_MASK+rip]
+        pxor    xmm1, xmmword ptr [SSE41_CMP_MSB_MASK+rip]
         pcmpgtd xmm0, xmm1
         movdqa  xmm1, xmmword ptr [rsp+0x120]
         psubd   xmm1, xmm0
@@ -1472,11 +1472,11 @@ blake3_hash_many_sse41:
         movaps  xmm9, xmm1
         movd    xmm13, dword ptr [rsp+0x110]
         pinsrd  xmm13, dword ptr [rsp+0x120], 1
-        pinsrd  xmm13, dword ptr [BLAKE3_BLOCK_LEN+rip], 2
+        pinsrd  xmm13, dword ptr [SSE41_BLAKE3_BLOCK_LEN+rip], 2
         movaps  xmmword ptr [rsp], xmm13
         movd    xmm14, dword ptr [rsp+0x114]
         pinsrd  xmm14, dword ptr [rsp+0x124], 1
-        pinsrd  xmm14, dword ptr [BLAKE3_BLOCK_LEN+rip], 2
+        pinsrd  xmm14, dword ptr [SSE41_BLAKE3_BLOCK_LEN+rip], 2
         movaps  xmmword ptr [rsp+0x10], xmm14
         mov     r8, qword ptr [rdi]
         mov     r9, qword ptr [rdi+0x8]
@@ -1489,7 +1489,7 @@ blake3_hash_many_sse41:
         add     rdx, 64
         cmp     rdx, r15
         cmovne  eax, r14d
-        movaps  xmm2, xmmword ptr [BLAKE3_IV+rip]
+        movaps  xmm2, xmmword ptr [SSE41_BLAKE3_IV+rip]
         movaps  xmm10, xmm2
         movups  xmm4, xmmword ptr [r8+rdx-0x40]
         movups  xmm5, xmmword ptr [r8+rdx-0x30]
@@ -1531,7 +1531,7 @@ blake3_hash_many_sse41:
         paddd   xmm8, xmm9
         pxor    xmm3, xmm0
         pxor    xmm11, xmm8
-        movaps  xmm12, xmmword ptr [ROT16+rip]
+        movaps  xmm12, xmmword ptr [SSE41_ROT16+rip]
         pshufb  xmm3, xmm12
         pshufb  xmm11, xmm12
         paddd   xmm2, xmm3
@@ -1554,7 +1554,7 @@ blake3_hash_many_sse41:
         paddd   xmm8, xmm9
         pxor    xmm3, xmm0
         pxor    xmm11, xmm8
-        movaps  xmm13, xmmword ptr [ROT8+rip]
+        movaps  xmm13, xmmword ptr [SSE41_ROT8+rip]
         pshufb  xmm3, xmm13
         pshufb  xmm11, xmm13
         paddd   xmm2, xmm3
@@ -1691,9 +1691,9 @@ blake3_hash_many_sse41:
         movups  xmm1, xmmword ptr [rcx+0x10]
         movd    xmm13, dword ptr [rsp+0x110]
         pinsrd  xmm13, dword ptr [rsp+0x120], 1
-        pinsrd  xmm13, dword ptr [BLAKE3_BLOCK_LEN+rip], 2
-        movaps  xmm14, xmmword ptr [ROT8+rip]
-        movaps  xmm15, xmmword ptr [ROT16+rip]
+        pinsrd  xmm13, dword ptr [SSE41_BLAKE3_BLOCK_LEN+rip], 2
+        movaps  xmm14, xmmword ptr [SSE41_ROT8+rip]
+        movaps  xmm15, xmmword ptr [SSE41_ROT16+rip]
         mov     r8, qword ptr [rdi]
         movzx   eax, byte ptr [rbp+0x80]
         or      eax, r13d
@@ -1704,7 +1704,7 @@ blake3_hash_many_sse41:
         add     rdx, 64
         cmp     rdx, r15
         cmovne  eax, r14d
-        movaps  xmm2, xmmword ptr [BLAKE3_IV+rip]
+        movaps  xmm2, xmmword ptr [SSE41_BLAKE3_IV+rip]
         movaps  xmm3, xmm13
         pinsrd  xmm3, eax, 3
         movups  xmm4, xmmword ptr [r8+rdx-0x40]
@@ -1810,7 +1810,7 @@ _blake3_compress_in_place_sse41:
         movdqa  xmmword ptr [rsp+0x60], xmm15
         movups  xmm0, xmmword ptr [rcx]
         movups  xmm1, xmmword ptr [rcx+0x10]
-        movaps  xmm2, xmmword ptr [BLAKE3_IV+rip]
+        movaps  xmm2, xmmword ptr [SSE41_BLAKE3_IV+rip]
         movzx   eax, byte ptr [rsp+0xA0]
         movzx   r8d, r8b
         shl     rax, 32
@@ -1831,8 +1831,8 @@ _blake3_compress_in_place_sse41:
         pshufd  xmm6, xmm6, 0x93
         shufps  xmm8, xmm7, 221
         pshufd  xmm7, xmm8, 0x93
-        movaps  xmm14, xmmword ptr [ROT8+rip]
-        movaps  xmm15, xmmword ptr [ROT16+rip]
+        movaps  xmm14, xmmword ptr [SSE41_ROT8+rip]
+        movaps  xmm15, xmmword ptr [SSE41_ROT16+rip]
         mov     al, 7
 9:
         paddd   xmm0, xmm4
@@ -1929,7 +1929,7 @@ blake3_compress_xof_sse41:
         movdqa  xmmword ptr [rsp+0x60], xmm15
         movups  xmm0, xmmword ptr [rcx]
         movups  xmm1, xmmword ptr [rcx+0x10]
-        movaps  xmm2, xmmword ptr [BLAKE3_IV+rip]
+        movaps  xmm2, xmmword ptr [SSE41_BLAKE3_IV+rip]
         movzx   eax, byte ptr [rsp+0xA0]
         movzx   r8d, r8b
         mov     r10, qword ptr [rsp+0xA8]
@@ -1951,8 +1951,8 @@ blake3_compress_xof_sse41:
         pshufd  xmm6, xmm6, 0x93
         shufps  xmm8, xmm7, 221
         pshufd  xmm7, xmm8, 0x93
-        movaps  xmm14, xmmword ptr [ROT8+rip]
-        movaps  xmm15, xmmword ptr [ROT16+rip]
+        movaps  xmm14, xmmword ptr [SSE41_ROT8+rip]
+        movaps  xmm15, xmmword ptr [SSE41_ROT16+rip]
         mov     al, 7
 9:
         paddd   xmm0, xmm4
@@ -2044,26 +2044,26 @@ blake3_compress_xof_sse41:
 
 .section .rodata
 .p2align  6
-BLAKE3_IV:
+SSE41_BLAKE3_IV:
         .long  0x6A09E667, 0xBB67AE85
         .long  0x3C6EF372, 0xA54FF53A
-ROT16:
+SSE41_ROT16:
         .byte  2, 3, 0, 1, 6, 7, 4, 5, 10, 11, 8, 9, 14, 15, 12, 13
-ROT8:
+SSE41_ROT8:
         .byte  1, 2, 3, 0, 5, 6, 7, 4, 9, 10, 11, 8, 13, 14, 15, 12
-ADD0:   
+SSE41_ADD0:   
         .long  0, 1, 2, 3
-ADD1:
+SSE41_ADD1:
         .long  4, 4, 4, 4
-BLAKE3_IV_0:
+SSE41_BLAKE3_IV_0:
         .long  0x6A09E667, 0x6A09E667, 0x6A09E667, 0x6A09E667
-BLAKE3_IV_1:
+SSE41_BLAKE3_IV_1:
         .long  0xBB67AE85, 0xBB67AE85, 0xBB67AE85, 0xBB67AE85
-BLAKE3_IV_2:
+SSE41_BLAKE3_IV_2:
         .long  0x3C6EF372, 0x3C6EF372, 0x3C6EF372, 0x3C6EF372
-BLAKE3_IV_3:
+SSE41_BLAKE3_IV_3:
         .long  0xA54FF53A, 0xA54FF53A, 0xA54FF53A, 0xA54FF53A
-BLAKE3_BLOCK_LEN:
+SSE41_BLAKE3_BLOCK_LEN:
         .long  64, 64, 64, 64
-CMP_MSB_MASK:
+SSE41_CMP_MSB_MASK:
         .long  0x80000000, 0x80000000, 0x80000000, 0x80000000

--- a/src/ffi_avx512.rs
+++ b/src/ffi_avx512.rs
@@ -1,5 +1,8 @@
 use crate::{CVWords, IncrementCounter, BLOCK_LEN, OUT_LEN};
 
+#[cfg(blake3_avx512_asm)]
+core::arch::global_asm!(include_str!(concat!(env!("OUT_DIR"), "/blake3_avx512.S")));
+
 // Unsafe because this may only be called on platforms supporting AVX-512.
 pub unsafe fn compress_in_place(
     cv: &mut CVWords,
@@ -61,7 +64,38 @@ pub unsafe fn hash_many<const N: usize>(
 }
 
 pub mod ffi {
+    #[cfg(not(blake3_avx512_asm))]
     extern "C" {
+        pub fn blake3_compress_in_place_avx512(
+            cv: *mut u32,
+            block: *const u8,
+            block_len: u8,
+            counter: u64,
+            flags: u8,
+        );
+        pub fn blake3_compress_xof_avx512(
+            cv: *const u32,
+            block: *const u8,
+            block_len: u8,
+            counter: u64,
+            flags: u8,
+            out: *mut u8,
+        );
+        pub fn blake3_hash_many_avx512(
+            inputs: *const *const u8,
+            num_inputs: usize,
+            blocks: usize,
+            key: *const u32,
+            counter: u64,
+            increment_counter: bool,
+            flags: u8,
+            flags_start: u8,
+            flags_end: u8,
+            out: *mut u8,
+        );
+    }
+    #[cfg(blake3_avx512_asm)]
+    extern "win64" {
         pub fn blake3_compress_in_place_avx512(
             cv: *mut u32,
             block: *const u8,

--- a/src/ffi_sse2.rs
+++ b/src/ffi_sse2.rs
@@ -1,5 +1,8 @@
 use crate::{CVWords, IncrementCounter, BLOCK_LEN, OUT_LEN};
 
+#[cfg(blake3_sse2_asm)]
+core::arch::global_asm!(include_str!(concat!(env!("OUT_DIR"), "/blake3_sse2.S")));
+
 // Unsafe because this may only be called on platforms supporting SSE2.
 pub unsafe fn compress_in_place(
     cv: &mut CVWords,
@@ -61,7 +64,38 @@ pub unsafe fn hash_many<const N: usize>(
 }
 
 pub mod ffi {
+    #[cfg(not(blake3_sse41_asm))]
     extern "C" {
+        pub fn blake3_compress_in_place_sse2(
+            cv: *mut u32,
+            block: *const u8,
+            block_len: u8,
+            counter: u64,
+            flags: u8,
+        );
+        pub fn blake3_compress_xof_sse2(
+            cv: *const u32,
+            block: *const u8,
+            block_len: u8,
+            counter: u64,
+            flags: u8,
+            out: *mut u8,
+        );
+        pub fn blake3_hash_many_sse2(
+            inputs: *const *const u8,
+            num_inputs: usize,
+            blocks: usize,
+            key: *const u32,
+            counter: u64,
+            increment_counter: bool,
+            flags: u8,
+            flags_start: u8,
+            flags_end: u8,
+            out: *mut u8,
+        );
+    }
+    #[cfg(blake3_sse41_asm)]
+    extern "win64" {
         pub fn blake3_compress_in_place_sse2(
             cv: *mut u32,
             block: *const u8,


### PR DESCRIPTION
This PR replaces uses Rust's `global_asm` to include the sse2/sse41/avx2/avx512 assembly functions used by blake3. This is useful to reduce the toolchain requirements of this crates' user, which is especially nice for cross-compilation purposes. We no longer require a working C compiler/assembler to get the fast asm version of blake3 on x86_64!

You'll notice this MR commits a certain amount of code crimes to get it working:

1. It will always take the `windows_gnu.S` version of the code, as it doesn't require running the preprocessor on it. However, this means it always uses the `win64` ABI, instead of the `C` ABI. As such, the FFI definitions have to be changed to show this (e.g. the `extern "win64"`). While this works, it feels terrible.
2. The asm is modified by the `build.rs` to fixup the assembly so it can be included in `global_asm` without issues. In particular, the initial `.intel_syntax` is removed (that's the default in global_asm), and the `{`s and `}`s are doubled to escape them (as a `{}` is used for formatting).
3. When compiling for apple, we replace `.section .text` with `.text` and `.section .rodata` with `.static_data`, to make it compile.

While I think most of this is fine, fixing the ABI so we can keep using `extern "C"` ABIs would be a bit nicer.