### PR TITLE
build(CMake): Fix pkg-config for absolute CMAKE_INSTALL_*DIR

### DIFF
--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -229,6 +229,31 @@ install(FILES
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/blake3"
 )
 
+# Function for joining paths known from most languages
+#
+# SPDX-License-Identifier: (MIT OR CC0-1.0)
+# Copyright 2020 Jan Tojnar
+# https://github.com/jtojnar/cmake-snips
+#
+# Modelled after Python’s os.path.join
+# https://docs.python.org/3.7/library/os.path.html#os.path.join
+# Windows not supported
+function(join_paths joined_path first_path_segment)
+    set(temp_path "${first_path_segment}")
+    foreach(current_segment IN LISTS ARGN)
+        if(NOT ("${current_segment}" STREQUAL ""))
+            if(IS_ABSOLUTE "${current_segment}")
+                set(temp_path "${current_segment}")
+            else()
+                set(temp_path "${temp_path}/${current_segment}")
+            endif()
+        endif()
+    endforeach()
+    set(${joined_path} "${temp_path}" PARENT_SCOPE)
+endfunction()
+
+join_paths(PKG_CONFIG_INSTALL_LIBDIR "\${prefix}" "${CMAKE_INSTALL_LIBDIR}")
+join_paths(PKG_CONFIG_INSTALL_INCLUDEDIR "\${prefix}" "${CMAKE_INSTALL_INCLUDEDIR}")
 configure_file(libblake3.pc.in libblake3.pc @ONLY)
 install(FILES "${CMAKE_BINARY_DIR}/libblake3.pc"
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")

--- a/c/libblake3.pc.in
+++ b/c/libblake3.pc.in
@@ -1,7 +1,7 @@
 prefix="@CMAKE_INSTALL_PREFIX@"
 exec_prefix="${prefix}"
-libdir="${prefix}/@CMAKE_INSTALL_LIBDIR@"
-includedir="${prefix}/@CMAKE_INSTALL_INCLUDEDIR@"
+libdir="@PKG_CONFIG_INSTALL_LIBDIR@"
+includedir="@PKG_CONFIG_INSTALL_INCLUDEDIR@"
 
 Name: @PROJECT_NAME@
 Description: @PROJECT_DESCRIPTION@


### PR DESCRIPTION
CMAKE_INSTALL_*DIR can be absolute, and in that case ${prefix} should not be prepended.

See https://github.com/jtojnar/cmake-snips/?tab=readme-ov-file#concatenating-paths-when-building-pkg-config-files