### PR TITLE
Add `ConstantTimeEq` support for `Hash`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,16 +41,16 @@ jobs:
       run: cargo run --quiet
       working-directory: ./tools/instruction_set_support
     # Default tests plus Rayon and trait implementations.
-    - run: cargo test --features=rayon,traits-preview,serde,zeroize
+    - run: cargo test --features=rayon,traits-preview,serde,subtle,zeroize
     # Same but with only one thread in the Rayon pool. This can find deadlocks.
     - name: "again with RAYON_NUM_THREADS=1"
-      run: cargo test --features=rayon,traits-preview,serde,zeroize
+      run: cargo test --features=rayon,traits-preview,serde,subtle,zeroize
       env:
         RAYON_NUM_THREADS: 1
     # The mmap feature by itself (update_mmap_rayon is omitted).
     - run: cargo test --features=mmap
     # All public features put together.
-    - run: cargo test --features=mmap,rayon,traits-preview,serde,zeroize
+    - run: cargo test --features=mmap,rayon,traits-preview,serde,subtle,zeroize
     # no_std tests.
     - run: cargo test --no-default-features
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,12 +24,12 @@ neon = []
 # This may become the default in the future.
 wasm32_simd = []
 
-# Enables std::io traits, including impl Write for Hasher, impl Read and Seek
-# for OutputReader, and the Hasher::update_reader method. This feature is
-# enabled by default. (Previously this also controlled runtime CPU feature
-# detection on x86, but now we use the no-std-compatible `cpufeatures` crate
-# for that.)
-std = []
+# This crate uses libstd for std::io trait implementations, and also for
+# runtime CPU feature detection. This feature is enabled by default. If you use
+# --no-default-features, the only way to use the SIMD implementations in this
+# crate is to enable the corresponding instruction sets statically for the
+# entire build, with e.g. RUSTFLAGS="-C target-cpu=native".
+std = ["subtle?/std"]
 
 # The `rayon` feature (disabled by default, but enabled for docs.rs) adds the
 # `update_rayon` and (in combination with `mmap` below) `update_mmap_rayon`
@@ -47,6 +47,9 @@ mmap = ["std", "dep:memmap2"]
 
 # Implement the zeroize::Zeroize trait for types in this crate.
 zeroize = ["dep:zeroize", "arrayvec/zeroize"]
+
+# Enable the `ConstantTimeEq` trait for `Hash` using `subtle` functionality.
+subtle = ["dep:subtle"]
 
 # This crate implements traits from the RustCrypto project, exposed here as the
 # "traits-preview" feature. However, these traits aren't stable, and they're
@@ -118,6 +121,7 @@ digest = { version = "0.10.1", features = ["mac"], optional = true }
 memmap2 = { version = "0.9", optional = true }
 rayon-core = { version = "1.12.1", optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
+subtle = { version = "2.6", default-features = false, optional = true }
 zeroize = { version = "1", default-features = false, optional = true }
 
 [target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,6 +143,8 @@ use arrayvec::{ArrayString, ArrayVec};
 use core::cmp;
 use core::fmt;
 use platform::{Platform, MAX_SIMD_DEGREE, MAX_SIMD_DEGREE_OR_2};
+#[cfg(feature = "subtle")]
+use subtle::ConstantTimeEq;
 #[cfg(feature = "zeroize")]
 use zeroize::Zeroize;
 
@@ -344,6 +346,13 @@ impl Zeroize for Hash {
         // Destructuring to trigger compile error as a reminder to update this impl.
         let Self(bytes) = self;
         bytes.zeroize();
+    }
+}
+
+#[cfg(feature = "subtle")]
+impl ConstantTimeEq for Hash {
+    fn ct_eq(&self, other: &Self) -> subtle::Choice {
+        self.0.ct_eq(&other.0)
     }
 }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -476,6 +476,16 @@ fn reference_hash(input: &[u8]) -> crate::Hash {
     bytes.into()
 }
 
+#[cfg(feature = "subtle")]
+#[test]
+fn test_constanttimeeq() {
+    use subtle::ConstantTimeEq;
+    
+    // Basic check that `ConstantTimeEq` behaves as expected
+    assert_eq!(reference_hash(&[0]).ct_eq(&reference_hash(&[0])).unwrap_u8(), 1);
+    assert_eq!(reference_hash(&[0]).ct_eq(&reference_hash(&[1])).unwrap_u8(), 0);
+}
+
 #[test]
 fn test_compare_update_multiple() {
     // Don't use all the long test cases here, since that's unnecessarily slow


### PR DESCRIPTION
This PR improves the handling of constant-time equality for hashes.

It adds an optional `subtle` feature that implements `ConstantTimeEq` for `Hash`. This trait uses `subtle` functionality under the hood for the trait implementation.

This also opens the door for other useful `subtle` traits elsewhere in the future.