### PR TITLE
Warn of any unicode replacement characters

### DIFF
--- a/b3sum/src/main.rs
+++ b/b3sum/src/main.rs
@@ -340,6 +340,9 @@ fn filepath_to_string(filepath: &Path) -> FilepathString {
         filepath_string = filepath_string.replace('\\', "\\\\").replace('\n', "\\n");
         is_escaped = true;
     }
+    if filepath_string.contains('�') {
+        eprintln!("{}: must be valid unicode and not contain '�' for --check", filepath_string);
+    }
     FilepathString {
         filepath_string,
         is_escaped,


### PR DESCRIPTION
Unicode replacement characters mean the --check is not able to check the file so warn when generating them.

Issue #281