### PR TITLE
replace unmaintained actions-rs/toolchain action in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,11 +39,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: actions-rs/toolchain@v1
+    - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ format('{0}-{1}', matrix.channel, matrix.target.toolchain) }}
-        profile: minimal
-        override: true
     # Print the compiler version, for debugging.
     - name: print compiler version
       run: cargo run --quiet
@@ -157,11 +155,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: actions-rs/toolchain@v1
+    - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ format('{0}-{1}', matrix.channel, matrix.target.toolchain) }}
-        profile: minimal
-        override: true
     # Test b3sum.
     - name: test b3sum
       run: cargo test
@@ -187,10 +183,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
+    - uses: dtolnay/rust-toolchain@stable
     - run: cargo install cross
     # Test the portable implementation on everything.
     - run: cross test --target ${{ matrix.arch }}
@@ -269,11 +262,9 @@ jobs:
       fail-fast: false
     steps:
     - uses: actions/checkout@v4
-    - uses: actions-rs/toolchain@v1
+    - uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: stable
-        target: aarch64-apple-darwin
-        override: true
+        targets: aarch64-apple-darwin
     - name: build blake3
       run: cargo build --target aarch64-apple-darwin
     - name: build b3sum

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -30,11 +30,9 @@ jobs:
       - run: pip install PyGithub
       - run: sudo apt-get install musl-tools
         if: matrix.target.os == 'ubuntu-latest'
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          profile: minimal
-      - run: rustup target add ${{ matrix.target.rust-target }}
+          targets: ${{ matrix.target.rust-target }}
       - name: build b3sum
         id: build_b3sum
         run: python -u .github/workflows/build_b3sum.py ${{ matrix.target.rust-target }}


### PR DESCRIPTION
Basically all of the `actions-rs/*` actions are unmaintained. See <https://github.com/actions-rs/toolchain/issues/216> for more information. Due to their age they generate several warnings in CI runs, for example in https://github.com/BLAKE3-team/BLAKE3/actions/runs/7144895807:

> The following action uses node12 which is deprecated and will be forced to run on node16: actions-rs/toolchain@v1. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

To get rid of those warnings the occurrences of `actions-rs/toolchain` are replaced by [`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain).