### PR TITLE
Improve NEON rot16/rot8

### DIFF
--- a/c/blake3_neon.c
+++ b/c/blake3_neon.c
@@ -36,7 +36,7 @@ INLINE uint32x4_t set4(uint32_t a, uint32_t b, uint32_t c, uint32_t d) {
 }
 
 INLINE uint32x4_t rot16_128(uint32x4_t x) {
-  return vorrq_u32(vshrq_n_u32(x, 16), vshlq_n_u32(x, 32 - 16));
+  return vreinterpretq_u32_u16(vrev32q_u16(vreinterpretq_u16_u32(x)));
 }
 
 INLINE uint32x4_t rot12_128(uint32x4_t x) {
@@ -44,7 +44,7 @@ INLINE uint32x4_t rot12_128(uint32x4_t x) {
 }
 
 INLINE uint32x4_t rot8_128(uint32x4_t x) {
-  return vorrq_u32(vshrq_n_u32(x, 8), vshlq_n_u32(x, 32 - 8));
+  return vreinterpretq_u32_u8(__builtin_shufflevector(vreinterpretq_u8_u32(x), vreinterpretq_u8_u32(x), 1,2,3,0,5,6,7,4,9,10,11,8,13,14,15,12));
 }
 
 INLINE uint32x4_t rot7_128(uint32x4_t x) {

--- a/c/blake3_neon.c
+++ b/c/blake3_neon.c
@@ -44,7 +44,14 @@ INLINE uint32x4_t rot12_128(uint32x4_t x) {
 }
 
 INLINE uint32x4_t rot8_128(uint32x4_t x) {
+#if defined(__clang__)
   return vreinterpretq_u32_u8(__builtin_shufflevector(vreinterpretq_u8_u32(x), vreinterpretq_u8_u32(x), 1,2,3,0,5,6,7,4,9,10,11,8,13,14,15,12));
+#elif __GNUC__ * 10000 + __GNUC_MINOR__ * 100 >=40700
+  static const uint8x16_t r8 = {1,2,3,0,5,6,7,4,9,10,11,8,13,14,15,12};
+  return vreinterpretq_u32_u8(__builtin_shuffle(vreinterpretq_u8_u32(x), vreinterpretq_u8_u32(x), r8));
+#else 
+  return vsriq_n_u32(vshlq_n_u32(x, 32-8), x, 8);
+#endif
 }
 
 INLINE uint32x4_t rot7_128(uint32x4_t x) {

--- a/c/blake3_neon.c
+++ b/c/blake3_neon.c
@@ -40,7 +40,7 @@ INLINE uint32x4_t rot16_128(uint32x4_t x) {
 }
 
 INLINE uint32x4_t rot12_128(uint32x4_t x) {
-  return vorrq_u32(vshrq_n_u32(x, 12), vshlq_n_u32(x, 32 - 12));
+  return vsriq_n_u32(vshlq_n_u32(x, 32-12), x, 12);
 }
 
 INLINE uint32x4_t rot8_128(uint32x4_t x) {
@@ -55,7 +55,7 @@ INLINE uint32x4_t rot8_128(uint32x4_t x) {
 }
 
 INLINE uint32x4_t rot7_128(uint32x4_t x) {
-  return vorrq_u32(vshrq_n_u32(x, 7), vshlq_n_u32(x, 32 - 7));
+  return vsriq_n_u32(vshlq_n_u32(x, 32-7), x, 7);
 }
 
 // TODO: compress_neon


### PR DESCRIPTION
On MacBook Air M1:

```
$ time dd if=/dev/zero bs=1048576 count=1024|./target/release/b3sum
1024+0 records in
1024+0 records out
1073741824 bytes transferred in 0.713978 secs (1503886428 bytes/sec)
94b4ec39d8d42ebda685fbb5429e8ab0086e65245e750142c1eea36a26abc24d  -
dd if=/dev/zero bs=1048576 count=1024  0.00s user 0.08s system 11% cpu 0.718 total
./target/release/b3sum  0.66s user 0.04s system 98% cpu 0.717 total
```

before:

```
$ time dd if=/dev/zero bs=1048576 count=1024|./target/release/b3sum
1024+0 records in
1024+0 records out
1073741824 bytes transferred in 0.793620 secs (1352967193 bytes/sec)
94b4ec39d8d42ebda685fbb5429e8ab0086e65245e750142c1eea36a26abc24d  -
dd if=/dev/zero bs=1048576 count=1024  0.00s user 0.08s system 9% cpu 0.798 total
./target/release/b3sum  0.76s user 0.03s system 99% cpu 0.798 total
```