### PR TITLE
[CMake] Fix pkg-config directory specification

### DIFF
--- a/c/libblake3.pc.in
+++ b/c/libblake3.pc.in
@@ -1,12 +1,12 @@
-prefix=@CMAKE_INSTALL_PREFIX@
-exec_prefix=@CMAKE_INSTALL_PREFIX@
-libdir=@CMAKE_INSTALL_LIBDIR@
-includedir=@CMAKE_INSTALL_INCLUDEDIR@
+prefix="@CMAKE_INSTALL_PREFIX@"
+exec_prefix="${prefix}"
+libdir="${prefix}/@CMAKE_INSTALL_LIBDIR@"
+includedir="${prefix}/@CMAKE_INSTALL_INCLUDEDIR@"
 
 Name: @PROJECT_NAME@
 Description: @PROJECT_DESCRIPTION@
 Version: @PROJECT_VERSION@
 
 Requires:
-Libs: -L${libdir} -lblake3
-Cflags: -I${includedir} @BLAKE3_PKGCONFIG_CFLAGS@
+Libs: -L"${libdir}" -lblake3
+Cflags: -I"${includedir}" @BLAKE3_PKGCONFIG_CFLAGS@


### PR DESCRIPTION
- Properly add the install prefix to the libdir and includedir.
- Define the prefix once.
- Quote paths which may contain whitespace.

Resolve #311