### PR TITLE
Add function to efficiently hash entire non-root subtrees to guts

### DIFF
--- a/src/guts.rs
+++ b/src/guts.rs
@@ -9,6 +9,12 @@
 pub const BLOCK_LEN: usize = 64;
 pub const CHUNK_LEN: usize = 1024;
 
+pub fn hash_block(start_chunk: u64, data: &[u8], is_root: bool) -> crate::Hash {
+    let mut hasher = crate::Hasher::new_with_start_chunk(start_chunk);
+    hasher.update(data);
+    hasher.finalize_node(is_root)
+}
+
 #[derive(Clone, Debug)]
 pub struct ChunkState(crate::ChunkState);
 
@@ -97,5 +103,13 @@ mod test {
         let parent = parent_cv(&chunk0_cv, &chunk1_cv, false);
         let root = parent_cv(&parent, &chunk2_cv, true);
         assert_eq!(hasher.finalize(), root);
+    }
+
+    #[test]
+    fn test_hash_block() {
+        assert_eq!(
+            crate::hash(b"foo"),
+            hash_block(0, b"foo", true)
+        );
     }
 }


### PR DESCRIPTION
provides an efficient way to compute the hash for multiple chunks that do not start at chunk 0, as part of a larger tree.

This is useful for crates like [bao](https://github.com/oconnor663/bao), [abao](https://github.com/n0-computer/abao) and [bao-tree](https://github.com/n0-computer/bao-tree) when using chunk groups.

Adding this required to disable some assertions that contained assumptions that are no longer true.

This gives a performance improvement of 4x when computing an outboard with a chunk group size of 16kb in bao-tree compared to using `blake3::guts::ChunkState` and `blake3::guts::parent_cv` to compute a hash for a chunk group.

UPDATE:

this works in the case of bao-tree, but the signature is not good since it can't work in the general case. E.g.

```rust
let data = [0u8; 2048];
let hash = hash_block(1, &data, false);
```

This does not make any sense at all, since there is no single root for chunks 1 and 2. I guess you could put in an assert to catch things like this?