### PR TITLE
build(cmake): Correctly detect x86 and arm64 Windows

### DIFF
--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -54,6 +54,13 @@ set_target_properties(blake3 PROPERTIES
   C_VISIBILITY_PRESET hidden
 )
 
+# optional SIMD sources
+macro(BLAKE3_DISABLE_SIMD)
+  set_source_files_properties(blake3_dispatch.c PROPERTIES 
+    COMPILE_DEFINITIONS BLAKE3_USE_NEON=0;BLAKE3_NO_SSE2;BLAKE3_NO_SSE41;BLAKE3_NO_AVX2;BLAKE3_NO_AVX512
+  )
+endmacro()
+
 if(CMAKE_SYSTEM_PROCESSOR IN_LIST BLAKE3_AMD64_NAMES OR BLAKE3_USE_AMD64_ASM)
   if(CMAKE_C_COMPILER_ID STREQUAL "MSVC")
     enable_language(ASM_MASM)
@@ -82,7 +89,13 @@ if(CMAKE_SYSTEM_PROCESSOR IN_LIST BLAKE3_AMD64_NAMES OR BLAKE3_USE_AMD64_ASM)
         blake3_sse2_x86-64_unix.S
         blake3_sse41_x86-64_unix.S
       )
+
+    else()
+      BLAKE3_DISABLE_SIMD()
     endif()
+
+  else()  
+    BLAKE3_DISABLE_SIMD()
   endif()
 
 elseif((CMAKE_SYSTEM_PROCESSOR IN_LIST BLAKE3_X86_NAMES OR BLAKE3_USE_X86_INTRINSICS)
@@ -110,6 +123,9 @@ elseif((ANDROID_ABI STREQUAL "armeabi-v7a"
   )
   set_source_files_properties(blake3_dispatch.c PROPERTIES COMPILE_DEFINITIONS BLAKE3_USE_NEON=1)
   set_source_files_properties(blake3_neon.c PROPERTIES COMPILE_FLAGS "${BLAKE3_CFLAGS_NEON}")
+
+else()
+  BLAKE3_DISABLE_SIMD()
 endif()
 
 # cmake install support

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -6,6 +6,7 @@ project(libblake3
   LANGUAGES C ASM
 )
 
+include(FeatureSummary)
 include(GNUInstallDirs)
 
 # default SIMD compiler flag configuration (can be overriden by toolchains or CLI)
@@ -56,12 +57,17 @@ set_target_properties(blake3 PROPERTIES
 
 # optional SIMD sources
 macro(BLAKE3_DISABLE_SIMD)
+  set(BLAKE3_SIMD_AMD64_ASM OFF)
+  set(BLAKE3_SIMD_X86_INTRINSICS OFF)
+  set(BLAKE3_SIMD_NEON_INTRINSICS OFF)
   set_source_files_properties(blake3_dispatch.c PROPERTIES 
     COMPILE_DEFINITIONS BLAKE3_USE_NEON=0;BLAKE3_NO_SSE2;BLAKE3_NO_SSE41;BLAKE3_NO_AVX2;BLAKE3_NO_AVX512
   )
 endmacro()
 
 if(CMAKE_SYSTEM_PROCESSOR IN_LIST BLAKE3_AMD64_NAMES OR BLAKE3_USE_AMD64_ASM)
+  set(BLAKE3_SIMD_AMD64_ASM ON)
+
   if(CMAKE_C_COMPILER_ID STREQUAL "MSVC")
     enable_language(ASM_MASM)
     target_sources(blake3 PRIVATE
@@ -103,6 +109,8 @@ elseif((CMAKE_SYSTEM_PROCESSOR IN_LIST BLAKE3_X86_NAMES OR BLAKE3_USE_X86_INTRIN
        AND DEFINED BLAKE3_CFLAGS_SSE4.1
        AND DEFINED BLAKE3_CFLAGS_AVX2
        AND DEFINED BLAKE3_CFLAGS_AVX512)
+  set(BLAKE3_SIMD_X86_INTRINSICS ON)
+
   target_sources(blake3 PRIVATE
     blake3_avx2.c
     blake3_avx512.c
@@ -118,6 +126,8 @@ elseif((ANDROID_ABI STREQUAL "armeabi-v7a"
           OR CMAKE_SYSTEM_PROCESSOR IN_LIST BLAKE3_ARM_NAMES
           OR BLAKE3_USE_NEON_INTRINSICS)
        AND DEFINED BLAKE3_CFLAGS_NEON)
+  set(BLAKE3_SIMD_NEON_INTRINSICS ON)
+
   target_sources(blake3 PRIVATE
     blake3_neon.c
   )
@@ -156,3 +166,9 @@ install(FILES
 configure_file(libblake3.pc.in libblake3.pc @ONLY)
 install(FILES "${CMAKE_BINARY_DIR}/libblake3.pc"
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+
+# print feature summary
+add_feature_info("AMD64 assembly" BLAKE3_SIMD_AMD64_ASM "The library uses hand written amd64 SIMD assembly.")
+add_feature_info("x86 SIMD intrinsics" BLAKE3_SIMD_X86_INTRINSICS "The library uses x86 SIMD intrinsics.")
+add_feature_info("NEON SIMD intrinsics" BLAKE3_SIMD_NEON_INTRINSICS "The library uses NEON SIMD intrinsics.")
+feature_summary(WHAT ENABLED_FEATURES)

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -25,6 +25,10 @@ elseif(CMAKE_C_COMPILER_ID STREQUAL "GNU"
   set(BLAKE3_CFLAGS_AVX512 "-mavx512f -mavx512vl" CACHE STRING "the compiler flags to enable AVX512")
   set(BLAKE3_CFLAGS_NEON "-mfpu=neon" CACHE STRING "the compiler flags to enable NEON")
 endif()
+# architecture lists for which to enable assembly / SIMD sources
+set(BLAKE3_AMD64_NAMES amd64 AMD64 x86_64)
+set(BLAKE3_X86_NAMES i686 x86 X86)
+set(BLAKE3_ARM_NAMES aarch64 AArch64 arm64 ARM64 armv8 armv8a)
 
 # library target
 add_library(blake3
@@ -50,10 +54,8 @@ set_target_properties(blake3 PROPERTIES
   C_VISIBILITY_PRESET hidden
 )
 
-# optional SIMD sources
-if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64"
-   OR CMAKE_SYSTEM_PROCESSOR STREQUAL "AMD64")
-    if(CMAKE_C_COMPILER_ID STREQUAL "MSVC")
+if(CMAKE_SYSTEM_PROCESSOR IN_LIST BLAKE3_AMD64_NAMES OR BLAKE3_USE_AMD64_ASM)
+  if(CMAKE_C_COMPILER_ID STREQUAL "MSVC")
     enable_language(ASM_MASM)
     target_sources(blake3 PRIVATE
       blake3_avx2_x86-64_windows_msvc.asm
@@ -83,8 +85,7 @@ if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64"
     endif()
   endif()
 
-elseif((CMAKE_SYSTEM_PROCESSOR STREQUAL "i686"
-          OR CMAKE_SYSTEM_PROCESSOR STREQUAL "X86")
+elseif((CMAKE_SYSTEM_PROCESSOR IN_LIST BLAKE3_X86_NAMES OR BLAKE3_USE_X86_INTRINSICS)
        AND DEFINED BLAKE3_CFLAGS_SSE2
        AND DEFINED BLAKE3_CFLAGS_SSE4.1
        AND DEFINED BLAKE3_CFLAGS_AVX2
@@ -101,8 +102,8 @@ elseif((CMAKE_SYSTEM_PROCESSOR STREQUAL "i686"
   set_source_files_properties(blake3_sse41.c PROPERTIES COMPILE_FLAGS "${BLAKE3_CFLAGS_SSE4.1}")
 
 elseif((ANDROID_ABI STREQUAL "armeabi-v7a"
-          OR CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64"
-          OR CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64") # For M1 macs
+          OR CMAKE_SYSTEM_PROCESSOR IN_LIST BLAKE3_ARM_NAMES
+          OR BLAKE3_USE_NEON_INTRINSICS)
        AND DEFINED BLAKE3_CFLAGS_NEON)
   target_sources(blake3 PRIVATE
     blake3_neon.c


### PR DESCRIPTION
@oconnor663 I hate to bother you again, but microsoft/vcpkg#31602 revealed that I missed a few `CMAKE_SYSTEM_PROCESSOR` values for `x86` and `arm64`. Furthermore I added escape hatches just in case that there are even more synonyms for these ISAs. See the commit messages for further details.

I took this as an opportunity to log the active SIMD configuration.