### PR TITLE
add missing MAYBE_UNUSED

### DIFF
--- a/c/blake3_dispatch.c
+++ b/c/blake3_dispatch.c
@@ -234,6 +234,7 @@ void blake3_xof_many(const uint32_t cv[8],
   }
 #if defined(IS_X86)
   const enum cpu_feature features = get_cpu_features();
+  MAYBE_UNUSED(features);
 #if !defined(_WIN32) && !defined(BLAKE3_NO_AVX512)
   if (features & AVX512VL) {
     blake3_xof_many_avx512(cv, block, block_len, counter, flags, out, outblocks);


### PR DESCRIPTION
caused
```
/Users/runner/work/php-src/php-src/ext/hash/blake3/upstream_blake3/c/blake3_dispatch.c:237:26: error: unused variable 'features' [-Werror,-Wunused-variable]
  const enum cpu_feature features = get_cpu_features();
```
on 32bit x86-32 linux builds.