### PR TITLE
Silence gcc -Wunused-function

### DIFF
--- a/c/blake3_dispatch.c
+++ b/c/blake3_dispatch.c
@@ -298,7 +298,7 @@ size_t blake3_simd_degree(void) {
   }
 #endif
 #else
-MAYBE_UNUSED(get_cpu_features)
+  MAYBE_UNUSED(get_cpu_features);
 #endif
 #if BLAKE3_USE_NEON == 1
   return 4;

--- a/c/blake3_dispatch.c
+++ b/c/blake3_dispatch.c
@@ -297,6 +297,8 @@ size_t blake3_simd_degree(void) {
     return 4;
   }
 #endif
+#else
+MAYBE_UNUSED(get_cpu_features)
 #endif
 #if BLAKE3_USE_NEON == 1
   return 4;


### PR DESCRIPTION
gcc on MacOS-ARM64  may error out with

/Users/runner/work/php-src/php-src/ext/hash/blake3/upstream_blake3/c/blake3_dispatch.c:112:5: error: unused function 'get_cpu_features' [-Werror,-Wunused-function]

full compiler log https://github.com/php/php-src/actions/runs/7762643678/job/21173438425?pr=13194

- the optimal fix would be to make sure get_cpu_features() is only compiled on platforms where it is used, but that would take more effort (have not investigated how much effort that would be)