### PR TITLE
fix build.rs errors on win7 targets

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -80,7 +80,8 @@ fn is_big_endian() -> bool {
 // disabled by old compilers.)
 fn is_windows_msvc() -> bool {
     // Some targets are only two components long, so check in steps.
-    target_components()[1] == "pc"
+    let second_component = &target_components()[1];
+    (second_component == "pc" || second_component == "win7")
         && target_components()[2] == "windows"
         && target_components()[3] == "msvc"
 }
@@ -91,7 +92,8 @@ fn is_windows_msvc() -> bool {
 // ends with `-gnullvm`.
 fn is_windows_gnu() -> bool {
     // Some targets are only two components long, so check in steps.
-    target_components()[1] == "pc"
+    let second_component = &target_components()[1];
+    (second_component == "pc" || second_component == "win7")
         && target_components()[2] == "windows"
         && target_components()[3] != "msvc"
 }


### PR DESCRIPTION
When trying to compile on the x86_64-win7-windows-msvc target, we're getting the following error:
It seems that the missing string "pc" is causing the build script to think we're building for Unix.


warning: blake3@1.4.1: The C compiler "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\VC\\Tools\\MSVC\\14.29.30133\\bin\\HostX64\\x64\\cl.exe" does not support -mavx512f and -mavx512vl.
warning: blake3@1.4.1: cl : Command line warning D9002 : ignoring unknown option '-std=c11'
warning: blake3@1.4.1: cl : Command line warning D9024 : unrecognized source file type 'c/blake3_sse2_x86-64_unix.S', object file assumed
warning: blake3@1.4.1: cl : Command line warning D9027 : source file 'c/blake3_sse2_x86-64_unix.S' ignored
  CFLAGS = None
  running: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\VC\\Tools\\MSVC\\14.29.30133\\bin\\HostX64\\x64\\cl.exe" "-nologo" "-MT" "-O1" "-Z7" "-Brepro" "-W4" "-std=c11" "-FoC:\\Users\\ContainerAdministrator\\AppData\\Local\\Temp\\66ea281f-7371-429e-8787-507757fb1b83\\x86_64-win7-windows-msvc\\release\\build\\blake3-15c154c91f03ef71\\out\\c/blake3_sse2_x86-64_unix.o" "-c" "c/blake3_sse2_x86-64_unix.S"
  cargo:warning=cl : Command line warning D9002 : ignoring unknown option '-std=c11'

  cargo:warning=cl : Command line warning D9024 : unrecognized source file type 'c/blake3_sse2_x86-64_unix.S', object file assumed

  cargo:warning=cl : Command line warning D9027 : source file 'c/blake3_sse2_x86-64_unix.S' ignored

  cl : Command line warning D9021 : no action performed
  exit code: 0
  running: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\VC\\Tools\\MSVC\\14.29.30133\\bin\\HostX64\\x64\\cl.exe" "-nologo" "-MT" "-O1" "-Z7" "-Brepro" "-W4" "-std=c11" "-FoC:\\Users\\ContainerAdministrator\\AppData\\Local\\Temp\\66ea281f-7371-429e-8787-507757fb1b83\\x86_64-win7-windows-msvc\\release\\build\\blake3-15c154c91f03ef71\\out\\c/blake3_sse41_x86-64_unix.o" "-c" "c/blake3_sse41_x86-64_unix.S"
  cargo:warning=cl : Command line warning D9002 : ignoring unknown option '-std=c11'

  cargo:warning=cl : Command line warning D9024 : unrecognized source file type 'c/blake3_sse41_x86-64_unix.S', object file assumed

  cargo:warning=cl : Command line warning D9027 : source file 'c/blake3_sse41_x86-64_unix.S' ignored

  cl : Command line warning D9021 : no action performed
  exit code: 0
  running: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\VC\\Tools\\MSVC\\14.29.30133\\bin\\HostX64\\x64\\cl.exe" "-nologo" "-MT" "-O1" "-Z7" "-Brepro" "-W4" "-std=c11" "-FoC:\\Users\\ContainerAdministrator\\AppData\\Local\\Temp\\66ea281f-7371-429e-8787-507757fb1b83\\x86_64-win7-windows-msvc\\release\\build\\blake3-15c154c91f03ef71\\out\\c/blake3_avx2_x86-64_unix.o" "-c" "c/blake3_avx2_x86-64_unix.S"
  cargo:warning=cl : Command line warning D9002 : ignoring unknown option '-std=c11'

  cargo:warning=cl : Command line warning D9024 : unrecognized source file type 'c/blake3_avx2_x86-64_unix.S', object file assumed

  cargo:warning=cl : Command line warning D9027 : source file 'c/blake3_avx2_x86-64_unix.S' ignored

  cl : Command line warning D9021 : no action performed
  exit code: 0
  cargo:rerun-if-env-changed=AR_x86_64-win7-windows-msvc
  AR_x86_64-win7-windows-msvc = None
  cargo:rerun-if-env-changed=AR_x86_64_win7_windows_msvc
  AR_x86_64_win7_windows_msvc = None
  cargo:rerun-if-env-changed=TARGET_AR
  TARGET_AR = None
  cargo:rerun-if-env-changed=AR
  AR = None
  cargo:rerun-if-env-changed=ARFLAGS_x86_64-win7-windows-msvc
  ARFLAGS_x86_64-win7-windows-msvc = None
  cargo:rerun-if-env-changed=ARFLAGS_x86_64_win7_windows_msvc
  ARFLAGS_x86_64_win7_windows_msvc = None
  cargo:rerun-if-env-changed=TARGET_ARFLAGS
  TARGET_ARFLAGS = None
  cargo:rerun-if-env-changed=ARFLAGS
  ARFLAGS = None
  running: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\VC\\Tools\\MSVC\\14.29.30133\\bin\\HostX64\\x64\\lib.exe" "-out:C:\\Users\\ContainerAdministrator\\AppData\\Local\\Temp\\66ea281f-7371-429e-8787-507757fb1b83\\x86_64-win7-windows-msvc\\release\\build\\blake3-15c154c91f03ef71\\out\\libblake3_sse2_sse41_avx2_assembly.a" "-nologo" "C:\\Users\\ContainerAdministrator\\AppData\\Local\\Temp\\66ea281f-7371-429e-8787-507757fb1b83\\x86_64-win7-windows-msvc\\release\\build\\blake3-15c154c91f03ef71\\out\\c/blake3_sse2_x86-64_unix.o" "C:\\Users\\ContainerAdministrator\\AppData\\Local\\Temp\\66ea281f-7371-429e-8787-507757fb1b83\\x86_64-win7-windows-msvc\\release\\build\\blake3-15c154c91f03ef71\\out\\c/blake3_sse41_x86-64_unix.o" "C:\\Users\\ContainerAdministrator\\AppData\\Local\\Temp\\66ea281f-7371-429e-8787-507757fb1b83\\x86_64-win7-windows-msvc\\release\\build\\blake3-15c154c91f03ef71\\out\\c/blake3_avx2_x86-64_unix.o"
  LINK : fatal error LNK1181: cannot open input file 'C:\Users\ContainerAdministrator\AppData\Local\Temp\66ea281f-7371-429e-8787-507757fb1b83\x86_64-win7-windows-msvc\release\build\blake3-15c154c91f03ef71\out\c\blake3_sse2_x86-64_unix.o'
  exit code: 1181

  --- stderr
