### PR TITLE
Make blake3 C library usable as meson subproject

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -331,6 +331,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: CMake generation
-        run: cmake -S c -B c/build -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/target
+        run: cmake -S . -B build -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/target
       - name: CMake build / install
-        run: cmake --build c/build --target install
+        run: cmake --build build --target install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.9)
+
+project(libblake3
+  VERSION 1.5.0
+  DESCRIPTION "BLAKE3 C implementation"
+  LANGUAGES C ASM
+)
+
+include_directories(c)
+add_subdirectory(c)

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -1,11 +1,3 @@
-cmake_minimum_required(VERSION 3.9)
-
-project(libblake3
-  VERSION 1.5.0
-  DESCRIPTION "BLAKE3 C implementation"
-  LANGUAGES C ASM
-)
-
 include(FeatureSummary)
 include(GNUInstallDirs)
 
@@ -167,7 +159,7 @@ install(FILES
 )
 
 configure_file(libblake3.pc.in libblake3.pc @ONLY)
-install(FILES "${CMAKE_BINARY_DIR}/libblake3.pc"
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libblake3.pc"
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 
 # print feature summary


### PR DESCRIPTION
The meson build system[1] support subprojects - a way to use another project in your build. The blake3 C library can be used like this, but meson requires that the subproject root directory has either `meson.build` (for meson projects) or `CMakeLists.txt` (meson can build cmake projects).

Add `CMakeLists.txt` in the root directory with the project info, including the `c` subdirectory. With this you can add blake3 as subproject to a meson project.

Example wrap file (using test release from my fork):

    % cat subprojects/blake3.wrap
    [wrap-file]
    directory = BLAKE3-1.4.1-cmake
    source_url = https://github.com/nirs/BLAKE3/archive/refs/tags/1.4.1-cmake.tar.gz
    source_filename = BLAKE3-1.4.1-cmake.tar.gz
    source_hash = 6c6f053ede700d76d12a7ced7bbd640e7a47f97122fe4cbe718aa9406251d043

With this wrap file, you can use blake3 in your meson project[2] like this:

    % cat meson.build
    project('blake3-meson', 'c', default_options: ['buildtype=release'])
    cmake = import('cmake')
    blake3_subproj = cmake.subproject('blake3')
    blake3_dep = blake3_subproj.dependency('blake3')
    executable(example, ['example.c'], dependencies: blake3_dep)

[1] https://mesonbuild.com/
[2] https://github.com/nirs/blake3-meson