### PR TITLE
Enable `doc_auto_cfg` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,8 +80,8 @@ no_neon = []
 zeroize = ["zeroize_crate", "arrayvec/zeroize"]
 
 [package.metadata.docs.rs]
-# Document Hasher::update_rayon on docs.rs.
-features = ["rayon"]
+features = ["rayon", "traits-preview", "zeroize"]
+rustdoc-args = ["--cfg", "doc_cfg"]
 
 [dependencies]
 arrayref = "0.3.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,7 @@
 //! [`signature`]: https://crates.io/crates/signature
 
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(doc_cfg, feature(doc_auto_cfg, doc_cfg))]
 
 #[cfg(feature = "zeroize")]
 extern crate zeroize_crate as zeroize; // Needed because `zeroize::Zeroize` assumes the crate is named `zeroize`.


### PR DESCRIPTION
This allows an API be documented as only available when the feature is enabled. This is useful when reading the document published on docs.rs.