### PR TITLE
Implement constant-time hash ordering

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ neon = []
 # --no-default-features, the only way to use the SIMD implementations in this
 # crate is to enable the corresponding instruction sets statically for the
 # entire build, with e.g. RUSTFLAGS="-C target-cpu=native".
-std = []
+std = ["subtle/std"]
 
 # The `rayon` feature (disabled by default, but enabled for docs.rs) adds the
 # `update_rayon` and (in combination with `mmap` below) `update_mmap_rayon`
@@ -112,6 +112,7 @@ digest = { version = "0.10.1", features = [ "mac" ], optional = true }
 memmap2 = { version = "0.9", optional = true }
 rayon-core = { version = "1.12.1", optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
+subtle = { version = "2.6", default-features = false }
 zeroize = { version = "1", default-features = false, optional = true }
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,8 +136,10 @@ mod join;
 use arrayref::{array_mut_ref, array_ref};
 use arrayvec::{ArrayString, ArrayVec};
 use core::cmp;
+use core::cmp::Ordering;
 use core::fmt;
 use platform::{Platform, MAX_SIMD_DEGREE, MAX_SIMD_DEGREE_OR_2};
+use subtle::{ConditionallySelectable, ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess};
 #[cfg(feature = "zeroize")]
 use zeroize::Zeroize;
 
@@ -340,6 +342,27 @@ impl PartialEq<[u8]> for Hash {
 }
 
 impl Eq for Hash {}
+
+impl PartialOrd for Hash {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Hash {
+    /// This ordering is [lexigraphical](https://doc.rust-lang.org/std/cmp/trait.Ord.html#lexicographical-comparison), and is done in constant time.
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
+        let mut order = Ordering::Equal;
+
+        // Iterate over all corresponding bytes, but only set a non-equal ordering on the first mismatch
+        for (l, r) in self.0.iter().zip(other.0.iter()) {
+            order.conditional_assign(&Ordering::Less, l.ct_lt(r) & order.ct_eq(&Ordering::Equal));
+            order.conditional_assign(&Ordering::Greater, l.ct_gt(r) & order.ct_eq(&Ordering::Equal));
+        }
+
+        order
+    }
+}
 
 impl fmt::Display for Hash {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,7 +1,7 @@
 use crate::{CVBytes, CVWords, IncrementCounter, BLOCK_LEN, CHUNK_LEN, OUT_LEN};
 use arrayref::array_ref;
 use arrayvec::ArrayVec;
-use core::usize;
+use core::{cmp::Ordering, usize};
 use rand::prelude::*;
 
 // Interesting input lengths to run tests on.
@@ -486,6 +486,26 @@ fn reference_hash(input: &[u8]) -> crate::Hash {
     let mut bytes = [0; 32];
     hasher.finalize(&mut bytes);
     bytes.into()
+}
+
+#[test]
+fn test_ordering() {
+    // Test equality behavior
+    let hash = reference_hash(&[0]);
+    assert_eq!(hash.0.cmp(&hash.0), Ordering::Equal);
+    assert_eq!(hash.cmp(&hash), Ordering::Equal);
+
+    // Test less-than behavior
+    let l = reference_hash(&[0]);
+    let r = reference_hash(&[1]);
+    assert_eq!(l.0.cmp(&r.0), Ordering::Less);
+    assert_eq!(l.cmp(&r), Ordering::Less);
+
+    // Test greater-than behavior
+    let l = reference_hash(&[3]);
+    let r = reference_hash(&[4]);
+    assert_eq!(l.0.cmp(&r.0), Ordering::Greater);
+    assert_eq!(l.cmp(&r), Ordering::Greater);
 }
 
 #[test]


### PR DESCRIPTION
This PR implements constant-time ordering (and partial ordering) for `Hash`, but does so differently than #267 and #370.

It uses [`subtle`](https://crates.io/crates/subtle) internally to [lexicographically](https://doc.rust-lang.org/std/cmp/trait.Ord.html#lexicographical-comparison) compare corresponding bytes, being careful not to short circuit. This simplifies the logic considerably.

Note that it does not use `subtle` to implement `PartialEq`; this functionality exists in #419 since it seemed better scoped for a separate PR. However, if #419 is implemented, it will be possible to implement `ConstantTimeGreater` and `ConstantTimeLess` due to the latter requiring a `ConstantTimeEq` trait bound included in that PR.