### PR TITLE
optimize neon loadu_128/storeu_128

### DIFF
--- a/c/blake3_neon.c
+++ b/c/blake3_neon.c
@@ -9,13 +9,13 @@
 #endif
 
 INLINE uint32x4_t loadu_128(const uint8_t src[16]) {
-    // vld1q_u32 has alignment requirements. Don't use it.
-    return vreinterpretq_u32_u8(vld1q_u8(src));
+  // vld1q_u32 has alignment requirements. Don't use it.
+  return vreinterpretq_u32_u8(vld1q_u8(src));
 }
 
 INLINE void storeu_128(uint32x4_t src, uint8_t dest[16]) {
-    // vst1q_u32 has alignment requirements. Don't use it.
-    vst1q_u8(dest, vreinterpretq_u8_u32(src));
+  // vst1q_u32 has alignment requirements. Don't use it.
+  vst1q_u8(dest, vreinterpretq_u8_u32(src));
 }
 
 INLINE uint32x4_t add_128(uint32x4_t a, uint32x4_t b) {

--- a/c/blake3_neon.c
+++ b/c/blake3_neon.c
@@ -9,15 +9,11 @@
 #endif
 
 INLINE uint32x4_t loadu_128(const uint8_t src[16]) {
-  // vld1q_u32 has alignment requirements. Don't use it.
-  uint32x4_t x;
-  memcpy(&x, src, 16);
-  return x;
+    return vreinterpretq_u32_u8(vld1q_u8(src));
 }
 
 INLINE void storeu_128(uint32x4_t src, uint8_t dest[16]) {
-  // vst1q_u32 has alignment requirements. Don't use it.
-  memcpy(dest, &src, 16);
+    vst1q_u8(dest, vreinterpretq_u8_u32(src));
 }
 
 INLINE uint32x4_t add_128(uint32x4_t a, uint32x4_t b) {

--- a/c/blake3_neon.c
+++ b/c/blake3_neon.c
@@ -9,10 +9,12 @@
 #endif
 
 INLINE uint32x4_t loadu_128(const uint8_t src[16]) {
+    // vld1q_u32 has alignment requirements. Don't use it.
     return vreinterpretq_u32_u8(vld1q_u8(src));
 }
 
 INLINE void storeu_128(uint32x4_t src, uint8_t dest[16]) {
+    // vst1q_u32 has alignment requirements. Don't use it.
     vst1q_u8(dest, vreinterpretq_u8_u32(src));
 }
 


### PR DESCRIPTION
vld1q_u8 and vst1q_u8 has no alignment requirements.

This improves performance on Oracle Cloud's VM.Standard.A1.Flex by 1.15% on a 16*1024 input, from 13920 nanoseconds down to 13800 nanoseconds (approx)