### PR TITLE
Implement llfio-based memory-mapped IO for C lib

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,7 +319,7 @@ jobs:
 
   # CMake build test (Library only).
   cmake_current_build:
-    name: CMake ${{ matrix.os }} CC=${{ matrix.toolchain.cc }} CXX=${{ matrix.toolchain.cxx }} TBB=${{ matrix.use_tbb }}
+    name: CMake ${{ matrix.os }} CC=${{ matrix.toolchain.cc }} CXX=${{ matrix.toolchain.cxx }} LLFIO=${{ matrix.use_llfio }} TBB=${{ matrix.use_tbb }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -333,6 +333,7 @@ jobs:
           { cc: clang-cl, cxx: clang-cl },
           { cc: gcc, cxx: g++ },
         ]
+        use_llfio: [OFF, ON]
         use_tbb: [OFF, ON]
         exclude:
           - os: macOS-latest
@@ -346,6 +347,9 @@ jobs:
           - os: windows-latest
             toolchain: { cc: clang, cxx: clang++ }
             use_tbb: ON
+          - os: windows-latest
+            toolchain: { cc: gcc, cxx: g++ }
+            use_llfio: ON
           - os: windows-latest
             toolchain: { cc: gcc, cxx: g++ }
             use_tbb: ON
@@ -368,7 +372,7 @@ jobs:
       - name: CMake generation, build, install
         run: |
           ${{ matrix.os != 'windows-latest' || '& "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/Common7/Tools/Launch-VsDevShell.ps1" -Arch amd64 -SkipAutomaticLocation' }}
-          cmake -S c -B c/build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/target -DCMAKE_C_COMPILER=${{ matrix.toolchain.cc }} -DCMAKE_CXX_COMPILER=${{ matrix.toolchain.cxx }} -DBLAKE3_USE_TBB=${{ matrix.use_tbb }} -DBLAKE3_FETCH_TBB=${{ matrix.os == 'windows-latest' && 'YES' || 'NO' }} -DBLAKE3_EXAMPLES=ON
+          cmake -S c -B c/build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/target -DCMAKE_C_COMPILER=${{ matrix.toolchain.cc }} -DCMAKE_CXX_COMPILER=${{ matrix.toolchain.cxx }} -DBLAKE3_USE_LLFIO=${{ matrix.use_llfio }} -DBLAKE3_FETCH_LLFIO=YES -DBLAKE3_USE_TBB=${{ matrix.use_tbb }} -DBLAKE3_FETCH_TBB=${{ matrix.os == 'windows-latest' && 'YES' || 'NO' }} -DBLAKE3_EXAMPLES=ON
           cmake --build c/build --target install
   cmake_3-9_build:
     name: CMake 3.9.6 ubuntu-latest

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -17,6 +17,12 @@ project(libblake3
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
+option(BLAKE3_USE_LLFIO "Enable llfio mmap support" OFF)
+set(BLAKE3_USE_LLFIO_DIR "" CACHE STRING "CMake subdirectory for existing llfio")
+set(BLAKE3_USE_LLFIO_TARGET "llfio_hl" CACHE STRING "Library target to use for llfio")
+option(BLAKE3_USE_LLFIO_EXPERIMENTAL_STATUS_CODE "Enable llfio experimental SG14 status code support" ON)
+option(BLAKE3_FETCH_LLFIO "Allow fetching llfio from GitHub if not found on system" OFF)
+
 option(BLAKE3_USE_TBB "Enable oneTBB parallelism" OFF)
 option(BLAKE3_FETCH_TBB "Allow fetching oneTBB from GitHub if not found on system" OFF)
 
@@ -217,6 +223,26 @@ else()
   message(FATAL_ERROR "BLAKE3_SIMD_TYPE is set to an unknown value: '${BLAKE3_SIMD_TYPE}'")
 endif()
 
+if(BLAKE3_USE_LLFIO)
+  if(NOT TARGET llfio::hl)
+    message(FATAL_ERROR
+      "llfio not found:\n"
+      "- Specify BLAKE3_USE_LLFIO_DIR to add llfio from a given directory\n"
+      "- Specify BLAKE3_FETCH_LLFIO to automatically fetch and build llfio\n"
+    )
+  else()
+    target_link_libraries(blake3 PRIVATE ${BLAKE3_USE_LLFIO_TARGET})
+    if(WIN32)
+      # Needed on Win32 to convert NTSTATUS codes to Win32 codes
+      target_link_libraries(blake3 PRIVATE ntdll)
+    endif()
+    target_compile_definitions(blake3 PUBLIC BLAKE3_USE_LLFIO)
+    target_sources(blake3 PRIVATE blake3_llfio.cpp)
+    # Disable pre-compiled headers; avoids issues with includes mixing C and C++ 
+    set_property(TARGET blake3 PROPERTY DISABLE_PRECOMPILE_HEADERS ON)
+  endif()
+endif()
+
 if(BLAKE3_USE_TBB)
   find_package(TBB 2021.11.0 QUIET)
   if(NOT TBB_FOUND AND NOT TARGET TBB::tbb)
@@ -242,7 +268,7 @@ if(BLAKE3_USE_TBB)
   endif()
 endif()
 
-if(BLAKE3_USE_TBB)
+if(BLAKE3_USE_LLFIO OR BLAKE3_USE_TBB)
   # Define some scratch variables for building appropriate flags per compiler
   if(CMAKE_VERSION VERSION_LESS 3.12)
     set(APPEND BLAKE3_CXX_STANDARD_FLAGS_GNU -std=c++20)
@@ -342,6 +368,7 @@ add_feature_info("AMD64 assembly" BLAKE3_SIMD_AMD64_ASM "The library uses hand w
 add_feature_info("x86 SIMD intrinsics" BLAKE3_SIMD_X86_INTRINSICS "The library uses x86 SIMD intrinsics.")
 add_feature_info("NEON SIMD intrinsics" BLAKE3_SIMD_NEON_INTRINSICS "The library uses NEON SIMD intrinsics.")
 add_feature_info("oneTBB parallelism" BLAKE3_USE_TBB "The library uses oneTBB parallelism.")
+add_feature_info("llfio mmap support" BLAKE3_USE_LLFIO "The library uses llfio for mmap support.")
 feature_summary(WHAT ENABLED_FEATURES)
 
 if(BLAKE3_EXAMPLES)

--- a/c/README.md
+++ b/c/README.md
@@ -272,6 +272,7 @@ cmake --build . --target install
 
 The following options are available when compiling with CMake:
 
+- `BLAKE3_USE_LLFIO`: Enable llfio memory-mapped IO (Requires a C++20 capable compiler)
 - `BLAKE3_USE_TBB`: Enable oneTBB parallelism (Requires a C++20 capable compiler)
 - `BLAKE3_FETCH_TBB`: Allow fetching oneTBB from GitHub (only if not found on system)
 - `BLAKE3_EXAMPLES`: Compile and install example programs

--- a/c/blake3.c
+++ b/c/blake3.c
@@ -472,8 +472,8 @@ INLINE void hasher_push_cv(blake3_hasher *self, uint8_t new_cv[BLAKE3_OUT_LEN],
   self->cv_stack_len += 1;
 }
 
-INLINE void blake3_hasher_update_base(blake3_hasher *self, const void *input,
-                                      size_t input_len, bool use_tbb) {
+void blake3_hasher_update_base(blake3_hasher *self, const void *input,
+                               size_t input_len, bool use_tbb) {
   // Explicitly checking for zero avoids causing UB by passing a null pointer
   // to memcpy. This comes up in practice with things like:
   //   std::vector<uint8_t> v;

--- a/c/blake3.h
+++ b/c/blake3.h
@@ -27,6 +27,12 @@
 #endif
 
 #ifdef __cplusplus
+#define BLAKE3_NOEXCEPT noexcept
+#else
+#define BLAKE3_NOEXCEPT
+#endif
+
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -69,9 +75,17 @@ BLAKE3_API void blake3_hasher_init_derive_key_raw(blake3_hasher *self, const voi
                                                   size_t context_len);
 BLAKE3_API void blake3_hasher_update(blake3_hasher *self, const void *input,
                                      size_t input_len);
+#if defined(BLAKE3_USE_LLFIO)
+BLAKE3_API int blake3_hasher_update_mmap(blake3_hasher *self,
+                                         const char *path) BLAKE3_NOEXCEPT;
+#endif // BLAKE3_USE_LLFIO
 #if defined(BLAKE3_USE_TBB)
 BLAKE3_API void blake3_hasher_update_tbb(blake3_hasher *self, const void *input,
                                          size_t input_len);
+#if defined(BLAKE3_USE_LLFIO)
+BLAKE3_API int blake3_hasher_update_mmap_tbb(blake3_hasher *self,
+                                             const char *path) BLAKE3_NOEXCEPT;
+#endif // BLAKE3_USE_LLFIO
 #endif // BLAKE3_USE_TBB
 BLAKE3_API void blake3_hasher_finalize(const blake3_hasher *self, uint8_t *out,
                                        size_t out_len);

--- a/c/blake3_impl.h
+++ b/c/blake3_impl.h
@@ -32,12 +32,6 @@ enum blake3_flags {
 #define INLINE static inline __attribute__((always_inline))
 #endif
 
-#ifdef __cplusplus
-#define NOEXCEPT noexcept
-#else
-#define NOEXCEPT
-#endif
-
 #if (defined(__x86_64__) || defined(_M_X64)) && !defined(_M_ARM64EC)
 #define IS_X86
 #define IS_X86_64
@@ -234,8 +228,12 @@ BLAKE3_PRIVATE void blake3_compress_subtree_wide_join_tbb(
     uint8_t *l_cvs, size_t *l_n,
     // right-hand side params
     const uint8_t *r_input, size_t r_input_len, uint64_t r_chunk_counter,
-    uint8_t *r_cvs, size_t *r_n) NOEXCEPT;
+    uint8_t *r_cvs, size_t *r_n) BLAKE3_NOEXCEPT;
 #endif
+
+BLAKE3_PRIVATE void blake3_hasher_update_base(blake3_hasher *self,
+                                              const void *input,
+                                              size_t input_len, bool use_tbb);
 
 // Declarations for implementation-specific functions.
 void blake3_compress_in_place_portable(uint32_t cv[8],

--- a/c/blake3_llfio.cpp
+++ b/c/blake3_llfio.cpp
@@ -1,0 +1,142 @@
+#include <array>
+#include <utility>
+#include <variant>
+
+#include <llfio.hpp>
+#include <outcome.hpp>
+#include <quickcpplib/signal_guard.hpp>
+
+#include "blake3.h"
+#include "blake3_impl.h"
+
+#ifdef _WIN32
+#include <windows.h>
+#include <winternl.h>
+#endif
+
+namespace llfio = LLFIO_V2_NAMESPACE;
+namespace quickcpp = QUICKCPPLIB_NAMESPACE;
+
+namespace {
+template <class... Ts> struct overloads : Ts... {
+  using Ts::operator()...;
+};
+// NOTE: Deduction guide only needed for Apple Clang.
+template <class... Ts> overloads(Ts...) -> overloads<Ts...>;
+
+template <class T> auto error_code(T &&error) -> long long {
+  const auto value = error.value();
+#if LLFIO_EXPERIMENTAL_STATUS_CODE
+  return value.sc;
+#elif !defined(_WIN32)
+  return value;
+#else
+  return NT_ERROR(value) ? RtlNtStatusToDosError(value) : value;
+#endif
+}
+
+namespace {
+const quickcpp::signal_guard::signalc_set guarded_signals =
+    quickcpp::signal_guard::signalc_set::undefined_memory_access // SIGBUS
+    | quickcpp::signal_guard::signalc_set::segmentation_fault    // SIGSEGV
+    ;
+
+// Install and enable global signal handlers for specified signals.
+static const quickcpp::signal_guard::signal_guard_install
+    signal_guard_install(guarded_signals);
+} // namespace
+} // namespace
+
+INLINE auto copy_wide(blake3_hasher *self, llfio::file_handle &file) noexcept
+    -> llfio::result<void> {
+  std::array<std::byte, 65536> buffer;
+  std::uint64_t offset = 0;
+  while (true) {
+    std::uint64_t bytes_read = 0;
+    if (auto result = llfio::read(file, offset, {buffer})) {
+      bytes_read = result.assume_value();
+      blake3_hasher_update(self, buffer.data(), bytes_read);
+      offset += bytes_read;
+    } else {
+#ifdef _WIN32
+      if (error_code(result.assume_error()) == ERROR_HANDLE_EOF) {
+        break;
+      }
+#endif
+      if (result.assume_error() != llfio::errc::interrupted) {
+        return std::move(result).as_failure();
+      }
+
+      continue;
+    }
+
+    if (bytes_read < buffer.size()) {
+      break;
+    }
+  }
+  return llfio::success();
+}
+
+INLINE auto maybe_mmap_path(char const *path) noexcept -> llfio::result<
+    std::variant<llfio::mapped_file_handle, llfio::file_handle>> {
+  const auto base_dir = llfio::path_handle{};
+  if (auto mmap = llfio::mapped_file(base_dir, path); mmap.has_value()) {
+    return std::move(mmap).value();
+  }
+  // Memory mapping may fail so fall back to normal file reading if necessary.
+  OUTCOME_TRY(auto file, llfio::file(base_dir, path));
+  return file;
+}
+
+INLINE int blake3_hasher_update_mmap_base(blake3_hasher *self, char const *path,
+                                          bool use_tbb) noexcept {
+  auto result = [=]() -> llfio::result<void> {
+    OUTCOME_TRY(auto handle, maybe_mmap_path(path));
+    OUTCOME_TRY(std::visit(
+        overloads{
+            [=](llfio::mapped_file_handle &mmap) -> llfio::result<void> {
+              OUTCOME_TRY(const auto extent, mmap.maximum_extent());
+              const auto result = quickcpp::signal_guard::signal_guard(
+                  guarded_signals,
+                  [&]() -> bool {
+                    const auto data = mmap.address();
+                    blake3_hasher_update_base(self, data, extent, use_tbb);
+                    return true;
+                  },
+                  [=]([[maybe_unused]] const auto *info) -> bool {
+                    return false;
+                  });
+              if (!result) {
+                return llfio::errc::io_error;
+              }
+              return llfio::success();
+            },
+            [=](llfio::file_handle &file) -> llfio::result<void> {
+              OUTCOME_TRY(copy_wide(self, file));
+              return llfio::success();
+            },
+        },
+        handle));
+    return llfio::success();
+  }();
+
+  if (result.has_error()) {
+    return error_code(result.assume_error());
+  }
+
+  return 0;
+}
+
+extern "C" int blake3_hasher_update_mmap(blake3_hasher *self,
+                                         char const *path) noexcept {
+  bool use_tbb = false;
+  return blake3_hasher_update_mmap_base(self, path, use_tbb);
+}
+
+#if defined(BLAKE3_USE_TBB)
+extern "C" int blake3_hasher_update_mmap_tbb(blake3_hasher *self,
+                                             char const *path) noexcept {
+  bool use_tbb = true;
+  return blake3_hasher_update_mmap_base(self, path, use_tbb);
+}
+#endif // BLAKE3_USE_TBB

--- a/c/cmake/BLAKE3/Examples.cmake
+++ b/c/cmake/BLAKE3/Examples.cmake
@@ -4,3 +4,10 @@ if(NOT WIN32)
   target_link_libraries(blake3-example PRIVATE blake3)
   install(TARGETS blake3-example)
 endif()
+
+if(BLAKE3_USE_LLFIO)
+  add_executable(blake3-example-mmap
+    example-mmap.c)
+  target_link_libraries(blake3-example-mmap PRIVATE blake3)
+  install(TARGETS blake3-example-mmap)
+endif()

--- a/c/dependencies/CMakeLists.txt
+++ b/c/dependencies/CMakeLists.txt
@@ -1,3 +1,6 @@
+if(BLAKE3_USE_LLFIO)
+    add_subdirectory(llfio)
+endif()
 if(BLAKE3_USE_TBB)
     add_subdirectory(tbb)
 endif()

--- a/c/dependencies/llfio/CMakeLists.txt
+++ b/c/dependencies/llfio/CMakeLists.txt
@@ -1,0 +1,52 @@
+if(WIN32 AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  message(FATAL_ERROR "BLAKE3_USE_LLFIO requires building with Clang or MSVC on Windows")
+  set(BLAKE3_USE_LLFIO OFF)
+endif()
+
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.11)
+  include(FetchContent)
+
+  if(NOT TARGET ${BLAKE3_USE_LLFIO_TARGET} AND BLAKE3_USE_LLFIO)
+    set(CMAKE_C_STANDARD 99)
+    set(CMAKE_C_EXTENSIONS OFF)
+
+    set(CMAKE_CXX_STANDARD 20)
+    set(CMAKE_CXX_EXTENSIONS OFF)
+
+    if(BLAKE3_FETCH_LLFIO)
+      FetchContent_Declare(
+        llfio
+        GIT_REPOSITORY https://github.com/ned14/llfio
+        GIT_TAG 20250206
+        GIT_SHALLOW TRUE
+        EXCLUDE_FROM_ALL
+      )
+      FetchContent_MakeAvailable(llfio)
+    elseif(${BLAKE3_USE_LLFIO_DIR})
+      add_subdirectory(${BLAKE3_USE_LLFIO_DIR} EXCLUDE_FROM_ALL)
+    endif()
+  endif()
+
+  if(TARGET ${BLAKE3_USE_LLFIO_TARGET})
+    if(${BLAKE3_USE_LLFIO_TARGET} STREQUAL "llfio_hl") 
+      if(WIN32 AND NOT ${BLAKE3_USE_LLFIO_EXPERIMENTAL_STATUS_CODE})
+        message(FATAL_ERROR 
+          "llfio as a header library without SG14 status codes is an unsupported configuration on Windows.\n"
+          "Select to link llfio as a dynamic or static library instead by setting `BLAKE3_USE_LLFIO_TARGET` to \"llfio_dl\" or \"llfio_sl\".")
+      endif()
+    endif()
+    if(${BLAKE3_USE_LLFIO_EXPERIMENTAL_STATUS_CODE})
+      target_compile_definitions(${BLAKE3_USE_LLFIO_TARGET}
+        INTERFACE
+          # Enable experimental SG14 `status_code` to work around unreliable Windows semantics.
+          # See here for more details: https://github.com/ned14/llfio/blob/develop/Build.md
+          LLFIO_EXPERIMENTAL_STATUS_CODE)
+    endif()
+    if(WIN32)
+      target_compile_definitions(${BLAKE3_USE_LLFIO_TARGET}
+        INTERFACE
+          # Silence excessive CXX20 deprecation warning noise from MSVC
+          _SILENCE_ALL_CXX20_DEPRECATION_WARNINGS)
+    endif()
+  endif()
+endif()

--- a/c/example-mmap.c
+++ b/c/example-mmap.c
@@ -1,0 +1,39 @@
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "blake3.h"
+
+int main(int argc, char **argv) {
+  if (argc != 2) {
+    fprintf(stderr, "USAGE: blake3-example-mmap <path>\n");
+    exit(1);
+  }
+
+  // Initialize the hasher.
+  blake3_hasher hasher;
+  blake3_hasher_init(&hasher);
+
+  // Update hash from file at path via mmap.
+#ifdef BLAKE3_USE_TBB
+  errno = blake3_hasher_update_mmap_tbb(&hasher, argv[1]);
+#else
+  errno = blake3_hasher_update_mmap(&hasher, argv[1]);
+#endif
+  // Check if any errors occurred because mmap may fail.
+  if (errno != 0) {
+    perror("ERROR");
+    exit(1);
+  }
+
+  // Finalize the hash. BLAKE3_OUT_LEN is the default output length, 32 bytes.
+  uint8_t output[BLAKE3_OUT_LEN];
+  blake3_hasher_finalize(&hasher, output, BLAKE3_OUT_LEN);
+
+  // Print the hash as hexadecimal.
+  for (size_t i = 0; i < BLAKE3_OUT_LEN; i++) {
+    printf("%02x", output[i]);
+  }
+  printf("\n");
+  return 0;
+}


### PR DESCRIPTION
This PR is a follow up to #445 and implements [llfio](https://github.com/ned14/llfio)-based memory-mapped IO.

A new example using this functionality has been added as `example-mmap.c`.

The example can be compiled, installed, and run with the following commands:

```bash
# Also add -DBLAKE3_FETCH_TBB=1 if compiling on Windows
$ cmake -S c -B c/build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=c/build/install -DBLAKE3_USE_LLFIO=1 -DBLAKE3_USE_TBB=1 -DBLAKE3_EXAMPLES=1
$ cmake --build c/build --target install
$ c/build/install/bin/blake3-example-mmap <path>
```