### PR TITLE
build(CMake): support running tests with ctest

### DIFF
--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -168,6 +168,17 @@ else()
   BLAKE3_DISABLE_SIMD()
 endif()
 
+# cmake test support
+if (BLAKE3_BUILD_TESTING)
+  find_package(Python3 REQUIRED)
+  get_target_property(BLAKE3_SOURCES blake3 SOURCES)
+  add_executable(blake3-testing ${BLAKE3_SOURCES} main.c)
+  set_property(TARGET blake3-testing PROPERTY OUTPUT_NAME blake3)
+  target_compile_definitions(blake3-testing PRIVATE BLAKE3_TESTING=1)
+  enable_testing()
+  add_test(test_vectors "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/test.py" WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
+endif()
+
 # cmake install support
 install(FILES blake3.h DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 install(TARGETS blake3 EXPORT blake3-targets)

--- a/c/test.py
+++ b/c/test.py
@@ -2,7 +2,7 @@
 
 from binascii import hexlify
 import json
-from os import path
+from os import getcwd, path
 import subprocess
 
 HERE = path.dirname(__file__)
@@ -11,7 +11,7 @@ TEST_VECTORS = json.load(open(TEST_VECTORS_PATH))
 
 
 def run_blake3(args, input):
-    output = subprocess.run([path.join(HERE, "blake3")] + args,
+    output = subprocess.run([path.join(getcwd(), "blake3")] + args,
                             input=input,
                             stdout=subprocess.PIPE,
                             check=True)


### PR DESCRIPTION
Adds the ability to run the test suite via `ctest`.  Works with both in-source and out-of-source builds.  Respects user flags, and builds SIMD into the tests corresponding to whatever was used to build the library.  Does not interfere with the ability to run tests the old way.