### PR TITLE
minor fixes for Xcode 14.2 warnings

### DIFF
--- a/c/blake3_dispatch.c
+++ b/c/blake3_dispatch.c
@@ -89,6 +89,7 @@ static void cpuidex(uint32_t out[4], uint32_t id, uint32_t sid) {
 #endif
 
 enum cpu_feature {
+  NONE = 0,
   SSE2 = 1 << 0,
   SSSE3 = 1 << 1,
   SSE41 = 1 << 2,
@@ -265,11 +266,11 @@ void blake3_hash_many(const uint8_t *const *inputs, size_t num_inputs,
   blake3_hash_many_neon(inputs, num_inputs, blocks, key, counter,
                         increment_counter, flags, flags_start, flags_end, out);
   return;
-#endif
-
+#else
   blake3_hash_many_portable(inputs, num_inputs, blocks, key, counter,
                             increment_counter, flags, flags_start, flags_end,
                             out);
+#endif
 }
 
 // The dynamically detected SIMD degree of the current platform.

--- a/c/blake3_impl.h
+++ b/c/blake3_impl.h
@@ -275,6 +275,10 @@ void blake3_hash_many_neon(const uint8_t *const *inputs, size_t num_inputs,
                            uint64_t counter, bool increment_counter,
                            uint8_t flags, uint8_t flags_start,
                            uint8_t flags_end, uint8_t *out);
+void blake3_hash4_neon(const uint8_t *const *inputs, size_t blocks,
+                       const uint32_t key[8], uint64_t counter,
+                       bool increment_counter, uint8_t flags,
+                       uint8_t flags_start, uint8_t flags_end, uint8_t *out);
 #endif
 
 


### PR DESCRIPTION
When trying to build the c version of BLAKE3 using Xcode 14.2 I saw some minor warnings about a missing prototype, the cpu_features enum not having a 0 value, and some unreachable code.  The proposed diff fixed these issues for me.  Thanks.