### PR TITLE
impl AsyncWrite for Hasher

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,9 @@ no_avx2 = []
 no_avx512 = []
 no_neon = []
 
+# This feature enables the tokio AsyncWrite implementation for the hashers.
+tokio = ["dep:tokio", "std"]
+
 [package.metadata.docs.rs]
 # Document the rayon/mmap methods and the Zeroize impls on docs.rs.
 features = ["mmap", "rayon", "zeroize"]
@@ -100,6 +103,7 @@ cfg-if = "1.0.0"
 digest = { version = "0.10.1", features = [ "mac" ], optional = true }
 zeroize = { version = "1", default-features = false, features = ["zeroize_derive"], optional = true }
 memmap2 = { version = "0.7.1", optional = true }
+tokio = { version = "1", default-features = false, features = [], optional = true }
 
 [dev-dependencies]
 hmac = "0.12.0"


### PR DESCRIPTION
This PR introduces the implementation of the `AsyncWrite` trait for the `Hasher` struct, allowing user to read asynchronously using the Tokio library and using `tokio::io::copy`.

The changes include:
- Updating the `Cargo.toml` file to add the optional `tokio` feature with the necessary dependencies.
- Modifying the `src/lib.rs` file to implement the `AsyncWrite` trait for `Hasher`.

Please review the changes and let me know if you have any suggestions or concerns. 