### PR TITLE
Remove Miri equality workaround function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ features = ["mmap", "rayon", "serde", "zeroize"]
 [dependencies]
 arrayref = "0.3.5"
 arrayvec = { version = "0.7.4", default-features = false }
-constant_time_eq = "0.3.0"
+constant_time_eq = { version = "0.3.1", default-features = false }
 cfg-if = "1.0.0"
 digest = { version = "0.10.1", features = [ "mac" ], optional = true }
 memmap2 = { version = "0.9", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -315,28 +315,10 @@ impl Zeroize for Hash {
     }
 }
 
-// A proper implementation of constant time equality is tricky, and we get it from the
-// constant_time_eq crate instead of rolling our own. However, that crate isn't compatible with
-// Miri, so we roll our own just for that.
-#[cfg(miri)]
-fn constant_time_eq_miri(a: &[u8], b: &[u8]) -> bool {
-    if a.len() != b.len() {
-        return false;
-    }
-    let mut x = 0;
-    for i in 0..a.len() {
-        x |= a[i] ^ b[i];
-    }
-    x == 0
-}
-
 /// This implementation is constant-time.
 impl PartialEq for Hash {
     #[inline]
     fn eq(&self, other: &Hash) -> bool {
-        #[cfg(miri)]
-        return constant_time_eq_miri(&self.0, &other.0);
-        #[cfg(not(miri))]
         constant_time_eq::constant_time_eq_32(&self.0, &other.0)
     }
 }
@@ -345,9 +327,6 @@ impl PartialEq for Hash {
 impl PartialEq<[u8; OUT_LEN]> for Hash {
     #[inline]
     fn eq(&self, other: &[u8; OUT_LEN]) -> bool {
-        #[cfg(miri)]
-        return constant_time_eq_miri(&self.0, other);
-        #[cfg(not(miri))]
         constant_time_eq::constant_time_eq_32(&self.0, other)
     }
 }
@@ -356,9 +335,6 @@ impl PartialEq<[u8; OUT_LEN]> for Hash {
 impl PartialEq<[u8]> for Hash {
     #[inline]
     fn eq(&self, other: &[u8]) -> bool {
-        #[cfg(miri)]
-        return constant_time_eq_miri(&self.0, other);
-        #[cfg(not(miri))]
         constant_time_eq::constant_time_eq(&self.0, other)
     }
 }


### PR DESCRIPTION
When testing with Miri, hash equality is checked using a [workaround function](https://github.com/BLAKE3-team/BLAKE3/blob/479eef82d756221abe9f93077b91ce8cf763c32a/src/lib.rs#L318-L331) that attempts to mimic constant-time functionality. This was done only because the [`constant_time_eq`](https://crates.io/crates/constant_time_eq) crate was not compatible with Miri.

However, thanks to a [PR](https://github.com/cesarb/constant_time_eq/pull/11) by @oconnor663, this incompatibility is no longer present, which means the workaround can be safely removed. This PR does so.