### PR TITLE
silenc gcc Werror=logical-op

### DIFF
--- a/c/blake3.c
+++ b/c/blake3.c
@@ -351,15 +351,13 @@ INLINE void compress_subtree_to_parent_node(
   // is set on platforms where MAX_SIMD_DEGREE_OR_2 == 2, GCC emits spurious
   // warnings here. GCC 8.5 is particularly sensitive, so if you're changing
   // this code, test it against that version.
-  while (num_cvs > 2
-#if MAX_SIMD_DEGREE_OR_2 > 2
-    && num_cvs <= MAX_SIMD_DEGREE_OR_2
-#endif
-  ) {
+#if  MAX_SIMD_DEGREE_OR_2 > 2
+  while (num_cvs > 2 && num_cvs <= MAX_SIMD_DEGREE_OR_2) {
     num_cvs =
         compress_parents_parallel(cv_array, num_cvs, key, flags, out_array);
     memcpy(cv_array, out_array, num_cvs * BLAKE3_OUT_LEN);
   }
+#endif
   memcpy(out, cv_array, 2 * BLAKE3_OUT_LEN);
 }
 

--- a/c/blake3.c
+++ b/c/blake3.c
@@ -351,7 +351,7 @@ INLINE void compress_subtree_to_parent_node(
   // is set on platforms where MAX_SIMD_DEGREE_OR_2 == 2, GCC emits spurious
   // warnings here. GCC 8.5 is particularly sensitive, so if you're changing
   // this code, test it against that version.
-#if  MAX_SIMD_DEGREE_OR_2 > 2
+#if MAX_SIMD_DEGREE_OR_2 > 2
   while (num_cvs > 2 && num_cvs <= MAX_SIMD_DEGREE_OR_2) {
     num_cvs =
         compress_parents_parallel(cv_array, num_cvs, key, flags, out_array);

--- a/c/blake3.c
+++ b/c/blake3.c
@@ -351,7 +351,11 @@ INLINE void compress_subtree_to_parent_node(
   // is set on platforms where MAX_SIMD_DEGREE_OR_2 == 2, GCC emits spurious
   // warnings here. GCC 8.5 is particularly sensitive, so if you're changing
   // this code, test it against that version.
-  while (num_cvs > 2 && num_cvs <= MAX_SIMD_DEGREE_OR_2) {
+  while (num_cvs > 2
+#if MAX_SIMD_DEGREE_OR_2 > 2
+    && num_cvs <= MAX_SIMD_DEGREE_OR_2
+#endif
+  ) {
     num_cvs =
         compress_parents_parallel(cv_array, num_cvs, key, flags, out_array);
     memcpy(cv_array, out_array, num_cvs * BLAKE3_OUT_LEN);

--- a/c/blake3.c
+++ b/c/blake3.c
@@ -342,17 +342,12 @@ INLINE void compress_subtree_to_parent_node(
                                                 chunk_counter, flags, cv_array);
   assert(num_cvs <= MAX_SIMD_DEGREE_OR_2);
 
-  // If MAX_SIMD_DEGREE is greater than 2 and there's enough input,
+#if MAX_SIMD_DEGREE_OR_2 > 2
+  // If MAX_SIMD_DEGREE_OR_2 is greater than 2 and there's enough input,
   // compress_subtree_wide() returns more than 2 chaining values. Condense
   // them into 2 by forming parent nodes repeatedly.
   uint8_t out_array[MAX_SIMD_DEGREE_OR_2 * BLAKE3_OUT_LEN / 2];
-  // The second half of this loop condition is always true, and we just
-  // asserted it above. But GCC can't tell that it's always true, and if NDEBUG
-  // is set on platforms where MAX_SIMD_DEGREE_OR_2 == 2, GCC emits spurious
-  // warnings here. GCC 8.5 is particularly sensitive, so if you're changing
-  // this code, test it against that version.
-#if MAX_SIMD_DEGREE_OR_2 > 2
-  while (num_cvs > 2 && num_cvs <= MAX_SIMD_DEGREE_OR_2) {
+  while (num_cvs > 2) {
     num_cvs =
         compress_parents_parallel(cv_array, num_cvs, key, flags, out_array);
     memcpy(cv_array, out_array, num_cvs * BLAKE3_OUT_LEN);

--- a/c/blake3.c
+++ b/c/blake3.c
@@ -341,7 +341,11 @@ INLINE void compress_subtree_to_parent_node(
   size_t num_cvs = blake3_compress_subtree_wide(input, input_len, key,
                                                 chunk_counter, flags, cv_array);
   assert(num_cvs <= MAX_SIMD_DEGREE_OR_2);
-
+  // This condition is always true, and we just
+  // asserted it above. But GCC can't tell that it's always true, and if NDEBUG
+  // is set on platforms where MAX_SIMD_DEGREE_OR_2 == 2, GCC emits spurious
+  // warnings here. GCC 8.5 is particularly sensitive, so if you're changing
+  // this code, test it against that version.
 #if MAX_SIMD_DEGREE_OR_2 > 2
   // If MAX_SIMD_DEGREE_OR_2 is greater than 2 and there's enough input,
   // compress_subtree_wide() returns more than 2 chaining values. Condense


### PR DESCRIPTION
ref https://github.com/BLAKE3-team/BLAKE3/issues/379
```
/home/travis/build/php/php-src/ext/hash/blake3/upstream_blake3/c/blake3.c: In function ‘compress_subtree_to_parent_node’:

/home/travis/build/php/php-src/ext/hash/blake3/upstream_blake3/c/blake3.c:354:22: error: logical ‘and’ of mutually exclusive tests is always false [-Werror=logical-op]

  354 |   while (num_cvs > 2 && num_cvs <= MAX_SIMD_DEGREE_OR_2) {

      |                      ^~

cc1: all warnings being treated as errors

make: *** [Makefile:1910: ext/hash/blake3/upstream_blake3/c/blake3.lo] Error 1
```
should resolve #379 