### PR TITLE
Switch to rayon-core for faster build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ std = []
 # `update_rayon` and (in combination with `mmap` below) `update_mmap_rayon`
 # methods, for multithreaded hashing. However, even if this feature is enabled,
 # all other APIs remain single-threaded.
-rayon = ["dep:rayon", "std"]
+rayon = ["dep:rayon-core", "std"]
 
 # The `mmap` feature (disabled by default, but enabled for docs.rs) adds the
 # `update_mmap` and (in combination with `rayon` above) `update_mmap_rayon`
@@ -98,7 +98,7 @@ constant_time_eq = "0.3.0"
 cfg-if = "1.0.0"
 digest = { version = "0.10.1", features = [ "mac" ], optional = true }
 memmap2 = { version = "0.9", optional = true }
-rayon = { version = "1.2.1", optional = true }
+rayon-core = { version = "1.12.1", optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 zeroize = { version = "1", default-features = false, features = ["zeroize_derive"], optional = true }
 

--- a/b3sum/Cargo.lock
+++ b/b3sum/Cargo.lock
@@ -77,7 +77,7 @@ dependencies = [
  "clap",
  "duct",
  "hex",
- "rayon",
+ "rayon-core",
  "tempfile",
  "wild",
 ]
@@ -98,7 +98,7 @@ dependencies = [
  "cfg-if",
  "constant_time_eq",
  "memmap2",
- "rayon",
+ "rayon-core",
 ]
 
 [[package]]
@@ -204,12 +204,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "either"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
-
-[[package]]
 name = "errno"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -296,16 +290,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rayon"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4963ed1bc86e4f3ee217022bd855b297cef07fb9eac5dfa1f788b220b49b3bd"
-dependencies = [
- "either",
- "rayon-core",
 ]
 
 [[package]]

--- a/b3sum/Cargo.toml
+++ b/b3sum/Cargo.toml
@@ -18,7 +18,7 @@ anyhow = "1.0.25"
 blake3 = { version = "1", path = "..", features = ["mmap", "rayon"] }
 clap = { version = "4.0.8", features = ["derive", "wrap_help"] }
 hex = "0.4.0"
-rayon = "1.2.1"
+rayon-core = "1.12.1"
 wild = "2.0.3"
 
 [dev-dependencies]

--- a/b3sum/src/main.rs
+++ b/b3sum/src/main.rs
@@ -475,7 +475,7 @@ fn check_one_checkfile(path: &Path, args: &Args, files_failed: &mut u64) -> Resu
 
 fn main() -> Result<()> {
     let args = Args::parse()?;
-    let mut thread_pool_builder = rayon::ThreadPoolBuilder::new();
+    let mut thread_pool_builder = rayon_core::ThreadPoolBuilder::new();
     if let Some(num_threads) = args.num_threads() {
         thread_pool_builder = thread_pool_builder.num_threads(num_threads);
     }

--- a/src/join.rs
+++ b/src/join.rs
@@ -67,7 +67,7 @@ impl Join for RayonJoin {
         RA: Send,
         RB: Send,
     {
-        rayon::join(oper_a, oper_b)
+        rayon_core::join(oper_a, oper_b)
     }
 }
 


### PR DESCRIPTION
This reduces the build time (with `--timings`) for `blake3` from around 1.7s to 1.3s on a Zen4 7950x.

This helps for situations where one is trying to minimize build time (e.g., for `build-dependencies`).

There seems to be no real downside since the crate doesn't use anything not included in the core rayon crate.

Below I've included the results from `cargo build --timings`.

The improvement doesn't really show up for `b3sum` on my system since other dependencies take long enough that it masks the difference. But it's still probably better to switch them both and maybe in some scenario the difference would surface.

[b3sum-rayon-core.pdf](https://github.com/user-attachments/files/15892931/b3sum-rayon-core.pdf)
[b3sum-rayon.pdf](https://github.com/user-attachments/files/15892932/b3sum-rayon.pdf)
[blake3-rayon-core.pdf](https://github.com/user-attachments/files/15892933/blake3-rayon-core.pdf)
[blake3-rayon.pdf](https://github.com/user-attachments/files/15892934/blake3-rayon.pdf)
