### PR TITLE
Suppress MemorySanitizer false positive

### DIFF
--- a/c/blake3.c
+++ b/c/blake3.c
@@ -5,6 +5,13 @@
 #include "blake3.h"
 #include "blake3_impl.h"
 
+#ifdef __has_feature
+#if __has_feature(memory_sanitizer)
+#include <sanitizer/msan_interface.h>
+#define BLAKE3_MEMORY_SANITIZER_BUILD
+#endif
+#endif
+
 const char *blake3_version(void) { return BLAKE3_VERSION_STRING; }
 
 INLINE void chunk_state_init(blake3_chunk_state *self, const uint32_t key[8],
@@ -580,6 +587,10 @@ void blake3_hasher_finalize_seek(const blake3_hasher *self, uint64_t seek,
   if (self->cv_stack_len == 0) {
     output_t output = chunk_state_output(&self->chunk);
     output_root_bytes(&output, seek, out, out_len);
+#ifdef BLAKE3_MEMORY_SANITIZER_BUILD
+    // MemorySanitizer gives a false positive due to use of assembly.
+    __msan_unpoison(out, out_len);
+#endif
     return;
   }
   // If there are any bytes in the chunk state, finalize that chunk and do a
@@ -608,6 +619,10 @@ void blake3_hasher_finalize_seek(const blake3_hasher *self, uint64_t seek,
     output = parent_output(parent_block, self->key, self->chunk.flags);
   }
   output_root_bytes(&output, seek, out, out_len);
+#ifdef BLAKE3_MEMORY_SANITIZER_BUILD
+  // MemorySanitizer gives a false positive due to use of assembly.
+  __msan_unpoison(out, out_len);
+#endif
 }
 
 void blake3_hasher_reset(blake3_hasher *self) {


### PR DESCRIPTION
MemorySanitizer does not support assembly, and therefore produces a false positive on `blake3_hasher_finalize` and related functions.

Note that a similar (but less comprehensive) fix was previously applied to LLVM's fork of this repo:

https://github.com/llvm/llvm-project/blob/34aff47521c3e0cbac58b0d5793197f76a304295/llvm/lib/Support/BLAKE3/blake3.c#L576