### PR TITLE
fix Windows ARM64 build and detect ARM64EC as ARM64

### DIFF
--- a/c/blake3_dispatch.c
+++ b/c/blake3_dispatch.c
@@ -4,9 +4,12 @@
 
 #include "blake3_impl.h"
 
-#if defined(IS_X86)
 #if defined(_MSC_VER)
 #include <Windows.h>
+#endif
+
+#if defined(IS_X86)
+#if defined(_MSC_VER)
 #include <intrin.h>
 #elif defined(__GNUC__)
 #include <immintrin.h>

--- a/c/blake3_impl.h
+++ b/c/blake3_impl.h
@@ -28,7 +28,7 @@ enum blake3_flags {
 #define INLINE static inline __attribute__((always_inline))
 #endif
 
-#if defined(__x86_64__) || defined(_M_X64) 
+#if (defined(__x86_64__) || defined(_M_X64)) && !defined(_M_ARM64EC)
 #define IS_X86
 #define IS_X86_64
 #endif
@@ -38,7 +38,7 @@ enum blake3_flags {
 #define IS_X86_32
 #endif
 
-#if defined(__aarch64__) || defined(_M_ARM64)
+#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
 #define IS_AARCH64
 #endif
 


### PR DESCRIPTION
This PR solves two issues when building for Windows on ARM:

1. A compilation error in `blake3_dispatch.c` due to a missing include.
2. A misdetection of the ARM64EC ABI as AMD64.

The first issue manifests as follows. You can repro in an [ARM64 Visual Studio Developer Command Prompt](https://devblogs.microsoft.com/cppblog/arm64ec-support-in-visual-studio/#developer-command-prompt):

```
> cl.exe /nologo /diagnostics:caret /c blake3_dispatch.c

blake3_dispatch.c(106,16): error C2061: syntax error: identifier 'g_cpu_features'
    ATOMIC_INT g_cpu_features = UNDEFINED;
               ^
blake3_dispatch.c(106,16): error C2059: syntax error: ';'
blake3_dispatch.c(106,31): error C2513: ' ': no variable declared before '='
    ATOMIC_INT g_cpu_features = UNDEFINED;
                              ^
blake3_dispatch.c(115,31): error C2065: 'g_cpu_features': undeclared identifier
  enum cpu_feature features = ATOMIC_LOAD(g_cpu_features);
```

The second issue is more subtle. When building for the [ARM64EC ABI](https://blogs.windows.com/windowsdeveloper/2021/06/28/announcing-arm64ec-building-native-and-interoperable-apps-for-windows-11-on-arm/), the compiler [defines the `_M_X64` macro and _not_ the `_M_ARM64` macro](https://techcommunity.microsoft.com/t5/windows-os-platform-blog/getting-to-know-arm64ec-defines-and-intrinsic-functions/ba-p/2957235), to make incremental porting existing X64 Windows code to ARM easier.

This means that the BLAKE3 library was detecting ARM64EC as AMD64 and defining `IS_X86` and `IS_X86_64`. This causes the library to compile in the SSE2 and SSE4.1 vector implementations of the algorithm instead of NEON, which amazingly does work even when building for Windows on ARM64, because Windows provides [an emulated implementation of Intel SIMD instruction sets](http://www.emulators.com/docs/abc_arm64ec_explained.htm) up to SSE4.2 in the `softintrin.lib` library. The end result is not ideal though, because it mixes native ARM64 code for the portable parts of the algorithm with emulated Intel SIMD intrinsics.

The second change is thus to make the CPU architecture detection in `blake3_impl.h` aware of the ARM64EC ABI so it can choose the NEON implementation.