### PR TITLE
Generate shell completions and man page for `b3sum` at build time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           # https://github.com/rust-lang/libs-team/issues/72.
           # This test target is here so that we notice if we accidentally bump
           # the MSRV, but it's not a promise that we won't bump it.
-          "1.66.1",
+          "1.72.0",
         ]
 
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "CC0-1.0 OR Apache-2.0"
 documentation = "https://docs.rs/blake3"
 readme = "README.md"
 edition = "2021"
-rust-version = "1.66.1"
+rust-version = "1.72.0"
 
 [features]
 default = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ license = "CC0-1.0 OR Apache-2.0"
 documentation = "https://docs.rs/blake3"
 readme = "README.md"
 edition = "2021"
+rust-version = "1.66.1"
 
 [features]
 default = ["std"]

--- a/b3sum/Cargo.lock
+++ b/b3sum/Cargo.lock
@@ -52,9 +52,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
+checksum = "f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519"
 
 [[package]]
 name = "arrayref"
@@ -86,9 +86,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.4.2"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
 name = "blake3"
@@ -117,9 +117,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.2"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b230ab84b0ffdf890d5a10abdbc8b83ae1c4918275daea1ab8801f71536b2651"
+checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -149,9 +149,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.0"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
+checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -226,9 +226,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
 
 [[package]]
 name = "errno"
@@ -242,9 +242,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
 
 [[package]]
 name = "glob"
@@ -254,9 +254,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "heck"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hex"
@@ -303,27 +303,27 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.79"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
+checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "rayon"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4963ed1bc86e4f3ee217022bd855b297cef07fb9eac5dfa1f788b220b49b3bd"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
 dependencies = [
  "either",
  "rayon-core",
@@ -347,9 +347,9 @@ checksum = "b833d8d034ea094b1ea68aa6d5c740e0d04bad9d16568d08ba6f76823a114316"
 
 [[package]]
 name = "rustix"
-version = "0.38.31"
+version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
  "bitflags",
  "errno",
@@ -370,15 +370,15 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.52"
+version = "2.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
+checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -465,7 +465,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.4",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -485,17 +485,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.4",
- "windows_aarch64_msvc 0.52.4",
- "windows_i686_gnu 0.52.4",
- "windows_i686_msvc 0.52.4",
- "windows_x86_64_gnu 0.52.4",
- "windows_x86_64_gnullvm 0.52.4",
- "windows_x86_64_msvc 0.52.4",
+ "windows_aarch64_gnullvm 0.52.5",
+ "windows_aarch64_msvc 0.52.5",
+ "windows_i686_gnu 0.52.5",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.5",
+ "windows_x86_64_gnu 0.52.5",
+ "windows_x86_64_gnullvm 0.52.5",
+ "windows_x86_64_msvc 0.52.5",
 ]
 
 [[package]]
@@ -506,9 +507,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -518,9 +519,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -530,9 +531,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -542,9 +549,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -554,9 +561,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -566,9 +573,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -578,6 +585,6 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"

--- a/b3sum/Cargo.lock
+++ b/b3sum/Cargo.lock
@@ -75,6 +75,7 @@ dependencies = [
  "anyhow",
  "blake3",
  "clap",
+ "clap_complete",
  "clap_mangen",
  "duct",
  "hex",
@@ -135,6 +136,15 @@ dependencies = [
  "clap_lex",
  "strsim",
  "terminal_size",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd79504325bf38b10165b02e89b4347300f855f273c4cb30c4a3209e6583275e"
+dependencies = [
+ "clap",
 ]
 
 [[package]]

--- a/b3sum/Cargo.lock
+++ b/b3sum/Cargo.lock
@@ -75,6 +75,7 @@ dependencies = [
  "anyhow",
  "blake3",
  "clap",
+ "clap_mangen",
  "duct",
  "hex",
  "rayon",
@@ -153,6 +154,16 @@ name = "clap_lex"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+
+[[package]]
+name = "clap_mangen"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1dd95b5ebb5c1c54581dd6346f3ed6a79a3eef95dd372fc2ac13d535535300e"
+dependencies = [
+ "clap",
+ "roff",
+]
 
 [[package]]
 name = "colorchoice"
@@ -317,6 +328,12 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "roff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b833d8d034ea094b1ea68aa6d5c740e0d04bad9d16568d08ba6f76823a114316"
 
 [[package]]
 name = "rustix"

--- a/b3sum/Cargo.toml
+++ b/b3sum/Cargo.toml
@@ -24,3 +24,8 @@ wild = "2.0.3"
 [dev-dependencies]
 duct = "0.13.3"
 tempfile = "3.1.0"
+
+[build-dependencies]
+blake3 = { version = "1", path = ".." }
+clap = { version = "4.0.8", features = ["derive"] }
+clap_mangen = "0.2.20"

--- a/b3sum/Cargo.toml
+++ b/b3sum/Cargo.toml
@@ -7,6 +7,7 @@ repository = "https://github.com/BLAKE3-team/BLAKE3"
 license = "CC0-1.0 OR Apache-2.0"
 readme = "README.md"
 edition = "2021"
+rust-version = "1.74.1"
 
 [features]
 neon = ["blake3/neon"]

--- a/b3sum/Cargo.toml
+++ b/b3sum/Cargo.toml
@@ -15,19 +15,19 @@ prefer_intrinsics = ["blake3/prefer_intrinsics"]
 pure = ["blake3/pure"]
 
 [dependencies]
-anyhow = "1.0.25"
+anyhow = "1.0.82"
 blake3 = { version = "1", path = "..", features = ["mmap", "rayon"] }
-clap = { version = "4.0.8", features = ["derive", "wrap_help"] }
-hex = "0.4.0"
-rayon = "1.2.1"
-wild = "2.0.3"
+clap = { version = "4.5.4", features = ["derive", "wrap_help"] }
+hex = "0.4.3"
+rayon = "1.10.0"
+wild = "2.2.1"
 
 [dev-dependencies]
-duct = "0.13.3"
-tempfile = "3.1.0"
+duct = "0.13.7"
+tempfile = "3.10.1"
 
 [build-dependencies]
 blake3 = { version = "1", path = ".." }
-clap = { version = "4.0.8", features = ["derive"] }
+clap = { version = "4.5.4", features = ["derive"] }
 clap_complete = "4.5.2"
 clap_mangen = "0.2.20"

--- a/b3sum/Cargo.toml
+++ b/b3sum/Cargo.toml
@@ -28,4 +28,5 @@ tempfile = "3.1.0"
 [build-dependencies]
 blake3 = { version = "1", path = ".." }
 clap = { version = "4.0.8", features = ["derive"] }
+clap_complete = "4.5.2"
 clap_mangen = "0.2.20"

--- a/b3sum/README.md
+++ b/b3sum/README.md
@@ -69,3 +69,7 @@ On Linux for example, Cargo will put the compiled binary in
 If you want to install directly from this directory, you can run `cargo
 install --path .`. Or you can just build with `cargo build --release`,
 which puts the binary at `./target/release/b3sum`.
+
+Also, shell completions and a man page are generated at build time. The
+output directory can be found by running `find ./target -path
+'*/b3sum-*/out' -type d`.

--- a/b3sum/build.rs
+++ b/b3sum/build.rs
@@ -1,0 +1,59 @@
+use clap::CommandFactory;
+
+include!("src/cli.rs");
+
+fn generate_man_page(out_dir: &std::path::Path) -> std::io::Result<()> {
+    let command = Inner::command();
+
+    let man = clap_mangen::Man::new(command).date("2024-04-24");
+    let mut buf = Vec::new();
+    man.render_title(&mut buf)?;
+
+    // The NAME section.
+    let mut roff = clap_mangen::roff::Roff::new();
+    roff.control("SH", ["NAME"]);
+    roff.text([clap_mangen::roff::roman(
+        "b3sum - compute and check BLAKE3 message digest",
+    )]);
+    roff.to_writer(&mut buf)?;
+
+    // The SYNOPSIS section.
+    let mut roff = clap_mangen::roff::Roff::new();
+    roff.control("SH", ["SYNOPSIS"]);
+    roff.text([
+        clap_mangen::roff::bold("b3sum"),
+        clap_mangen::roff::roman(" ["),
+        clap_mangen::roff::italic("OPTIONS"),
+        clap_mangen::roff::roman("] ["),
+        clap_mangen::roff::italic("FILE"),
+        clap_mangen::roff::roman("]..."),
+    ]);
+    roff.to_writer(&mut buf)?;
+
+    man.render_description_section(&mut buf)?;
+    man.render_options_section(&mut buf)?;
+
+    // The SEE ALSO section.
+    let mut roff = clap_mangen::roff::Roff::new();
+    roff.control("SH", ["SEE ALSO"]);
+    roff.text([
+        clap_mangen::roff::bold("b2sum"),
+        clap_mangen::roff::roman("(1), "),
+        clap_mangen::roff::bold("md5sum"),
+        clap_mangen::roff::roman("(1)"),
+    ]);
+    roff.to_writer(&mut buf)?;
+
+    std::fs::write(out_dir.join("b3sum.1"), buf)?;
+    Ok(())
+}
+
+fn main() -> std::io::Result<()> {
+    println!("cargo:rerun-if-changed=src/cli.rs");
+
+    let out_dir = std::env::var("OUT_DIR").expect("environment variable `OUT_DIR` not defined");
+    let out_dir = std::path::PathBuf::from(out_dir);
+
+    generate_man_page(&out_dir)?;
+    Ok(())
+}

--- a/b3sum/build.rs
+++ b/b3sum/build.rs
@@ -2,6 +2,23 @@ use clap::CommandFactory;
 
 include!("src/cli.rs");
 
+fn generate_completions(out_dir: &std::path::Path) -> std::io::Result<()> {
+    fn generate_to(
+        gen: impl clap_complete::Generator,
+        out_dir: &std::path::Path,
+    ) -> std::io::Result<std::path::PathBuf> {
+        let mut command = Inner::command();
+        clap_complete::generate_to(gen, &mut command, "b3sum", out_dir)
+    }
+
+    generate_to(clap_complete::Shell::Bash, out_dir)?;
+    generate_to(clap_complete::Shell::Elvish, out_dir)?;
+    generate_to(clap_complete::Shell::Fish, out_dir)?;
+    generate_to(clap_complete::Shell::PowerShell, out_dir)?;
+    generate_to(clap_complete::Shell::Zsh, out_dir)?;
+    Ok(())
+}
+
 fn generate_man_page(out_dir: &std::path::Path) -> std::io::Result<()> {
     let command = Inner::command();
 
@@ -54,6 +71,7 @@ fn main() -> std::io::Result<()> {
     let out_dir = std::env::var("OUT_DIR").expect("environment variable `OUT_DIR` not defined");
     let out_dir = std::path::PathBuf::from(out_dir);
 
+    generate_completions(&out_dir)?;
     generate_man_page(&out_dir)?;
     Ok(())
 }

--- a/b3sum/src/cli.rs
+++ b/b3sum/src/cli.rs
@@ -1,4 +1,4 @@
-use clap::Parser;
+use clap::{Parser, ValueHint};
 use std::path::PathBuf;
 
 const DERIVE_KEY_ARG: &str = "derive_key";
@@ -17,6 +17,7 @@ pub struct Inner {
     /// Files to hash, or checkfiles to check
     ///
     /// When no file is given, or when - is given, read standard input.
+    #[arg(value_hint(ValueHint::FilePath))]
     pub file: Vec<PathBuf>,
 
     /// Use the keyed mode, reading the 32-byte key from stdin

--- a/b3sum/src/cli.rs
+++ b/b3sum/src/cli.rs
@@ -1,0 +1,96 @@
+use clap::Parser;
+use std::path::PathBuf;
+
+const DERIVE_KEY_ARG: &str = "derive_key";
+const KEYED_ARG: &str = "keyed";
+const LENGTH_ARG: &str = "length";
+const NO_NAMES_ARG: &str = "no_names";
+const RAW_ARG: &str = "raw";
+const CHECK_ARG: &str = "check";
+
+/// Print or check BLAKE3 checksums.
+///
+/// With no FILE, or when FILE is -, read standard input.
+#[derive(Parser)]
+#[command(version, max_term_width(100))]
+pub struct Inner {
+    /// Files to hash, or checkfiles to check
+    ///
+    /// When no file is given, or when - is given, read standard input.
+    pub file: Vec<PathBuf>,
+
+    /// Use the keyed mode, reading the 32-byte key from stdin
+    #[arg(long, requires("file"))]
+    pub keyed: bool,
+
+    /// Use the key derivation mode, with the given context string
+    ///
+    /// Cannot be used with --keyed.
+    #[arg(long, value_name("CONTEXT"), conflicts_with(KEYED_ARG))]
+    pub derive_key: Option<String>,
+
+    /// The number of output bytes, before hex encoding
+    #[arg(
+        short,
+        long,
+        default_value_t = blake3::OUT_LEN as u64,
+        value_name("LEN")
+    )]
+    pub length: u64,
+
+    /// The starting output byte offset, before hex encoding
+    #[arg(long, default_value_t = 0, value_name("SEEK"))]
+    pub seek: u64,
+
+    /// The maximum number of threads to use
+    ///
+    /// By default, this is the number of logical cores. If this flag is
+    /// omitted, or if its value is 0, RAYON_NUM_THREADS is also respected.
+    #[arg(long, value_name("NUM"))]
+    pub num_threads: Option<usize>,
+
+    /// Disable memory mapping
+    ///
+    /// Currently this also disables multithreading.
+    #[arg(long)]
+    pub no_mmap: bool,
+
+    /// Omit filenames in the output
+    #[arg(long)]
+    pub no_names: bool,
+
+    /// Write raw output bytes to stdout, rather than hex
+    ///
+    /// --no-names is implied. In this case, only a single input is allowed.
+    #[arg(long)]
+    pub raw: bool,
+
+    /// Read BLAKE3 sums from the [FILE]s and check them
+    #[arg(
+        short,
+        long,
+        conflicts_with(DERIVE_KEY_ARG),
+        conflicts_with(KEYED_ARG),
+        conflicts_with(LENGTH_ARG),
+        conflicts_with(RAW_ARG),
+        conflicts_with(NO_NAMES_ARG)
+    )]
+    pub check: bool,
+
+    /// Skip printing OK for each checked file
+    ///
+    /// Must be used with --check.
+    #[arg(long, requires(CHECK_ARG))]
+    pub quiet: bool,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use clap::CommandFactory;
+
+    #[test]
+    fn test_args() {
+        Inner::command().debug_assert();
+    }
+}

--- a/c/blake3_c_rust_bindings/Cargo.toml
+++ b/c/blake3_c_rust_bindings/Cargo.toml
@@ -8,6 +8,7 @@ name = "blake3_c_rust_bindings"
 version = "0.0.0"
 description = "TESTING ONLY Rust bindings for the BLAKE3 C implementation"
 edition = "2021"
+rust-version = "1.56.0"
 
 [features]
 # By default the x86-64 build uses assembly implementations. This feature makes

--- a/reference_impl/Cargo.toml
+++ b/reference_impl/Cargo.toml
@@ -2,6 +2,7 @@
 name = "reference_impl"
 version = "0.0.0"
 edition = "2021"
+rust-version = "1.56.0"
 
 [lib]
 name = "reference_impl"

--- a/rust/guts/Cargo.toml
+++ b/rust/guts/Cargo.toml
@@ -8,6 +8,7 @@ license = "CC0-1.0 OR Apache-2.0"
 documentation = "https://docs.rs/blake3_guts"
 readme = "readme.md"
 edition = "2021"
+rust-version = "1.56.0"
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/test_vectors/Cargo.toml
+++ b/test_vectors/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test_vectors"
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.66.1"
+rust-version = "1.72.0"
 
 [features]
 neon = ["blake3/neon"]

--- a/test_vectors/Cargo.toml
+++ b/test_vectors/Cargo.toml
@@ -2,6 +2,7 @@
 name = "test_vectors"
 version = "0.0.0"
 edition = "2021"
+rust-version = "1.66.1"
 
 [features]
 neon = ["blake3/neon"]

--- a/tools/compiler_version/Cargo.toml
+++ b/tools/compiler_version/Cargo.toml
@@ -2,6 +2,7 @@
 name = "compiler_version"
 version = "0.0.0"
 edition = "2021"
+rust-version = "1.56.0"
 
 [build-dependencies]
 cc = "1.0.50"

--- a/tools/instruction_set_support/Cargo.toml
+++ b/tools/instruction_set_support/Cargo.toml
@@ -2,5 +2,6 @@
 name = "instruction_set_support"
 version = "0.0.0"
 edition = "2021"
+rust-version = "1.56.0"
 
 [dependencies]


### PR DESCRIPTION
With this change, the following files will be generated when building `b3sum`:

- A man page (`b3sum.1`).
- Shell completions files for Bash (`b3sum.bash`), Elvish (`b3sum.elv`), fish (`b3sum.fish`), PowerShell (`_b3sum.ps1`), and Zsh (`_b3sum`).

To find where these files are generated run the following command in `b3sum/`:

```sh
find ./target -path '*/b3sum-*/out' -type d
```

To use these, install them to the destination (e.g., `/usr/share/man/man1` or `/usr/share/bash-completion/completions`).

Also, I set `rust-version` to `Cargo.toml`. This is based on the value of `.github/workflows/ci.yml`. If there is no value, `1.56.0` is set based on `edition`.

This closes #190 and closes #235.