### PR TITLE
Add `b3sum --tag` for BSD-style checksums

### DIFF
--- a/b3sum/src/main.rs
+++ b/b3sum/src/main.rs
@@ -17,6 +17,7 @@ const LENGTH_ARG: &str = "length";
 const NO_NAMES_ARG: &str = "no_names";
 const RAW_ARG: &str = "raw";
 const CHECK_ARG: &str = "check";
+const TAG_ARG: &str = "tag";
 
 #[derive(Parser)]
 #[command(version, max_term_width(100))]
@@ -89,6 +90,10 @@ struct Inner {
     /// Must be used with --check.
     #[arg(long, requires(CHECK_ARG))]
     quiet: bool,
+
+    /// Create a BSD-style checksum.
+    #[arg(long, requires(TAG_ARG))]
+    tag: bool,
 }
 
 struct Args {
@@ -160,6 +165,10 @@ impl Args {
 
     fn quiet(&self) -> bool {
         self.inner.quiet
+    }
+
+    fn tag(&self) -> bool {
+        self.inner.tag
     }
 }
 
@@ -391,8 +400,14 @@ fn hash_one_input(path: &Path, args: &Args) -> Result<()> {
     if is_escaped {
         print!("\\");
     }
-    write_hex_output(output, args)?;
-    println!("  {}", filepath_string);
+    if args.tag() {
+        print!("BLAKE3 ({}) = ", filepath_string);
+        write_hex_output(output, args)?;
+        println!("");
+    } else {
+        write_hex_output(output, args)?;
+        println!("  {}", filepath_string);
+    }
     Ok(())
 }
 


### PR DESCRIPTION
This PR implements BSD-style tagged checksums:

```none
> md5sum --tag README.md
MD5 (README.md) = ff09fcad4f884b11b2fe4085f2f429c7
> b2sum --tag README.md
BLAKE2b (README.md) = be06a6f301d49e92141bd98009a467896003e4aec8684cc057abd874913e2800ad48857b6a677bbebb5e33341d8939e62be4e1ae04e97bc4fd2cff8f1fd8d95f
> target/debug/b3sum --tag README.md
BLAKE3 (README.md) = 37805572dd6e1f5ed985a618e13aae25b443f5099e3c680c9f21fec9635667e0
```

It resolves #242.