### PR TITLE
Fix build for big endian AArch64 hosts

### DIFF
--- a/c/blake3_impl.h
+++ b/c/blake3_impl.h
@@ -49,8 +49,9 @@ enum blake3_flags {
 #endif
 
 #if !defined(BLAKE3_USE_NEON) 
-  // If BLAKE3_USE_NEON not manually set, autodetect based on AArch64ness
-  #if defined(IS_AARCH64)
+  // If BLAKE3_USE_NEON not manually set, autodetect based on
+  // AArch64ness and endianness.
+  #if defined(IS_AARCH64) && !defined(__ARM_BIG_ENDIAN)
     #define BLAKE3_USE_NEON 1
   #else
     #define BLAKE3_USE_NEON 0


### PR DESCRIPTION
The implementation does not support using arm neon on big-endian hosts: see blake3_neon.c. Setting `BLAKE3_USE_NEON` to 1 by default for all AArch64 hosts broke builds for big endian hosts. This patch fixes the behavior by introducing an additional check against `__ARM_BIG_ENDIAN` before setting `BLAKE3_USE_NEON`.