### PR TITLE
Make portable implementation `const`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,9 @@ jobs:
     - run: cargo test --features= --release
     - run: cargo test --features=prefer_intrinsics --release
     - run: cargo test --features=pure --release
+    # const fn
+    - run: cargo test --features=const
+    - run: cargo test --features=const --release
     # No AVX-512.
     - run: cargo test --features=no_avx512
     - run: cargo test --features=no_avx512,prefer_intrinsics

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,9 @@ wasm32_simd = []
 # entire build, with e.g. RUSTFLAGS="-C target-cpu=native".
 std = []
 
+# This feature enables `const fn` variants of functions, but requires Rust 1.85.0+
+const = []
+
 # The `rayon` feature (disabled by default, but enabled for docs.rs) adds the
 # `update_rayon` and (in combination with `mmap` below) `update_mmap_rayon`
 # methods, for multithreaded hashing. However, even if this feature is enabled,
@@ -114,7 +117,7 @@ arrayref = "0.3.5"
 arrayvec = { version = "0.7.4", default-features = false }
 constant_time_eq = { version = "0.3.1", default-features = false }
 cfg-if = "1.0.0"
-digest = { version = "0.10.1", features = [ "mac" ], optional = true }
+digest = { version = "0.10.1", features = ["mac"], optional = true }
 memmap2 = { version = "0.9", optional = true }
 rayon-core = { version = "1.12.1", optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }

--- a/src/hazmat.rs
+++ b/src/hazmat.rs
@@ -368,7 +368,7 @@ fn test_max_subtree_len() {
 /// # }
 /// ```
 #[inline(always)]
-pub fn left_subtree_len(input_len: u64) -> u64 {
+pub const fn left_subtree_len(input_len: u64) -> u64 {
     debug_assert!(input_len > CHUNK_LEN as u64);
     // Note that .next_power_of_two() is greater than *or equal*.
     ((input_len + 1) / 2).next_power_of_two()
@@ -553,6 +553,15 @@ pub fn hash_derive_key_context(context: &str) -> ContextKey {
     )
     .root_hash()
     .0
+}
+
+/// Hash a [`derive_key`](crate::derive_key) context like [`hash_derive_key_context`], but
+/// `const fn`.
+#[cfg(feature = "const")]
+pub const fn const_hash_derive_key_context(context: &str) -> ContextKey {
+    crate::const_hash_all_at_once(context.as_bytes(), IV, crate::DERIVE_KEY_CONTEXT)
+        .root_hash()
+        .0
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,6 +144,10 @@ use arrayref::{array_mut_ref, array_ref};
 use arrayvec::{ArrayString, ArrayVec};
 use core::cmp;
 use core::fmt;
+#[cfg(feature = "const")]
+use core::mem::MaybeUninit;
+#[cfg(feature = "const")]
+use core::slice;
 use platform::{Platform, MAX_SIMD_DEGREE, MAX_SIMD_DEGREE_OR_2};
 #[cfg(feature = "zeroize")]
 use zeroize::Zeroize;
@@ -203,13 +207,25 @@ const KEYED_HASH: u8 = 1 << 4;
 const DERIVE_KEY_CONTEXT: u8 = 1 << 5;
 const DERIVE_KEY_MATERIAL: u8 = 1 << 6;
 
+// TODO: Replace with `dst.copy_from_slice(src)` when Rust 1.86.0 is stable and used in this crate
+#[cfg(feature = "const")]
+#[inline(always)]
+const fn const_copy_from_slice(mut dst: &mut [u8], mut src: &[u8]) {
+    assert!(dst.len() == src.len());
+    while !src.is_empty() {
+        dst[0] = src[0];
+        dst = dst.split_at_mut(1).1;
+        src = src.split_at(1).1;
+    }
+}
+
 #[inline]
-fn counter_low(counter: u64) -> u32 {
+const fn counter_low(counter: u64) -> u32 {
     counter as u32
 }
 
 #[inline]
-fn counter_high(counter: u64) -> u32 {
+const fn counter_high(counter: u64) -> u32 {
     (counter >> 32) as u32
 }
 
@@ -489,6 +505,60 @@ impl Zeroize for Output {
     }
 }
 
+/// [`Output`] with `const fn` methods
+#[cfg(feature = "const")]
+#[derive(Clone)]
+struct ConstOutput {
+    input_chaining_value: CVWords,
+    block: [u8; 64],
+    block_len: u8,
+    counter: u64,
+    flags: u8,
+}
+
+#[cfg(feature = "const")]
+impl ConstOutput {
+    const fn chaining_value(&self) -> CVBytes {
+        let mut cv = self.input_chaining_value;
+        portable::compress_in_place(
+            &mut cv,
+            &self.block,
+            self.block_len,
+            self.counter,
+            self.flags,
+        );
+        platform::le_bytes_from_words_32(&cv)
+    }
+
+    const fn root_hash(&self) -> Hash {
+        debug_assert!(self.counter == 0);
+        let mut cv = self.input_chaining_value;
+        portable::compress_in_place(&mut cv, &self.block, self.block_len, 0, self.flags | ROOT);
+        Hash(platform::le_bytes_from_words_32(&cv))
+    }
+}
+
+#[cfg(feature = "zeroize")]
+#[cfg(feature = "const")]
+impl Zeroize for ConstOutput {
+    fn zeroize(&mut self) {
+        // Destructuring to trigger compile error as a reminder to update this impl.
+        let Self {
+            input_chaining_value,
+            block,
+            block_len,
+            counter,
+            flags,
+        } = self;
+
+        input_chaining_value.zeroize();
+        block.zeroize();
+        block_len.zeroize();
+        counter.zeroize();
+        flags.zeroize();
+    }
+}
+
 #[derive(Clone)]
 struct ChunkState {
     cv: CVWords,
@@ -622,6 +692,151 @@ impl Zeroize for ChunkState {
     }
 }
 
+/// [`ChunkState`] with `const fn` methods
+#[cfg(feature = "const")]
+#[derive(Clone)]
+struct ConstChunkState {
+    cv: CVWords,
+    chunk_counter: u64,
+    buf: [u8; BLOCK_LEN],
+    buf_len: u8,
+    blocks_compressed: u8,
+    flags: u8,
+}
+
+#[cfg(feature = "const")]
+impl ConstChunkState {
+    const fn new(key: &CVWords, chunk_counter: u64, flags: u8) -> Self {
+        Self {
+            cv: *key,
+            chunk_counter,
+            buf: [0; BLOCK_LEN],
+            buf_len: 0,
+            blocks_compressed: 0,
+            flags,
+        }
+    }
+
+    const fn count(&self) -> usize {
+        BLOCK_LEN * self.blocks_compressed as usize + self.buf_len as usize
+    }
+
+    const fn fill_buf(&mut self, input: &mut &[u8]) {
+        let want = BLOCK_LEN - self.buf_len as usize;
+        let take = if want < input.len() {
+            want
+        } else {
+            input.len()
+        };
+        let output = self
+            .buf
+            .split_at_mut(self.buf_len as usize)
+            .1
+            .split_at_mut(take)
+            .0;
+        const_copy_from_slice(output, input.split_at(take).0);
+        self.buf_len += take as u8;
+        *input = input.split_at(take).1;
+    }
+
+    const fn start_flag(&self) -> u8 {
+        if self.blocks_compressed == 0 {
+            CHUNK_START
+        } else {
+            0
+        }
+    }
+
+    // Try to avoid buffering as much as possible, by compressing directly from
+    // the input slice when full blocks are available.
+    const fn update(&mut self, mut input: &[u8]) -> &mut Self {
+        if self.buf_len > 0 {
+            self.fill_buf(&mut input);
+            if !input.is_empty() {
+                debug_assert!(self.buf_len as usize == BLOCK_LEN);
+                let block_flags = self.flags | self.start_flag(); // borrowck
+                portable::compress_in_place(
+                    &mut self.cv,
+                    &self.buf,
+                    BLOCK_LEN as u8,
+                    self.chunk_counter,
+                    block_flags,
+                );
+                self.buf_len = 0;
+                self.buf = [0; BLOCK_LEN];
+                self.blocks_compressed += 1;
+            }
+        }
+
+        while input.len() > BLOCK_LEN {
+            debug_assert!(self.buf_len == 0);
+            let block_flags = self.flags | self.start_flag(); // borrowck
+            portable::compress_in_place(
+                &mut self.cv,
+                input
+                    .first_chunk::<BLOCK_LEN>()
+                    .expect("Interation only starts when there is at least `BLOCK_LEN` bytes; qed"),
+                BLOCK_LEN as u8,
+                self.chunk_counter,
+                block_flags,
+            );
+            self.blocks_compressed += 1;
+            input = input.split_at(BLOCK_LEN).1;
+        }
+
+        self.fill_buf(&mut input);
+        debug_assert!(input.is_empty());
+        debug_assert!(self.count() <= CHUNK_LEN);
+        self
+    }
+
+    const fn output(&self) -> ConstOutput {
+        let block_flags = self.flags | self.start_flag() | CHUNK_END;
+        ConstOutput {
+            input_chaining_value: self.cv,
+            block: self.buf,
+            block_len: self.buf_len,
+            counter: self.chunk_counter,
+            flags: block_flags,
+        }
+    }
+}
+
+// Don't derive(Debug), because the state may be secret.
+#[cfg(feature = "const")]
+impl fmt::Debug for ConstChunkState {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("ConstChunkState")
+            .field("count", &self.count())
+            .field("chunk_counter", &self.chunk_counter)
+            .field("flags", &self.flags)
+            .finish()
+    }
+}
+
+#[cfg(feature = "const")]
+#[cfg(feature = "zeroize")]
+impl Zeroize for ConstChunkState {
+    fn zeroize(&mut self) {
+        // Destructuring to trigger compile error as a reminder to update this impl.
+        let Self {
+            cv,
+            chunk_counter,
+            buf,
+            buf_len,
+            blocks_compressed,
+            flags,
+        } = self;
+
+        cv.zeroize();
+        chunk_counter.zeroize();
+        buf.zeroize();
+        buf_len.zeroize();
+        blocks_compressed.zeroize();
+        flags.zeroize();
+    }
+}
+
 // IMPLEMENTATION NOTE
 // ===================
 // The recursive function compress_subtree_wide(), implemented below, is the
@@ -647,7 +862,7 @@ pub enum IncrementCounter {
 
 impl IncrementCounter {
     #[inline]
-    fn yes(&self) -> bool {
+    const fn yes(&self) -> bool {
         match self {
             IncrementCounter::Yes => true,
             IncrementCounter::No => false,
@@ -657,7 +872,7 @@ impl IncrementCounter {
 
 // The largest power of two less than or equal to `n`, used in Hasher::update(). This is similar to
 // left_subtree_len(n), but note that left_subtree_len(n) is strictly less than `n`.
-fn largest_power_of_two_leq(n: usize) -> usize {
+const fn largest_power_of_two_leq(n: usize) -> usize {
     ((n / 2) + 1).next_power_of_two()
 }
 
@@ -892,6 +1107,213 @@ fn hash_all_at_once<J: join::Join>(input: &[u8], key: &CVWords, flags: u8) -> Ou
     }
 }
 
+/// `const fn` version of [`compress_chunks_parallel`]
+#[cfg(feature = "const")]
+const fn const_compress_chunks_parallel(
+    input: &[u8],
+    key: &CVWords,
+    chunk_counter: u64,
+    flags: u8,
+    out: &mut [u8],
+) -> usize {
+    debug_assert!(!input.is_empty(), "empty chunks below the root");
+    debug_assert!(input.len() <= MAX_SIMD_DEGREE * CHUNK_LEN);
+
+    let mut chunks = input;
+    let mut chunks_so_far = 0;
+    let mut chunks_array = [MaybeUninit::<&[u8; CHUNK_LEN]>::uninit(); MAX_SIMD_DEGREE];
+    while let Some(chunk) = chunks.first_chunk::<CHUNK_LEN>() {
+        chunks = chunks.split_at(CHUNK_LEN).1;
+        chunks_array[chunks_so_far].write(chunk);
+        chunks_so_far += 1;
+    }
+    portable::hash_many(
+        // SAFETY: Exactly `chunks_so_far` elements of `chunks_array` were initialized above
+        unsafe {
+            slice::from_raw_parts(
+                chunks_array.as_ptr().cast::<&[u8; CHUNK_LEN]>(),
+                chunks_so_far,
+            )
+        },
+        key,
+        chunk_counter,
+        IncrementCounter::Yes,
+        flags,
+        CHUNK_START,
+        CHUNK_END,
+        out,
+    );
+
+    // Hash the remaining partial chunk, if there is one. Note that the empty
+    // chunk (meaning the empty message) is a different codepath.
+    if !chunks.is_empty() {
+        let counter = chunk_counter + chunks_so_far as u64;
+        let mut chunk_state = ConstChunkState::new(key, counter, flags);
+        chunk_state.update(chunks);
+        let out = out
+            .split_at_mut(chunks_so_far * OUT_LEN)
+            .1
+            .split_at_mut(OUT_LEN)
+            .0;
+        let chaining_value = chunk_state.output().chaining_value();
+        const_copy_from_slice(out, &chaining_value);
+        chunks_so_far + 1
+    } else {
+        chunks_so_far
+    }
+}
+
+/// `const fn` version of [`compress_parents_parallel`]
+#[cfg(feature = "const")]
+const fn const_compress_parents_parallel(
+    child_chaining_values: &[u8],
+    key: &CVWords,
+    flags: u8,
+    out: &mut [u8],
+) -> usize {
+    debug_assert!(
+        child_chaining_values.len() % OUT_LEN == 0,
+        "wacky hash bytes"
+    );
+    let num_children = child_chaining_values.len() / OUT_LEN;
+    debug_assert!(num_children >= 2, "not enough children");
+    debug_assert!(num_children <= 2 * MAX_SIMD_DEGREE_OR_2, "too many");
+
+    let mut parents = child_chaining_values;
+    // Use MAX_SIMD_DEGREE_OR_2 rather than MAX_SIMD_DEGREE here, because of
+    // the requirements of compress_subtree_wide().
+    let mut parents_so_far = 0;
+    let mut parents_array = [MaybeUninit::<&[u8; BLOCK_LEN]>::uninit(); MAX_SIMD_DEGREE_OR_2];
+    while let Some(parent) = parents.first_chunk::<BLOCK_LEN>() {
+        parents = parents.split_at(BLOCK_LEN).1;
+        parents_array[parents_so_far].write(parent);
+        parents_so_far += 1;
+    }
+    portable::hash_many(
+        // SAFETY: Exactly `parents_so_far` elements of `parents_array` were initialized above
+        unsafe {
+            slice::from_raw_parts(
+                parents_array.as_ptr().cast::<&[u8; BLOCK_LEN]>(),
+                parents_so_far,
+            )
+        },
+        key,
+        0, // Parents always use counter 0.
+        IncrementCounter::No,
+        flags | PARENT,
+        0, // Parents have no start flags.
+        0, // Parents have no end flags.
+        out,
+    );
+
+    // If there's an odd child left over, it becomes an output.
+    if !parents.is_empty() {
+        let out = out
+            .split_at_mut(parents_so_far * OUT_LEN)
+            .1
+            .split_at_mut(OUT_LEN)
+            .0;
+        const_copy_from_slice(out, parents);
+        parents_so_far + 1
+    } else {
+        parents_so_far
+    }
+}
+
+/// `const fn` version of [`compress_subtree_wide`]
+#[cfg(feature = "const")]
+const fn const_compress_subtree_wide(
+    input: &[u8],
+    key: &CVWords,
+    chunk_counter: u64,
+    flags: u8,
+    out: &mut [u8],
+) -> usize {
+    if input.len() <= CHUNK_LEN {
+        return const_compress_chunks_parallel(input, key, chunk_counter, flags, out);
+    }
+
+    let (left, right) = input.split_at(hazmat::left_subtree_len(input.len() as u64) as usize);
+    let right_chunk_counter = chunk_counter + (left.len() / CHUNK_LEN) as u64;
+
+    // Make space for the child outputs. Here we use MAX_SIMD_DEGREE_OR_2 to
+    // account for the special case of returning 2 outputs when the SIMD degree
+    // is 1.
+    let mut cv_array = [0; 2 * MAX_SIMD_DEGREE_OR_2 * OUT_LEN];
+    let degree = if left.len() == CHUNK_LEN { 1 } else { 2 };
+    let (left_out, right_out) = cv_array.split_at_mut(degree * OUT_LEN);
+
+    // Recurse!
+    let left_n = const_compress_subtree_wide(left, key, chunk_counter, flags, left_out);
+    let right_n = const_compress_subtree_wide(right, key, right_chunk_counter, flags, right_out);
+
+    // The special case again. If simd_degree=1, then we'll have left_n=1 and
+    // right_n=1. Rather than compressing them into a single output, return
+    // them directly, to make sure we always have at least two outputs.
+    debug_assert!(left_n == degree);
+    debug_assert!(right_n >= 1 && right_n <= left_n);
+    if left_n == 1 {
+        const_copy_from_slice(
+            out.split_at_mut(2 * OUT_LEN).0,
+            cv_array.split_at(2 * OUT_LEN).0,
+        );
+        return 2;
+    }
+
+    // Otherwise, do one layer of parent node compression.
+    let num_children = left_n + right_n;
+    const_compress_parents_parallel(cv_array.split_at(num_children * OUT_LEN).0, key, flags, out)
+}
+
+/// `const fn` version of [`compress_subtree_to_parent_node`]
+#[cfg(feature = "const")]
+const fn const_compress_subtree_to_parent_node(
+    input: &[u8],
+    key: &CVWords,
+    chunk_counter: u64,
+    flags: u8,
+) -> [u8; BLOCK_LEN] {
+    debug_assert!(input.len() > CHUNK_LEN);
+    let mut cv_array = [0; MAX_SIMD_DEGREE_OR_2 * OUT_LEN];
+    let mut num_cvs = const_compress_subtree_wide(input, &key, chunk_counter, flags, &mut cv_array);
+    debug_assert!(num_cvs >= 2);
+
+    // If MAX_SIMD_DEGREE is greater than 2 and there's enough input,
+    // compress_subtree_wide() returns more than 2 chaining values. Condense
+    // them into 2 by forming parent nodes repeatedly.
+    let mut out_array = [0; MAX_SIMD_DEGREE_OR_2 * OUT_LEN / 2];
+    while num_cvs > 2 {
+        let cv_slice = cv_array.split_at(num_cvs * OUT_LEN).0;
+        num_cvs = const_compress_parents_parallel(cv_slice, key, flags, &mut out_array);
+        const_copy_from_slice(
+            cv_array.split_at_mut(num_cvs * OUT_LEN).0,
+            out_array.split_at(num_cvs * OUT_LEN).0,
+        );
+    }
+    *cv_array
+        .first_chunk::<BLOCK_LEN>()
+        .expect("`cv_array` is larger than `BLOCK_LEN`; qed")
+}
+
+/// `const fn` version of [`hash_all_at_once`]
+#[cfg(feature = "const")]
+const fn const_hash_all_at_once(input: &[u8], key: &CVWords, flags: u8) -> ConstOutput {
+    // If the whole subtree is one chunk, hash it directly with a ChunkState.
+    if input.len() <= CHUNK_LEN {
+        return ConstChunkState::new(key, 0, flags).update(input).output();
+    }
+
+    // Otherwise construct an Output object from the parent node returned by
+    // compress_subtree_to_parent_node().
+    ConstOutput {
+        input_chaining_value: *key,
+        block: const_compress_subtree_to_parent_node(input, key, 0, flags),
+        block_len: BLOCK_LEN as u8,
+        counter: 0,
+        flags: flags | PARENT,
+    }
+}
+
 /// The default hash function.
 ///
 /// For an incremental version that accepts multiple writes, see [`Hasher::new`],
@@ -913,6 +1335,16 @@ fn hash_all_at_once<J: join::Join>(input: &[u8], key: &CVWords, flags: u8) -> Ou
 /// [`Hasher::update_rayon`](struct.Hasher.html#method.update_rayon).
 pub fn hash(input: &[u8]) -> Hash {
     hash_all_at_once::<join::SerialJoin>(input, IV, 0).root_hash()
+}
+
+/// Hashing function like [`hash`], but `const fn`.
+///
+/// ```
+/// const HASH: blake3::Hash = blake3::const_hash(b"foo");
+/// ```
+#[cfg(feature = "const")]
+pub const fn const_hash(input: &[u8]) -> Hash {
+    const_hash_all_at_once(input, IV, 0).root_hash()
 }
 
 /// The keyed hash function.
@@ -943,6 +1375,13 @@ pub fn hash(input: &[u8]) -> Hash {
 pub fn keyed_hash(key: &[u8; KEY_LEN], input: &[u8]) -> Hash {
     let key_words = platform::words_from_le_bytes_32(key);
     hash_all_at_once::<join::SerialJoin>(input, &key_words, KEYED_HASH).root_hash()
+}
+
+/// The keyed hash function like [`keyed_hash`]. but `const fn`.
+#[cfg(feature = "const")]
+pub const fn const_keyed_hash(key: &[u8; KEY_LEN], input: &[u8]) -> Hash {
+    let key_words = platform::words_from_le_bytes_32(key);
+    const_hash_all_at_once(input, &key_words, KEYED_HASH).root_hash()
 }
 
 /// The key derivation function.
@@ -998,6 +1437,16 @@ pub fn derive_key(context: &str, key_material: &[u8]) -> [u8; OUT_LEN] {
     let context_key = hazmat::hash_derive_key_context(context);
     let context_key_words = platform::words_from_le_bytes_32(&context_key);
     hash_all_at_once::<join::SerialJoin>(key_material, &context_key_words, DERIVE_KEY_MATERIAL)
+        .root_hash()
+        .0
+}
+
+/// The key derivation function like [`derive_key`], but `const fn`.
+#[cfg(feature = "const")]
+pub const fn const_derive_key(context: &str, key_material: &[u8]) -> [u8; OUT_LEN] {
+    let context_key = hazmat::const_hash_derive_key_context(context);
+    let context_key_words = platform::words_from_le_bytes_32(&context_key);
+    const_hash_all_at_once(key_material, &context_key_words, DERIVE_KEY_MATERIAL)
         .root_hash()
         .0
 }

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -1,5 +1,4 @@
 use crate::{portable, CVWords, IncrementCounter, BLOCK_LEN};
-use arrayref::{array_mut_ref, array_ref};
 
 cfg_if::cfg_if! {
     if #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {
@@ -514,74 +513,96 @@ pub fn sse2_detected() -> bool {
     false
 }
 
+macro_rules! extract_u32_from_byte_chunks {
+    ($src:ident, $chunk_index:literal) => {
+        u32::from_le_bytes([
+            $src[$chunk_index * 4 + 0],
+            $src[$chunk_index * 4 + 1],
+            $src[$chunk_index * 4 + 2],
+            $src[$chunk_index * 4 + 3],
+        ])
+    };
+}
+
+macro_rules! store_u32_to_by_chunks {
+    ($src:ident, $dst:ident, $chunk_index:literal) => {
+        [
+            $dst[$chunk_index * 4 + 0],
+            $dst[$chunk_index * 4 + 1],
+            $dst[$chunk_index * 4 + 2],
+            $dst[$chunk_index * 4 + 3],
+        ] = $src[$chunk_index].to_le_bytes();
+    };
+}
+
 #[inline(always)]
-pub fn words_from_le_bytes_32(bytes: &[u8; 32]) -> [u32; 8] {
+pub const fn words_from_le_bytes_32(bytes: &[u8; 32]) -> [u32; 8] {
     let mut out = [0; 8];
-    out[0] = u32::from_le_bytes(*array_ref!(bytes, 0 * 4, 4));
-    out[1] = u32::from_le_bytes(*array_ref!(bytes, 1 * 4, 4));
-    out[2] = u32::from_le_bytes(*array_ref!(bytes, 2 * 4, 4));
-    out[3] = u32::from_le_bytes(*array_ref!(bytes, 3 * 4, 4));
-    out[4] = u32::from_le_bytes(*array_ref!(bytes, 4 * 4, 4));
-    out[5] = u32::from_le_bytes(*array_ref!(bytes, 5 * 4, 4));
-    out[6] = u32::from_le_bytes(*array_ref!(bytes, 6 * 4, 4));
-    out[7] = u32::from_le_bytes(*array_ref!(bytes, 7 * 4, 4));
+    out[0] = extract_u32_from_byte_chunks!(bytes, 0);
+    out[1] = extract_u32_from_byte_chunks!(bytes, 1);
+    out[2] = extract_u32_from_byte_chunks!(bytes, 2);
+    out[3] = extract_u32_from_byte_chunks!(bytes, 3);
+    out[4] = extract_u32_from_byte_chunks!(bytes, 4);
+    out[5] = extract_u32_from_byte_chunks!(bytes, 5);
+    out[6] = extract_u32_from_byte_chunks!(bytes, 6);
+    out[7] = extract_u32_from_byte_chunks!(bytes, 7);
     out
 }
 
 #[inline(always)]
-pub fn words_from_le_bytes_64(bytes: &[u8; 64]) -> [u32; 16] {
+pub const fn words_from_le_bytes_64(bytes: &[u8; 64]) -> [u32; 16] {
     let mut out = [0; 16];
-    out[0] = u32::from_le_bytes(*array_ref!(bytes, 0 * 4, 4));
-    out[1] = u32::from_le_bytes(*array_ref!(bytes, 1 * 4, 4));
-    out[2] = u32::from_le_bytes(*array_ref!(bytes, 2 * 4, 4));
-    out[3] = u32::from_le_bytes(*array_ref!(bytes, 3 * 4, 4));
-    out[4] = u32::from_le_bytes(*array_ref!(bytes, 4 * 4, 4));
-    out[5] = u32::from_le_bytes(*array_ref!(bytes, 5 * 4, 4));
-    out[6] = u32::from_le_bytes(*array_ref!(bytes, 6 * 4, 4));
-    out[7] = u32::from_le_bytes(*array_ref!(bytes, 7 * 4, 4));
-    out[8] = u32::from_le_bytes(*array_ref!(bytes, 8 * 4, 4));
-    out[9] = u32::from_le_bytes(*array_ref!(bytes, 9 * 4, 4));
-    out[10] = u32::from_le_bytes(*array_ref!(bytes, 10 * 4, 4));
-    out[11] = u32::from_le_bytes(*array_ref!(bytes, 11 * 4, 4));
-    out[12] = u32::from_le_bytes(*array_ref!(bytes, 12 * 4, 4));
-    out[13] = u32::from_le_bytes(*array_ref!(bytes, 13 * 4, 4));
-    out[14] = u32::from_le_bytes(*array_ref!(bytes, 14 * 4, 4));
-    out[15] = u32::from_le_bytes(*array_ref!(bytes, 15 * 4, 4));
+    out[0] = extract_u32_from_byte_chunks!(bytes, 0);
+    out[1] = extract_u32_from_byte_chunks!(bytes, 1);
+    out[2] = extract_u32_from_byte_chunks!(bytes, 2);
+    out[3] = extract_u32_from_byte_chunks!(bytes, 3);
+    out[4] = extract_u32_from_byte_chunks!(bytes, 4);
+    out[5] = extract_u32_from_byte_chunks!(bytes, 5);
+    out[6] = extract_u32_from_byte_chunks!(bytes, 6);
+    out[7] = extract_u32_from_byte_chunks!(bytes, 7);
+    out[8] = extract_u32_from_byte_chunks!(bytes, 8);
+    out[9] = extract_u32_from_byte_chunks!(bytes, 9);
+    out[10] = extract_u32_from_byte_chunks!(bytes, 10);
+    out[11] = extract_u32_from_byte_chunks!(bytes, 11);
+    out[12] = extract_u32_from_byte_chunks!(bytes, 12);
+    out[13] = extract_u32_from_byte_chunks!(bytes, 13);
+    out[14] = extract_u32_from_byte_chunks!(bytes, 14);
+    out[15] = extract_u32_from_byte_chunks!(bytes, 15);
     out
 }
 
 #[inline(always)]
-pub fn le_bytes_from_words_32(words: &[u32; 8]) -> [u8; 32] {
+pub const fn le_bytes_from_words_32(words: &[u32; 8]) -> [u8; 32] {
     let mut out = [0; 32];
-    *array_mut_ref!(out, 0 * 4, 4) = words[0].to_le_bytes();
-    *array_mut_ref!(out, 1 * 4, 4) = words[1].to_le_bytes();
-    *array_mut_ref!(out, 2 * 4, 4) = words[2].to_le_bytes();
-    *array_mut_ref!(out, 3 * 4, 4) = words[3].to_le_bytes();
-    *array_mut_ref!(out, 4 * 4, 4) = words[4].to_le_bytes();
-    *array_mut_ref!(out, 5 * 4, 4) = words[5].to_le_bytes();
-    *array_mut_ref!(out, 6 * 4, 4) = words[6].to_le_bytes();
-    *array_mut_ref!(out, 7 * 4, 4) = words[7].to_le_bytes();
+    store_u32_to_by_chunks!(words, out, 0);
+    store_u32_to_by_chunks!(words, out, 1);
+    store_u32_to_by_chunks!(words, out, 2);
+    store_u32_to_by_chunks!(words, out, 3);
+    store_u32_to_by_chunks!(words, out, 4);
+    store_u32_to_by_chunks!(words, out, 5);
+    store_u32_to_by_chunks!(words, out, 6);
+    store_u32_to_by_chunks!(words, out, 7);
     out
 }
 
 #[inline(always)]
-pub fn le_bytes_from_words_64(words: &[u32; 16]) -> [u8; 64] {
+pub const fn le_bytes_from_words_64(words: &[u32; 16]) -> [u8; 64] {
     let mut out = [0; 64];
-    *array_mut_ref!(out, 0 * 4, 4) = words[0].to_le_bytes();
-    *array_mut_ref!(out, 1 * 4, 4) = words[1].to_le_bytes();
-    *array_mut_ref!(out, 2 * 4, 4) = words[2].to_le_bytes();
-    *array_mut_ref!(out, 3 * 4, 4) = words[3].to_le_bytes();
-    *array_mut_ref!(out, 4 * 4, 4) = words[4].to_le_bytes();
-    *array_mut_ref!(out, 5 * 4, 4) = words[5].to_le_bytes();
-    *array_mut_ref!(out, 6 * 4, 4) = words[6].to_le_bytes();
-    *array_mut_ref!(out, 7 * 4, 4) = words[7].to_le_bytes();
-    *array_mut_ref!(out, 8 * 4, 4) = words[8].to_le_bytes();
-    *array_mut_ref!(out, 9 * 4, 4) = words[9].to_le_bytes();
-    *array_mut_ref!(out, 10 * 4, 4) = words[10].to_le_bytes();
-    *array_mut_ref!(out, 11 * 4, 4) = words[11].to_le_bytes();
-    *array_mut_ref!(out, 12 * 4, 4) = words[12].to_le_bytes();
-    *array_mut_ref!(out, 13 * 4, 4) = words[13].to_le_bytes();
-    *array_mut_ref!(out, 14 * 4, 4) = words[14].to_le_bytes();
-    *array_mut_ref!(out, 15 * 4, 4) = words[15].to_le_bytes();
+    store_u32_to_by_chunks!(words, out, 0);
+    store_u32_to_by_chunks!(words, out, 1);
+    store_u32_to_by_chunks!(words, out, 2);
+    store_u32_to_by_chunks!(words, out, 3);
+    store_u32_to_by_chunks!(words, out, 4);
+    store_u32_to_by_chunks!(words, out, 5);
+    store_u32_to_by_chunks!(words, out, 6);
+    store_u32_to_by_chunks!(words, out, 7);
+    store_u32_to_by_chunks!(words, out, 8);
+    store_u32_to_by_chunks!(words, out, 9);
+    store_u32_to_by_chunks!(words, out, 10);
+    store_u32_to_by_chunks!(words, out, 11);
+    store_u32_to_by_chunks!(words, out, 12);
+    store_u32_to_by_chunks!(words, out, 13);
+    store_u32_to_by_chunks!(words, out, 14);
+    store_u32_to_by_chunks!(words, out, 15);
     out
 }

--- a/src/portable.rs
+++ b/src/portable.rs
@@ -3,178 +3,229 @@ use crate::{
     OUT_LEN,
 };
 
-#[inline(always)]
-fn g(state: &mut [u32; 16], a: usize, b: usize, c: usize, d: usize, x: u32, y: u32) {
-    state[a] = state[a].wrapping_add(state[b]).wrapping_add(x);
-    state[d] = (state[d] ^ state[a]).rotate_right(16);
-    state[c] = state[c].wrapping_add(state[d]);
-    state[b] = (state[b] ^ state[c]).rotate_right(12);
-    state[a] = state[a].wrapping_add(state[b]).wrapping_add(y);
-    state[d] = (state[d] ^ state[a]).rotate_right(8);
-    state[c] = state[c].wrapping_add(state[d]);
-    state[b] = (state[b] ^ state[c]).rotate_right(7);
+/// This macro matches the functions below and conditionally adds `const` before `fn` to avoid code
+/// duplication
+macro_rules! maybe_const_fn {
+    ($(#[$attr:meta])* $vis:vis fn $name:ident (
+        $($arg_name:ident : $arg_type:ty),* $(,)?
+    ) $(-> $ret:ty)? $body:block) => {
+        #[cfg(feature = "const")]
+        $(#[$attr])* $vis const fn $name(
+            $($arg_name: $arg_type),*
+        ) $(-> $ret)* $body
+
+        #[cfg(not(feature = "const"))]
+        $(#[$attr])* $vis fn $name(
+            $($arg_name: $arg_type),*
+        ) $(-> $ret)* $body
+    };
+
+    ($(#[$attr:meta])* $vis:vis fn $name:ident<const N: usize> (
+        $($arg_name:ident : $arg_type:ty),* $(,)?
+    ) $(-> $ret:ty)? $body:block) => {
+        #[cfg(feature = "const")]
+        $(#[$attr])* $vis const fn $name<const N: usize>(
+            $($arg_name: $arg_type),*
+        ) $(-> $ret)* $body
+
+        #[cfg(not(feature = "const"))]
+        $(#[$attr])* $vis fn $name<const N: usize>(
+            $($arg_name: $arg_type),*
+        ) $(-> $ret)* $body
+    };
 }
 
-#[inline(always)]
-fn round(state: &mut [u32; 16], msg: &[u32; 16], round: usize) {
-    // Select the message schedule based on the round.
-    let schedule = MSG_SCHEDULE[round];
-
-    // Mix the columns.
-    g(state, 0, 4, 8, 12, msg[schedule[0]], msg[schedule[1]]);
-    g(state, 1, 5, 9, 13, msg[schedule[2]], msg[schedule[3]]);
-    g(state, 2, 6, 10, 14, msg[schedule[4]], msg[schedule[5]]);
-    g(state, 3, 7, 11, 15, msg[schedule[6]], msg[schedule[7]]);
-
-    // Mix the diagonals.
-    g(state, 0, 5, 10, 15, msg[schedule[8]], msg[schedule[9]]);
-    g(state, 1, 6, 11, 12, msg[schedule[10]], msg[schedule[11]]);
-    g(state, 2, 7, 8, 13, msg[schedule[12]], msg[schedule[13]]);
-    g(state, 3, 4, 9, 14, msg[schedule[14]], msg[schedule[15]]);
-}
-
-#[inline(always)]
-fn compress_pre(
-    cv: &CVWords,
-    block: &[u8; BLOCK_LEN],
-    block_len: u8,
-    counter: u64,
-    flags: u8,
-) -> [u32; 16] {
-    let block_words = crate::platform::words_from_le_bytes_64(block);
-
-    let mut state = [
-        cv[0],
-        cv[1],
-        cv[2],
-        cv[3],
-        cv[4],
-        cv[5],
-        cv[6],
-        cv[7],
-        IV[0],
-        IV[1],
-        IV[2],
-        IV[3],
-        counter_low(counter),
-        counter_high(counter),
-        block_len as u32,
-        flags as u32,
-    ];
-
-    round(&mut state, &block_words, 0);
-    round(&mut state, &block_words, 1);
-    round(&mut state, &block_words, 2);
-    round(&mut state, &block_words, 3);
-    round(&mut state, &block_words, 4);
-    round(&mut state, &block_words, 5);
-    round(&mut state, &block_words, 6);
-
-    state
-}
-
-pub fn compress_in_place(
-    cv: &mut CVWords,
-    block: &[u8; BLOCK_LEN],
-    block_len: u8,
-    counter: u64,
-    flags: u8,
-) {
-    let state = compress_pre(cv, block, block_len, counter, flags);
-
-    cv[0] = state[0] ^ state[8];
-    cv[1] = state[1] ^ state[9];
-    cv[2] = state[2] ^ state[10];
-    cv[3] = state[3] ^ state[11];
-    cv[4] = state[4] ^ state[12];
-    cv[5] = state[5] ^ state[13];
-    cv[6] = state[6] ^ state[14];
-    cv[7] = state[7] ^ state[15];
-}
-
-pub fn compress_xof(
-    cv: &CVWords,
-    block: &[u8; BLOCK_LEN],
-    block_len: u8,
-    counter: u64,
-    flags: u8,
-) -> [u8; 64] {
-    let mut state = compress_pre(cv, block, block_len, counter, flags);
-    state[0] ^= state[8];
-    state[1] ^= state[9];
-    state[2] ^= state[10];
-    state[3] ^= state[11];
-    state[4] ^= state[12];
-    state[5] ^= state[13];
-    state[6] ^= state[14];
-    state[7] ^= state[15];
-    state[8] ^= cv[0];
-    state[9] ^= cv[1];
-    state[10] ^= cv[2];
-    state[11] ^= cv[3];
-    state[12] ^= cv[4];
-    state[13] ^= cv[5];
-    state[14] ^= cv[6];
-    state[15] ^= cv[7];
-    crate::platform::le_bytes_from_words_64(&state)
-}
-
-fn hash1<const N: usize>(
-    input: &[u8; N],
-    key: &CVWords,
-    counter: u64,
-    flags: u8,
-    flags_start: u8,
-    flags_end: u8,
-    out: &mut CVBytes,
-) {
-    debug_assert!(N % BLOCK_LEN == 0, "uneven blocks");
-    let mut cv = *key;
-    let mut block_flags = flags | flags_start;
-    let mut slice = input.as_slice();
-    while slice.len() >= BLOCK_LEN {
-        let block;
-        (block, slice) = slice.split_at(BLOCK_LEN);
-        if slice.is_empty() {
-            block_flags |= flags_end;
-        }
-        let block = {
-            let ptr = block.as_ptr() as *const [u8; BLOCK_LEN];
-            // SAFETY: Sliced off correct length above
-            unsafe { &*ptr }
-        };
-
-        compress_in_place(&mut cv, block, BLOCK_LEN as u8, counter, block_flags);
-        block_flags = flags;
+maybe_const_fn! {
+    #[inline(always)]
+    fn g(state: &mut [u32; 16], a: usize, b: usize, c: usize, d: usize, x: u32, y: u32) {
+        state[a] = state[a].wrapping_add(state[b]).wrapping_add(x);
+        state[d] = (state[d] ^ state[a]).rotate_right(16);
+        state[c] = state[c].wrapping_add(state[d]);
+        state[b] = (state[b] ^ state[c]).rotate_right(12);
+        state[a] = state[a].wrapping_add(state[b]).wrapping_add(y);
+        state[d] = (state[d] ^ state[a]).rotate_right(8);
+        state[c] = state[c].wrapping_add(state[d]);
+        state[b] = (state[b] ^ state[c]).rotate_right(7);
     }
-    *out = crate::platform::le_bytes_from_words_32(&cv);
 }
 
-pub fn hash_many<const N: usize>(
-    mut inputs: &[&[u8; N]],
-    key: &CVWords,
-    mut counter: u64,
-    increment_counter: IncrementCounter,
-    flags: u8,
-    flags_start: u8,
-    flags_end: u8,
-    mut out: &mut [u8],
-) {
-    debug_assert!(out.len() >= inputs.len() * OUT_LEN, "out too short");
-    while !inputs.is_empty() {
-        let input;
-        (input, inputs) = inputs.split_first().expect("Not empty; qed");
-        let o;
-        (o, out) = out.split_at_mut(OUT_LEN);
-        let o = {
-            let ptr = o.as_mut_ptr() as *mut [u8; OUT_LEN];
-            // SAFETY: Sliced off correct length above
-            unsafe { &mut *ptr }
-        };
+maybe_const_fn! {
+    #[inline(always)]
+    fn round(state: &mut [u32; 16], msg: &[u32; 16], round: usize) {
+        // Select the message schedule based on the round.
+        let schedule = MSG_SCHEDULE[round];
 
-        hash1(input, key, counter, flags, flags_start, flags_end, o);
-        if increment_counter.yes() {
-            counter += 1;
+        // Mix the columns.
+        g(state, 0, 4, 8, 12, msg[schedule[0]], msg[schedule[1]]);
+        g(state, 1, 5, 9, 13, msg[schedule[2]], msg[schedule[3]]);
+        g(state, 2, 6, 10, 14, msg[schedule[4]], msg[schedule[5]]);
+        g(state, 3, 7, 11, 15, msg[schedule[6]], msg[schedule[7]]);
+
+        // Mix the diagonals.
+        g(state, 0, 5, 10, 15, msg[schedule[8]], msg[schedule[9]]);
+        g(state, 1, 6, 11, 12, msg[schedule[10]], msg[schedule[11]]);
+        g(state, 2, 7, 8, 13, msg[schedule[12]], msg[schedule[13]]);
+        g(state, 3, 4, 9, 14, msg[schedule[14]], msg[schedule[15]]);
+    }
+}
+
+maybe_const_fn! {
+    #[inline(always)]
+    fn compress_pre(
+        cv: &CVWords,
+        block: &[u8; BLOCK_LEN],
+        block_len: u8,
+        counter: u64,
+        flags: u8,
+    ) -> [u32; 16] {
+        let block_words = crate::platform::words_from_le_bytes_64(block);
+
+        let mut state = [
+            cv[0],
+            cv[1],
+            cv[2],
+            cv[3],
+            cv[4],
+            cv[5],
+            cv[6],
+            cv[7],
+            IV[0],
+            IV[1],
+            IV[2],
+            IV[3],
+            counter_low(counter),
+            counter_high(counter),
+            block_len as u32,
+            flags as u32,
+        ];
+
+        round(&mut state, &block_words, 0);
+        round(&mut state, &block_words, 1);
+        round(&mut state, &block_words, 2);
+        round(&mut state, &block_words, 3);
+        round(&mut state, &block_words, 4);
+        round(&mut state, &block_words, 5);
+        round(&mut state, &block_words, 6);
+
+        state
+    }
+}
+
+maybe_const_fn! {
+    pub fn compress_in_place(
+        cv: &mut CVWords,
+        block: &[u8; BLOCK_LEN],
+        block_len: u8,
+        counter: u64,
+        flags: u8,
+    ) {
+        let state = compress_pre(cv, block, block_len, counter, flags);
+
+        cv[0] = state[0] ^ state[8];
+        cv[1] = state[1] ^ state[9];
+        cv[2] = state[2] ^ state[10];
+        cv[3] = state[3] ^ state[11];
+        cv[4] = state[4] ^ state[12];
+        cv[5] = state[5] ^ state[13];
+        cv[6] = state[6] ^ state[14];
+        cv[7] = state[7] ^ state[15];
+    }
+}
+
+maybe_const_fn! {
+    pub fn compress_xof(
+        cv: &CVWords,
+        block: &[u8; BLOCK_LEN],
+        block_len: u8,
+        counter: u64,
+        flags: u8,
+    ) -> [u8; 64] {
+        let mut state = compress_pre(cv, block, block_len, counter, flags);
+        state[0] ^= state[8];
+        state[1] ^= state[9];
+        state[2] ^= state[10];
+        state[3] ^= state[11];
+        state[4] ^= state[12];
+        state[5] ^= state[13];
+        state[6] ^= state[14];
+        state[7] ^= state[15];
+        state[8] ^= cv[0];
+        state[9] ^= cv[1];
+        state[10] ^= cv[2];
+        state[11] ^= cv[3];
+        state[12] ^= cv[4];
+        state[13] ^= cv[5];
+        state[14] ^= cv[6];
+        state[15] ^= cv[7];
+        crate::platform::le_bytes_from_words_64(&state)
+    }
+}
+
+maybe_const_fn! {
+    fn hash1<const N: usize>(
+        input: &[u8; N],
+        key: &CVWords,
+        counter: u64,
+        flags: u8,
+        flags_start: u8,
+        flags_end: u8,
+        out: &mut CVBytes,
+    ) {
+        debug_assert!(N % BLOCK_LEN == 0, "uneven blocks");
+        let mut cv = *key;
+        let mut block_flags = flags | flags_start;
+        let mut slice = input.as_slice();
+        while slice.len() >= BLOCK_LEN {
+            let block;
+            (block, slice) = slice.split_at(BLOCK_LEN);
+            if slice.is_empty() {
+                block_flags |= flags_end;
+            }
+            let block = {
+                let ptr = block.as_ptr() as *const [u8; BLOCK_LEN];
+                // SAFETY: Sliced off correct length above
+                unsafe { &*ptr }
+            };
+
+            compress_in_place(&mut cv, block, BLOCK_LEN as u8, counter, block_flags);
+            block_flags = flags;
+        }
+        *out = crate::platform::le_bytes_from_words_32(&cv);
+    }
+}
+
+maybe_const_fn! {
+    pub fn hash_many<const N: usize>(
+        inputs: &[&[u8; N]],
+        key: &CVWords,
+        counter: u64,
+        increment_counter: IncrementCounter,
+        flags: u8,
+        flags_start: u8,
+        flags_end: u8,
+        out: &mut [u8],
+    ) {
+        // These assignments are for simpler `maybe_const_fn!` usage
+        let mut inputs = inputs;
+        let mut counter = counter;
+        let mut out = out;
+
+        debug_assert!(out.len() >= inputs.len() * OUT_LEN, "out too short");
+        while !inputs.is_empty() {
+            let input;
+            (input, inputs) = inputs.split_first().expect("Not empty; qed");
+            let o;
+            (o, out) = out.split_at_mut(OUT_LEN);
+            let o = {
+                let ptr = o.as_mut_ptr() as *mut [u8; OUT_LEN];
+                // SAFETY: Sliced off correct length above
+                unsafe { &mut *ptr }
+            };
+
+            hash1(input, key, counter, flags, flags_start, flags_end, o);
+            if increment_counter.yes() {
+                counter += 1;
+            }
         }
     }
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -351,6 +351,12 @@ fn test_compare_reference_impl() {
             // all at once
             let test_out = crate::hash(input);
             assert_eq!(test_out, *array_ref!(expected_out, 0, 32));
+            #[cfg(feature = "const")]
+            {
+                // all at once const
+                let test_out = crate::const_hash(input);
+                assert_eq!(test_out, *array_ref!(expected_out, 0, 32));
+            }
             // incremental
             let mut hasher = crate::Hasher::new();
             hasher.update(input);
@@ -380,6 +386,12 @@ fn test_compare_reference_impl() {
             // all at once
             let test_out = crate::keyed_hash(&TEST_KEY, input);
             assert_eq!(test_out, *array_ref!(expected_out, 0, 32));
+            #[cfg(feature = "const")]
+            {
+                // all at once const
+                let test_out = crate::const_keyed_hash(&TEST_KEY, input);
+                assert_eq!(test_out, *array_ref!(expected_out, 0, 32));
+            }
             // incremental
             let mut hasher = crate::Hasher::new_keyed(&TEST_KEY);
             hasher.update(input);
@@ -410,6 +422,12 @@ fn test_compare_reference_impl() {
             // all at once
             let test_out = crate::derive_key(context, input);
             assert_eq!(test_out, expected_out[..32]);
+            #[cfg(feature = "const")]
+            {
+                // all at once const
+                let test_out = crate::const_derive_key(context, input);
+                assert_eq!(test_out, expected_out[..32]);
+            }
             // incremental
             let mut hasher = crate::Hasher::new_derive_key(context);
             hasher.update(input);


### PR DESCRIPTION
I was going to use BLAKE3 in `const` environment, but it doesn't support such use case yet.

This relatively small PR refactors portable implementation to make it work in `const` environment.

There is a bit of trivially verifiable `unsafe` due to nicer APIs not yet available in `const` environment, but these all work on stable.

`arrayref` were hard to read and used slicing that is not compatible with `const`, so I replaced it with a couple simple macros where it was necessary and left other usages as is.

---

UPD: I decided to implement the whole thing, added `const_hash`, `const_keyed_hash` and `const_derive_key` functions by copying the originals and modifying them to use `const fn` portable implementation.

I didn't add `ConstHasher`, though it is possible too if someone needs it.

Resolves https://github.com/BLAKE3-team/BLAKE3/issues/440