### PR TITLE
silence -Wunused-function on MacOS-arm64

### DIFF
--- a/c/blake3_dispatch.c
+++ b/c/blake3_dispatch.c
@@ -86,7 +86,6 @@ static void cpuidex(uint32_t out[4], uint32_t id, uint32_t sid) {
 #endif
 }
 
-#endif
 
 enum cpu_feature {
   SSE2 = 1 << 0,
@@ -161,6 +160,7 @@ static
 #endif
   }
 }
+#endif
 
 void blake3_compress_in_place(uint32_t cv[8],
                               const uint8_t block[BLAKE3_BLOCK_LEN],


### PR DESCRIPTION
the #endif was in the wrong place, causing the error /Users/runner/work/php-src/php-src/ext/hash/blake3/upstream_blake3/c/blake3_dispatch.c:112:5: error: unused function 'get_cpu_features' [-Werror,-Wunused-function]

full compiler log https://github.com/php/php-src/actions/runs/7762643678/job/21173438425?pr=13194