### PR TITLE
Optionally derive defmt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,9 @@ no_avx2 = []
 no_avx512 = []
 no_neon = []
 
+# the defmt feature enables deriving  [defmt::Format] on the Hash struct
+defmt = ["dep:defmt"]
+
 [package.metadata.docs.rs]
 # Document the rayon/mmap methods and the Serialize/Deserialize/Zeroize impls on docs.rs.
 features = ["mmap", "rayon", "serde", "zeroize"]
@@ -104,6 +107,7 @@ memmap2 = { version = "0.9", optional = true }
 rayon-core = { version = "1.12.1", optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 zeroize = { version = "1", default-features = false, optional = true }
+defmt = { version = "0.3.8", default-features = false, optional = true }
 
 [dev-dependencies]
 hmac = "0.12.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -365,6 +365,15 @@ impl fmt::Debug for Hash {
     }
 }
 
+#[cfg(feature = "defmt")]
+impl defmt::Format for Hash {
+    fn format(&self, fmt: defmt::Formatter) {
+        for v in self.0.iter() {
+            defmt::write!(fmt, "{:02x}", v)
+        }
+    }
+}
+
 /// The error type for [`Hash::from_hex`].
 ///
 /// The `.to_string()` representation of this error currently distinguishes between bad length


### PR DESCRIPTION
Optionally derive [defmt::Format](https://docs.rs/defmt/latest/defmt/trait.Format.html) in the hash struct, feature gated on the `defmt` feature.

This is targeted at using `blake3` in embedded `no_std` contexts.