### PR TITLE
Correct section names on Windows GNU assembly

### DIFF
--- a/c/blake3_avx2_x86-64_windows_gnu.S
+++ b/c/blake3_avx2_x86-64_windows_gnu.S
@@ -1784,7 +1784,7 @@ blake3_hash_many_avx2:
         vmovdqu xmmword ptr [rbx+0x10], xmm1
         jmp     4b
 
-.section .rodata
+.section .rdata
 .p2align  6
 ADD0:
         .long  0, 1, 2, 3, 4, 5, 6, 7

--- a/c/blake3_avx512_x86-64_windows_gnu.S
+++ b/c/blake3_avx512_x86-64_windows_gnu.S
@@ -2587,7 +2587,7 @@ blake3_compress_xof_avx512:
         add     rsp, 72
         ret
 
-.section .rodata
+.section .rdata
 .p2align  6
 INDEX0:
         .long    0,  1,  2,  3, 16, 17, 18, 19

--- a/c/blake3_sse2_x86-64_windows_gnu.S
+++ b/c/blake3_sse2_x86-64_windows_gnu.S
@@ -2301,7 +2301,7 @@ blake3_compress_xof_sse2:
         ret
 
 
-.section .rodata
+.section .rdata
 .p2align  6
 BLAKE3_IV:
         .long  0x6A09E667, 0xBB67AE85

--- a/c/blake3_sse41_x86-64_windows_gnu.S
+++ b/c/blake3_sse41_x86-64_windows_gnu.S
@@ -2042,7 +2042,7 @@ blake3_compress_xof_sse41:
         ret
 
 
-.section .rodata
+.section .rdata
 .p2align  6
 BLAKE3_IV:
         .long  0x6A09E667, 0xBB67AE85


### PR DESCRIPTION
Currently this data is placed into ".rodata", which is an unknown section, therefore has read-write protections by default. After this change, it would be in .rdata, which is for read only data, and therefore has such protections set.