### PR TITLE
Update the license field in b3sum/Cargo.toml

### DIFF
--- a/b3sum/Cargo.toml
+++ b/b3sum/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.5.3"
 authors = ["Jack O'Connor <oconnor663@gmail.com>"]
 description = "a command line implementation of the BLAKE3 hash function"
 repository = "https://github.com/BLAKE3-team/BLAKE3"
-license = "CC0-1.0 OR Apache-2.0"
+license = "CC0-1.0 OR Apache-2.0 OR Apache-2.0 WITH LLVM-exception"
 readme = "README.md"
 edition = "2021"
 


### PR DESCRIPTION
The top-level `Cargo.toml` was updated to include the `OR Apache-2.0 WITH LLVM-exception` option in b5c6017ea74d7a8be302aefd710dd801c91088a2, but the published crate still just has `CC0-1.0 OR Apache-2.0`. This PR would fix that.