### PR TITLE
Refactor CMake buildsystem to be portable and modern

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,17 +278,23 @@ jobs:
 
   # CMake build test (Library only), current macOS/Linux only.
   cmake_build:
-      name: CMake ${{ matrix.os }}
-      runs-on: ${{ matrix.os }}
-      strategy:
-        fail-fast: false
-        matrix:
-          os: ["ubuntu-latest", "macOS-latest"]
-      steps:
+    name: CMake ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest", "macOS-latest", "windows-latest"]
+        compiler: [gcc, clang, cl]
+        exclude:
+          - os: windows-latest
+            compiler: gcc
+          - os: ubuntu-latest
+            compiler: msvc
+          - os: macOS-latest
+            compiler: msvc
+    steps:
       - uses: actions/checkout@v3
       - name: CMake generation
-        run: cmake . -Bbuild
-        working-directory: ./c
-      - name: CMake build
-        run: cmake --build build/
-        working-directory: ./c
+        run: cmake -S c -B c/build -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/target
+      - name: CMake build / install
+        run: cmake --build c/build --target install

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -128,7 +128,7 @@ configure_package_config_file(blake3-config.cmake.in
 write_basic_package_version_file(
     "${CMAKE_CURRENT_BINARY_DIR}/blake3-config-version.cmake"
     VERSION ${libblake3_VERSION}
-    COMPATIBILITY SameMinorVersion # as long as libblake3_VERSION < 1.0.0
+    COMPATIBILITY SameMajorVersion
 )
 install(FILES
         "${CMAKE_CURRENT_BINARY_DIR}/blake3-config.cmake"

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -35,10 +35,19 @@ add_library(blake3
 add_library(BLAKE3::blake3 ALIAS blake3)
 
 # library configuration
+set(BLAKE3_PKGCONFIG_CFLAGS)
+if (BUILD_SHARED_LIBS)
+  target_compile_definitions(blake3 
+    PUBLIC BLAKE3_DLL
+    PRIVATE BLAKE3_DLL_EXPORTS
+  )
+  list(APPEND BLAKE3_PKGCONFIG_CFLAGS -DBLAKE3_DLL)
+endif()
 target_include_directories(blake3 PUBLIC $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 set_target_properties(blake3 PROPERTIES
   VERSION ${PROJECT_VERSION}
   SOVERSION 0
+  C_VISIBILITY_PRESET hidden
 )
 
 # optional SIMD sources

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -1,74 +1,132 @@
 cmake_minimum_required(VERSION 3.9)
 
-project(libblake3 VERSION 0.1.0 DESCRIPTION "BLAKE3 C implementation")
-enable_language(C ASM)
+project(libblake3
+  VERSION 0.1.0
+  DESCRIPTION "BLAKE3 C implementation"
+  LANGUAGES C ASM
+)
 
 include(GNUInstallDirs)
 
-option(BLAKE3_STATIC ON)
+# default SIMD compiler flag configuration (can be overriden by toolchains or CLI)
+if(CMAKE_C_COMPILER_ID STREQUAL "MSVC")
+  set(BLAKE3_CFLAGS_SSE2 "/arch:SSE2" CACHE STRING "the compiler flags to enable SSE2")
+  # MSVC has no dedicated sse4.1 flag (see https://learn.microsoft.com/en-us/cpp/build/reference/arch-x86?view=msvc-170)
+  set(BLAKE3_CFLAGS_SSE4.1 "/arch:AVX" CACHE STRING "the compiler flags to enable SSE4.1")
+  set(BLAKE3_CFLAGS_AVX2 "/arch:AVX2" CACHE STRING "the compiler flags to enable AVX2")
+  set(BLAKE3_CFLAGS_AVX512 "/arch:AVX512" CACHE STRING "the compiler flags to enable AVX512")
 
-set(blake3_SOURCES)
-list(APPEND blake3_SOURCES
+elseif(CMAKE_C_COMPILER_ID STREQUAL "GNU"
+       OR CMAKE_C_COMPILER_ID STREQUAL "Clang"
+       OR CMAKE_C_COMPILER_ID STREQUAL "AppleClang")
+  set(BLAKE3_CFLAGS_SSE2 "-msse2" CACHE STRING "the compiler flags to enable SSE2")
+  set(BLAKE3_CFLAGS_SSE4.1 "-msse4.1" CACHE STRING "the compiler flags to enable SSE4.1")
+  set(BLAKE3_CFLAGS_AVX2 "-mavx2" CACHE STRING "the compiler flags to enable AVX2")
+  set(BLAKE3_CFLAGS_AVX512 "-mavx512f -mavx512vl" CACHE STRING "the compiler flags to enable AVX512")
+  set(BLAKE3_CFLAGS_NEON "-mfpu=neon" CACHE STRING "the compiler flags to enable NEON")
+endif()
+
+# library target
+add_library(blake3
   blake3.c
   blake3_dispatch.c
-  blake3_portable.c)
+  blake3_portable.c
+)
+add_library(BLAKE3::blake3 ALIAS blake3)
 
-if(CMAKE_SYSTEM_PROCESSOR STREQUAL x86_64)
-  list(APPEND blake3_SOURCES
-    blake3_avx2_x86-64_unix.S
-    blake3_avx512_x86-64_unix.S
-    blake3_sse2_x86-64_unix.S
-    blake3_sse41_x86-64_unix.S)
+# library configuration
+target_include_directories(blake3 PUBLIC $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+set_target_properties(blake3 PROPERTIES
+  VERSION ${PROJECT_VERSION}
+  SOVERSION 0
+)
 
-elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL i686)
-  list(APPEND blake3_SOURCES
+# optional SIMD sources
+if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64"
+   OR CMAKE_SYSTEM_PROCESSOR STREQUAL "AMD64")
+    if(CMAKE_C_COMPILER_ID STREQUAL "MSVC")
+    enable_language(ASM_MASM)
+    target_sources(blake3 PRIVATE
+      blake3_avx2_x86-64_windows_msvc.asm
+      blake3_avx512_x86-64_windows_msvc.asm
+      blake3_sse2_x86-64_windows_msvc.asm
+      blake3_sse41_x86-64_windows_msvc.asm
+    )
+
+  elseif(CMAKE_C_COMPILER_ID STREQUAL "GNU"
+         OR CMAKE_C_COMPILER_ID STREQUAL "Clang"
+         OR CMAKE_C_COMPILER_ID STREQUAL "AppleClang")
+    if (WIN32)
+      target_sources(blake3 PRIVATE
+        blake3_avx2_x86-64_windows_gnu.S
+        blake3_avx512_x86-64_windows_gnu.S
+        blake3_sse2_x86-64_windows_gnu.S
+        blake3_sse41_x86-64_windows_gnu.S
+      )
+
+    elseif(UNIX)
+      target_sources(blake3 PRIVATE
+        blake3_avx2_x86-64_unix.S
+        blake3_avx512_x86-64_unix.S
+        blake3_sse2_x86-64_unix.S
+        blake3_sse41_x86-64_unix.S
+      )
+    endif()
+  endif()
+
+elseif((CMAKE_SYSTEM_PROCESSOR STREQUAL "i686"
+          OR CMAKE_SYSTEM_PROCESSOR STREQUAL "X86")
+       AND DEFINED BLAKE3_CFLAGS_SSE2
+       AND DEFINED BLAKE3_CFLAGS_SSE4.1
+       AND DEFINED BLAKE3_CFLAGS_AVX2
+       AND DEFINED BLAKE3_CFLAGS_AVX512)
+  target_sources(blake3 PRIVATE
     blake3_avx2.c
     blake3_avx512.c
     blake3_sse2.c
-    blake3_sse41.c)
-  set_source_files_properties(blake3_avx2.c PROPERTIES COMPILE_FLAGS -mavx2)
-  set_source_files_properties(blake3_avx512.c PROPERTIES COMPILE_FLAGS "-mavx512f -mavx512vl")
-  set_source_files_properties(blake3_sse2.c PROPERTIES COMPILE_FLAGS -msse2)
-  set_source_files_properties(blake3_sse41.c PROPERTIES COMPILE_FLAGS -msse4.1)
+    blake3_sse41.c
+  )
+  set_source_files_properties(blake3_avx2.c PROPERTIES COMPILE_FLAGS "${BLAKE3_CFLAGS_AVX2}")
+  set_source_files_properties(blake3_avx512.c PROPERTIES COMPILE_FLAGS "${BLAKE3_CFLAGS_AVX512}")
+  set_source_files_properties(blake3_sse2.c PROPERTIES COMPILE_FLAGS "${BLAKE3_CFLAGS_SSE2}")
+  set_source_files_properties(blake3_sse41.c PROPERTIES COMPILE_FLAGS "${BLAKE3_CFLAGS_SSE4.1}")
 
-elseif((ANDROID_ABI STREQUAL armeabi-v7a) OR
-       (CMAKE_SYSTEM_PROCESSOR STREQUAL aarch64) OR 
-       (CMAKE_SYSTEM_PROCESSOR STREQUAL arm64) # For M1 macs
-      )
-  list(APPEND blake3_SOURCES blake3_neon.c)
-  set_source_files_properties(blake3_dispatch.c PROPERTIES COMPILE_FLAGS -DBLAKE3_USE_NEON=1)
-  set_source_files_properties(blake3_neon.c PROPERTIES COMPILE_FLAGS -mfpu=neon)
+elseif((ANDROID_ABI STREQUAL "armeabi-v7a"
+          OR CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64"
+          OR CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64") # For M1 macs
+       AND DEFINED BLAKE3_CFLAGS_NEON)
+  target_sources(blake3 PRIVATE
+    blake3_neon.c
+  )
+  set_source_files_properties(blake3_dispatch.c PROPERTIES COMPILE_DEFINITIONS BLAKE3_USE_NEON=1)
+  set_source_files_properties(blake3_neon.c PROPERTIES COMPILE_FLAGS "${BLAKE3_CFLAGS_NEON}")
 endif()
 
+# cmake install support
+install(FILES blake3.h DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+install(TARGETS blake3 EXPORT blake3-targets)
+install(EXPORT blake3-targets
+  NAMESPACE BLAKE3::
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/blake3"
+)
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(blake3-config.cmake.in
+    "${CMAKE_CURRENT_BINARY_DIR}/blake3-config.cmake"
+
+    INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/blake3"
+)
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/blake3-config-version.cmake"
+    VERSION ${libblake3_VERSION}
+    COMPATIBILITY SameMinorVersion # as long as libblake3_VERSION < 1.0.0
+)
+install(FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/blake3-config.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/blake3-config-version.cmake"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/blake3"
+)
+
 configure_file(libblake3.pc.in libblake3.pc @ONLY)
-install(FILES ${CMAKE_BINARY_DIR}/libblake3.pc
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
-
-if(BLAKE3_STATIC)
-  add_library(blake3-static STATIC ${blake3_SOURCES})
-  set_target_properties(blake3-static PROPERTIES OUTPUT_NAME blake3)
-  set_target_properties(blake3-static PROPERTIES VERSION ${PROJECT_VERSION})
-  set_target_properties(blake3-static PROPERTIES SOVERSION 0)
-  set_target_properties(blake3-static PROPERTIES PUBLIC_HEADER blake3.h)
-  set_target_properties(blake3-static PROPERTIES COMPILE_FLAGS -fPIC)
-  target_include_directories(blake3-static PUBLIC .)
-
-  install(TARGETS blake3-static
-  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-
-else()
-
-  add_library(blake3-shared SHARED ${blake3_SOURCES})
-  set_target_properties(blake3-shared PROPERTIES VERSION ${PROJECT_VERSION})
-  set_target_properties(blake3-shared PROPERTIES SOVERSION 0)
-  set_target_properties(blake3-shared PROPERTIES PUBLIC_HEADER blake3.h)
-  target_include_directories(blake3-shared PUBLIC .)
-  
-  install(TARGETS blake3-shared
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-
-endif(BLAKE3_STATIC)
-
-unset(BLAKE3_STATIC)
+install(FILES "${CMAKE_BINARY_DIR}/libblake3.pc"
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.9)
 
 project(libblake3
-  VERSION 0.1.0
+  VERSION 1.3.3
   DESCRIPTION "BLAKE3 C implementation"
   LANGUAGES C ASM
 )

--- a/c/blake3-config.cmake.in
+++ b/c/blake3-config.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/blake3-targets.cmake")
+
+check_required_components(blake3)

--- a/c/blake3.h
+++ b/c/blake3.h
@@ -4,6 +4,28 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#if !defined(BLAKE3_API)
+# if defined(_WIN32) || defined(__CYGWIN__)
+#   if defined(BLAKE3_DLL)
+#     if defined(BLAKE3_DLL_EXPORTS)
+#       define BLAKE3_API __declspec(dllexport)
+#     else
+#       define BLAKE3_API __declspec(dllimport)
+#     endif
+#     define BLAKE3_PRIVATE
+#   else
+#     define BLAKE3_API
+#     define BLAKE3_PRIVATE
+#   endif
+# elif __GNUC__ >= 4
+#   define BLAKE3_API __attribute__((visibility("default")))
+#   define BLAKE3_PRIVATE __attribute__((visibility("hidden")))
+# else
+#   define BLAKE3_API
+#   define BLAKE3_PRIVATE
+# endif
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -38,20 +60,20 @@ typedef struct {
   uint8_t cv_stack[(BLAKE3_MAX_DEPTH + 1) * BLAKE3_OUT_LEN];
 } blake3_hasher;
 
-const char *blake3_version(void);
-void blake3_hasher_init(blake3_hasher *self);
-void blake3_hasher_init_keyed(blake3_hasher *self,
-                              const uint8_t key[BLAKE3_KEY_LEN]);
-void blake3_hasher_init_derive_key(blake3_hasher *self, const char *context);
-void blake3_hasher_init_derive_key_raw(blake3_hasher *self, const void *context,
-                                       size_t context_len);
-void blake3_hasher_update(blake3_hasher *self, const void *input,
-                          size_t input_len);
-void blake3_hasher_finalize(const blake3_hasher *self, uint8_t *out,
-                            size_t out_len);
-void blake3_hasher_finalize_seek(const blake3_hasher *self, uint64_t seek,
-                                 uint8_t *out, size_t out_len);
-void blake3_hasher_reset(blake3_hasher *self);
+BLAKE3_API const char *blake3_version(void);
+BLAKE3_API void blake3_hasher_init(blake3_hasher *self);
+BLAKE3_API void blake3_hasher_init_keyed(blake3_hasher *self,
+                                         const uint8_t key[BLAKE3_KEY_LEN]);
+BLAKE3_API void blake3_hasher_init_derive_key(blake3_hasher *self, const char *context);
+BLAKE3_API void blake3_hasher_init_derive_key_raw(blake3_hasher *self, const void *context,
+                                                  size_t context_len);
+BLAKE3_API void blake3_hasher_update(blake3_hasher *self, const void *input,
+                                     size_t input_len);
+BLAKE3_API void blake3_hasher_finalize(const blake3_hasher *self, uint8_t *out,
+                                       size_t out_len);
+BLAKE3_API void blake3_hasher_finalize_seek(const blake3_hasher *self, uint64_t seek,
+                                            uint8_t *out, size_t out_len);
+BLAKE3_API void blake3_hasher_reset(blake3_hasher *self);
 
 #ifdef __cplusplus
 }

--- a/c/libblake3.pc.in
+++ b/c/libblake3.pc.in
@@ -9,4 +9,4 @@ Version: @PROJECT_VERSION@
 
 Requires:
 Libs: -L${libdir} -lblake3
-Cflags: -I${includedir}
+Cflags: -I${includedir} @BLAKE3_PKGCONFIG_CFLAGS@


### PR DESCRIPTION
This is building on top of @SteveGremory's #247
Resolves #102

Aggreggate source files directly in the target instead of a proxy variable.

Install CMake package config files in order to allow the project to be found via `find_package()` by dependents.

Remove hard coded compiler flags (including -fPIC). These are not portable and should be set by the toolchain file or on the CLI.

Replace hard coded SIMD compiler flags with configurable options. Retain the current GCC/Clang flags as defaults for these compilers. Add default SIMD compiler flags for MSVC.

Guard ASM sources with triplet compatibility checks.

Remove the `BLAKE3_STATIC` option in favor of [`BUILD_SHARED_LIBS`].

[`BUILD_SHARED_LIBS`]: https://cmake.org/cmake/help/v3.9/variable/BUILD_SHARED_LIBS.html