### PR TITLE
Add --check summary of failures

### DIFF
--- a/b3sum/src/main.rs
+++ b/b3sum/src/main.rs
@@ -537,7 +537,7 @@ fn check_one_line(line: &str, args: &Args) -> bool {
     }
 }
 
-fn check_one_checkfile(path: &Path, args: &Args, files_failed: &mut i64) -> Result<()> {
+fn check_one_checkfile(path: &Path, args: &Args, files_failed: &mut u64) -> Result<()> {
     let checkfile_input = Input::open(path, args)?;
     let mut bufreader = io::BufReader::new(checkfile_input);
     let mut line = String::new();
@@ -564,7 +564,7 @@ fn main() -> Result<()> {
     }
     let thread_pool = thread_pool_builder.build()?;
     thread_pool.install(|| {
-        let mut files_failed = 0i64;
+        let mut files_failed = 0u64;
         // Note that file_args automatically includes `-` if nothing is given.
         for path in &args.file_args {
             if args.check() {

--- a/b3sum/tests/cli_tests.rs
+++ b/b3sum/tests/cli_tests.rs
@@ -420,7 +420,7 @@ fn test_check() {
         c/d: OK\n";
     assert!(!output.status.success());
     assert_eq!(expected_check_failure, stdout);
-    assert_eq!("", stderr);
+    assert_eq!("b3sum: WARNING 1 computed checksum did NOT match\n", stderr);
 
     // Delete one of the files and check again.
     fs::remove_file(dir.path().join("b")).unwrap();
@@ -442,7 +442,7 @@ fn test_check() {
     );
     assert!(!output.status.success());
     assert_eq!(expected_check_failure, stdout);
-    assert_eq!("", stderr);
+    assert_eq!("b3sum: WARNING 1 computed checksum did NOT match\n", stderr);
 
     // Confirm that --quiet suppresses the OKs but not the FAILEDs.
     let output = cmd!(b3sum_exe(), "--check", "--quiet", &checkfile_path)
@@ -457,7 +457,7 @@ fn test_check() {
     let expected_check_failure = format!("b: FAILED ({})\n", open_file_error);
     assert!(!output.status.success());
     assert_eq!(expected_check_failure, stdout);
-    assert_eq!("", stderr);
+    assert_eq!("b3sum: WARNING 1 computed checksum did NOT match\n", stderr);
 }
 
 #[test]
@@ -472,9 +472,12 @@ fn test_check_invalid_characters() {
         .unwrap();
     let stdout = std::str::from_utf8(&output.stdout).unwrap();
     let stderr = std::str::from_utf8(&output.stderr).unwrap();
+    let expected_stderr = "\
+        b3sum: Null character in path\n\
+        b3sum: WARNING 1 computed checksum did NOT match\n";
     assert!(!output.status.success());
     assert_eq!("", stdout);
-    assert_eq!("b3sum: Null character in path\n", stderr);
+    assert_eq!(expected_stderr, stderr);
 
     // Check that a Unicode replacement character in the path fails.
     let output = cmd!(b3sum_exe(), "--check")
@@ -486,9 +489,12 @@ fn test_check_invalid_characters() {
         .unwrap();
     let stdout = std::str::from_utf8(&output.stdout).unwrap();
     let stderr = std::str::from_utf8(&output.stderr).unwrap();
+    let expected_stderr = "\
+        b3sum: Unicode replacement character in path\n\
+        b3sum: WARNING 1 computed checksum did NOT match\n";
     assert!(!output.status.success());
     assert_eq!("", stdout);
-    assert_eq!("b3sum: Unicode replacement character in path\n", stderr);
+    assert_eq!(expected_stderr, stderr);
 
     // Check that an invalid escape sequence in the path fails.
     let output = cmd!(b3sum_exe(), "--check")
@@ -500,9 +506,12 @@ fn test_check_invalid_characters() {
         .unwrap();
     let stdout = std::str::from_utf8(&output.stdout).unwrap();
     let stderr = std::str::from_utf8(&output.stderr).unwrap();
+    let expected_stderr = "\
+        b3sum: Invalid backslash escape\n\
+        b3sum: WARNING 1 computed checksum did NOT match\n";
     assert!(!output.status.success());
     assert_eq!("", stdout);
-    assert_eq!("b3sum: Invalid backslash escape\n", stderr);
+    assert_eq!(expected_stderr, stderr);
 
     // Windows also forbids literal backslashes. Check for that if and only if
     // we're on Windows.
@@ -516,9 +525,12 @@ fn test_check_invalid_characters() {
             .unwrap();
         let stdout = std::str::from_utf8(&output.stdout).unwrap();
         let stderr = std::str::from_utf8(&output.stderr).unwrap();
+        let expected_stderr = "\
+            b3sum: Backslash in path\n\
+            b3sum: WARNING 1 computed checksum did NOT match\n";
         assert!(!output.status.success());
         assert_eq!("", stdout);
-        assert_eq!("b3sum: Backslash in path\n", stderr);
+        assert_eq!(expected_stderr, stderr);
     }
 }
 


### PR DESCRIPTION
Add a warning to stderr at the end similar to other *sum utilities when --check is used and some files failed verification.

At least the last part of the comment above check_one_checkfile seemed to be incorrect so I removed that comment.

Fixes #283