### PR TITLE
Add serde support for Hash behind optional feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,11 +95,12 @@ features = ["mmap", "rayon", "zeroize"]
 arrayref = "0.3.5"
 arrayvec = { version = "0.7.4", default-features = false }
 constant_time_eq = "0.3.0"
-rayon = { version = "1.2.1", optional = true }
 cfg-if = "1.0.0"
 digest = { version = "0.10.1", features = [ "mac" ], optional = true }
-zeroize = { version = "1", default-features = false, features = ["zeroize_derive"], optional = true }
 memmap2 = { version = "0.7.1", optional = true }
+rayon = { version = "1.2.1", optional = true }
+serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
+zeroize = { version = "1", default-features = false, features = ["zeroize_derive"], optional = true }
 
 [dev-dependencies]
 hmac = "0.12.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,9 @@
 //! expect breaking changes between patch versions. (The "-preview" feature name
 //! follows the conventions of the RustCrypto [`signature`] crate.)
 //!
+//! The `serde` feature (disabled by default) enables serde compatibility for
+//! the `Hash` struct.
+//!
 //! [`Hasher::update_rayon`]: struct.Hasher.html#method.update_rayon
 //! [BLAKE3]: https://blake3.io
 //! [Rayon]: https://github.com/rayon-rs/rayon
@@ -212,6 +215,7 @@ fn counter_high(counter: u64) -> u32 {
 /// [`Display`]: https://doc.rust-lang.org/std/fmt/trait.Display.html
 /// [`FromStr`]: https://doc.rust-lang.org/std/str/trait.FromStr.html
 #[cfg_attr(feature = "zeroize", derive(zeroize::Zeroize))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[derive(Clone, Copy, Hash)]
 pub struct Hash([u8; OUT_LEN]);
 


### PR DESCRIPTION
Added a new cargo feature `serde` that when enabled will derive `serde::Serialize` and `serde::Deserialize` for the `blake3::Hash` struct.

Fixes https://github.com/BLAKE3-team/BLAKE3/issues/290