### PR TITLE
add the `hazmat` module

### DIFF
--- a/b3sum/src/main.rs
+++ b/b3sum/src/main.rs
@@ -196,7 +196,7 @@ fn write_hex_output(mut output: blake3::OutputReader, args: &Args) -> anyhow::Re
     // TODO: This computes each output block twice when the --seek argument isn't a multiple of 64.
     // We'll refactor all of this soon anyway, once SIMD optimizations are available for the XOF.
     let mut len = args.len();
-    let mut block = [0; blake3::guts::BLOCK_LEN];
+    let mut block = [0; blake3::BLOCK_LEN];
     while len > 0 {
         output.fill(&mut block);
         let hex_str = hex::encode(&block[..]);

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -4,9 +4,9 @@ extern crate test;
 
 use arrayref::array_ref;
 use arrayvec::ArrayVec;
-use blake3::guts::{BLOCK_LEN, CHUNK_LEN};
 use blake3::platform::{Platform, MAX_SIMD_DEGREE};
 use blake3::OUT_LEN;
+use blake3::{BLOCK_LEN, CHUNK_LEN};
 use rand::prelude::*;
 use test::Bencher;
 

--- a/c/blake3.c
+++ b/c/blake3.c
@@ -158,10 +158,10 @@ INLINE output_t parent_output(const uint8_t block[BLAKE3_BLOCK_LEN],
 // Given some input larger than one chunk, return the number of bytes that
 // should go in the left subtree. This is the largest power-of-2 number of
 // chunks that leaves at least 1 byte for the right subtree.
-INLINE size_t left_len(size_t content_len) {
-  // Subtract 1 to reserve at least one byte for the right side. content_len
+INLINE size_t left_subtree_len(size_t input_len) {
+  // Subtract 1 to reserve at least one byte for the right side. input_len
   // should always be greater than BLAKE3_CHUNK_LEN.
-  size_t full_chunks = (content_len - 1) / BLAKE3_CHUNK_LEN;
+  size_t full_chunks = (input_len - 1) / BLAKE3_CHUNK_LEN;
   return round_down_to_power_of_2(full_chunks) * BLAKE3_CHUNK_LEN;
 }
 
@@ -282,7 +282,7 @@ size_t blake3_compress_subtree_wide(const uint8_t *input, size_t input_len,
   // the input into left and right subtrees. (Note that this is only optimal
   // as long as the SIMD degree is a power of 2. If we ever get a SIMD degree
   // of 3 or something, we'll need a more complicated strategy.)
-  size_t left_input_len = left_len(input_len);
+  size_t left_input_len = left_subtree_len(input_len);
   size_t right_input_len = input_len - left_input_len;
   const uint8_t *right_input = &input[left_input_len];
   uint64_t right_chunk_counter =

--- a/src/guts.rs
+++ b/src/guts.rs
@@ -26,7 +26,7 @@ impl ChunkState {
 
     #[inline]
     pub fn len(&self) -> usize {
-        self.0.len()
+        self.0.count()
     }
 
     #[inline]

--- a/src/guts.rs
+++ b/src/guts.rs
@@ -1,143 +1,20 @@
-//! This undocumented and unstable module is for use cases like the `bao` crate,
-//! which need to traverse the BLAKE3 Merkle tree and work with chunk and parent
-//! chaining values directly. There might be breaking changes to this module
-//! between patch versions.
-//!
-//! We could stabilize something like this module in the future. If you have a
-//! use case for it, please let us know by filing a GitHub issue.
-//!
-//! <div class="warning">
-//! <strong>Warning:</strong> This whole <code>guts</code> module is <em>hazardous material</em>.
-//! If you've heard folks say <em>don't roll you're own crypto,</em> this is the sort of thing they
-//! were talking about. Playing with these APIs is a great way to learn more about how BLAKE3 works
-//! on the inside, but the rules are complicated, and minor mistakes will give you garbage output
-//! and/or break all the security properties that BLAKE3 is supposed to have. Read <a
-//! href="https://github.com/BLAKE3-team/BLAKE3-specs/blob/master/blake3.pdf">the BLAKE3 paper</a>,
-//! particularly sections 2.1 and 5.1, to understand the tree structure that you need to maintain.
-//! Test your code against the regular BLAKE3 API (<a
-//! href="../fn.hash.html"><code>blake3::hash</code></a> etc.), and make sure that you can get the
-//! same root hash both ways for <a
-//! href="https://github.com/BLAKE3-team/BLAKE3/blob/master/test_vectors/test_vectors.json">lots of
-//! different inputs</a>.
-//! </div>
-//!
-//! # Examples
-//!
-//! Expanding this API is work-in-progress. Here's an example of computing all the interior hashes
-//! in a 3-chunk tree:
-//!
-//! ```text
-//!            root
-//!          /      \
-//!      parent      \
-//!    /       \      \
-//! chunk0  chunk1  chunk2
-//! ```
-//!
-//! ```
-//! # fn main() {
-//! use blake3::Hasher;
-//! use blake3::guts::{Mode, HasherExt, merge_subtrees_non_root, merge_subtrees_root};
-//!
-//! let chunk0 = [b'a'; 1024];
-//! let chunk1 = [b'b'; 1024];
-//! let chunk2 = [b'c'; 1024];
-//!
-//! // Hash all three chunks. Chunks or subtrees that don't begin at the start of the input use
-//! // `set_input_offset` to say where they begin.
-//! let chunk0_hash = Hasher::new().update(&chunk0).finalize_non_root();
-//! let chunk1_hash = Hasher::new().set_input_offset(1024).update(&chunk1).finalize_non_root();
-//! let chunk2_hash = Hasher::new().set_input_offset(2048).update(&chunk2).finalize_non_root();
-//!
-//! // Join the first two chunks with a parent node.
-//! let parent_hash = merge_subtrees_non_root(&chunk0_hash, &chunk1_hash, Mode::Hash);
-//!
-//! // Finish the tree by joining that parent node with the third chunk.
-//! let root_hash = merge_subtrees_root(&parent_hash, &chunk2_hash, Mode::Hash);
-//!
-//! // Double check that we got the right answer.
-//! let mut combined_input = [0; 1024 * 3];
-//! combined_input[..1024].copy_from_slice(&chunk0);
-//! combined_input[1024..2048].copy_from_slice(&chunk1);
-//! combined_input[2048..].copy_from_slice(&chunk2);
-//! assert_eq!(root_hash, blake3::hash(&combined_input));
-//! # }
-//! ```
-//!
-//! Hashing many chunks together is important for performance, because it allows the implementation
-//! to use SIMD parallelism internally. ([AVX-512](https://en.wikipedia.org/wiki/AVX-512) for
-//! example needs 16 chunks to really get going.) We can reproduce `parent_hash` by hashing
-//! `chunk0` and `chunk1` at the same time:
-//!
-//! ```
-//! # fn main() {
-//! # use blake3::Hasher;
-//! # use blake3::guts::{Mode, HasherExt, merge_subtrees_non_root, merge_subtrees_root};
-//! # let chunk0 = [b'a'; 1024];
-//! # let chunk1 = [b'b'; 1024];
-//! # let chunk2 = [b'c'; 1024];
-//! # let mut combined_input = [0; 1024 * 3];
-//! # combined_input[..1024].copy_from_slice(&chunk0);
-//! # combined_input[1024..2048].copy_from_slice(&chunk1);
-//! # combined_input[2048..].copy_from_slice(&chunk2);
-//! # let chunk0_hash = Hasher::new().update(&chunk0).finalize_non_root();
-//! # let chunk1_hash = Hasher::new().set_input_offset(1024).update(&chunk1).finalize_non_root();
-//! # let parent_hash = merge_subtrees_non_root(&chunk0_hash, &chunk1_hash, Mode::Hash);
-//! let left_subtree_hash = Hasher::new().update(&combined_input[..2048]).finalize_non_root();
-//! assert_eq!(left_subtree_hash, parent_hash);
-//! # }
-//! ```
-//!
-//! However, hashing multiple chunks together **must** respect the overall tree structure. Hashing
-//! `chunk0` and `chunk1` together is valid, but hashing `chunk1` and `chunk2` together is
-//! incorrect and gives a garbage result that will never match a standard BLAKE3 hash. The
-//! implementation includes a few best-effort asserts to catch some of these mistakes, but these
-//! checks aren't guaranteed. For example, this call to `update` currently panics:
-//!
-//! ```should_panic
-//! # fn main() {
-//! # use blake3::Hasher;
-//! # use blake3::guts::HasherExt;
-//! # let chunk0 = [b'a'; 1024];
-//! # let chunk1 = [b'b'; 1024];
-//! # let chunk2 = [b'c'; 1024];
-//! # let mut combined_input = [0; 1024 * 3];
-//! # combined_input[..1024].copy_from_slice(&chunk0);
-//! # combined_input[1024..2048].copy_from_slice(&chunk1);
-//! # combined_input[2048..].copy_from_slice(&chunk2);
-//! let oops = Hasher::new()
-//!     .set_input_offset(1024)
-//!     // PANIC: "the subtree starting at 1024 contains at most 1024 bytes"
-//!     .update(&combined_input[1024..])
-//!     .finalize_non_root();
-//! # }
-//! ```
-//!
-//! Note that the merging functions ([`merge_subtrees_non_root`] and friends) don't know the shape
-//! of the left and right subtrees you're giving them, and they can't help you catch mistakes. The
-//! only way to catch mistakes with those is to compare your root output to the
-//! [`blake3::hash`](crate::hash) or similar of the same input.
-
-use crate::platform::Platform;
-use crate::{CVWords, Hash, Hasher, IV, KEY_LEN, OUT_LEN};
+//! Deprecated in favor of [`hazmat`](crate::hazmat)
 
 pub const BLOCK_LEN: usize = 64;
 pub const CHUNK_LEN: usize = 1024;
 
-#[deprecated]
 #[derive(Clone, Debug)]
 pub struct ChunkState(crate::ChunkState);
 
-#[allow(deprecated)]
 impl ChunkState {
     // Currently this type only supports the regular hash mode. If an
     // incremental user needs keyed_hash or derive_key, we can add that.
     pub fn new(chunk_counter: u64) -> Self {
         Self(crate::ChunkState::new(
-            IV,
+            crate::IV,
             chunk_counter,
             0,
-            Platform::detect(),
+            crate::platform::Platform::detect(),
         ))
     }
 
@@ -152,7 +29,7 @@ impl ChunkState {
         self
     }
 
-    pub fn finalize(&self, is_root: bool) -> Hash {
+    pub fn finalize(&self, is_root: bool) -> crate::Hash {
         let output = self.0.output();
         if is_root {
             output.root_hash()
@@ -164,14 +41,17 @@ impl ChunkState {
 
 // As above, this currently assumes the regular hash mode. If an incremental
 // user needs keyed_hash or derive_key, we can add that.
-#[deprecated]
-pub fn parent_cv(left_child: &Hash, right_child: &Hash, is_root: bool) -> Hash {
+pub fn parent_cv(
+    left_child: &crate::Hash,
+    right_child: &crate::Hash,
+    is_root: bool,
+) -> crate::Hash {
     let output = crate::parent_node_output(
         left_child.as_bytes(),
         right_child.as_bytes(),
-        IV,
+        crate::IV,
         0,
-        Platform::detect(),
+        crate::platform::Platform::detect(),
     );
     if is_root {
         output.root_hash()
@@ -180,161 +60,11 @@ pub fn parent_cv(left_child: &Hash, right_child: &Hash, is_root: bool) -> Hash {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
-pub enum Mode<'a> {
-    Hash,
-    KeyedHash(&'a [u8; KEY_LEN]),
-    DeriveKeyMaterial(&'a [u8; KEY_LEN]),
-}
-
-impl<'a> Mode<'a> {
-    #[inline(always)]
-    fn key_words(&self) -> CVWords {
-        match self {
-            Mode::Hash => *IV,
-            Mode::KeyedHash(key) => crate::platform::words_from_le_bytes_32(key),
-            Mode::DeriveKeyMaterial(cx_key) => crate::platform::words_from_le_bytes_32(cx_key),
-        }
-    }
-
-    fn flags_byte(&self) -> u8 {
-        match self {
-            Mode::Hash => 0,
-            Mode::KeyedHash(_) => crate::KEYED_HASH,
-            Mode::DeriveKeyMaterial(_) => crate::DERIVE_KEY_MATERIAL,
-        }
-    }
-}
-
-// In the diagram below, the subtree that starts with chunk 2 includes chunk 3 but not chunk 4. The
-// subtree that starts with chunk 4 includes chunk 7 but (if the tree was bigger) would not include
-// chunk 8. For a subtree starting at chunk index N, the maximum number of chunks in the tree is
-// 2 ^ (trailing zero bits of N). If you try to hash more input than this in a subtree, you'll
-// merge parent nodes that should never be merged, and your output will be garbage.
-//                .
-//            /       \
-//          .           .
-//        /   \       /   \
-//       .     .     .     .
-//      / \   / \   / \   / \
-//     0  1  2  3  4  5  6  7
-pub(crate) fn max_subtree_len(counter: u64) -> u64 {
-    assert_ne!(counter, 0);
-    (1 << counter.trailing_zeros()) * CHUNK_LEN as u64
-}
-
-/// "Chaining value" is the academic term for a non-root or non-final hash.
-pub type ChainingValue = [u8; OUT_LEN];
-
-#[test]
-fn test_max_subtree_len() {
-    // (chunk index, max chunks)
-    let cases = [
-        (1, 1),
-        (2, 2),
-        (3, 1),
-        (4, 4),
-        (5, 1),
-        (6, 2),
-        (7, 1),
-        (8, 8),
-    ];
-    for (counter, chunks) in cases {
-        assert_eq!(max_subtree_len(counter), chunks * CHUNK_LEN as u64);
-    }
-}
-
-fn merge_subtrees_inner(
-    left_child: &ChainingValue,
-    right_child: &ChainingValue,
-    mode: Mode,
-) -> crate::Output {
-    crate::parent_node_output(
-        &left_child,
-        &right_child,
-        &mode.key_words(),
-        mode.flags_byte(),
-        Platform::detect(),
-    )
-}
-
-/// Compute a non-root chaining value. It's never correct to cast this function's return value to
-/// Hash.
-pub fn merge_subtrees_non_root(
-    left_child: &ChainingValue,
-    right_child: &ChainingValue,
-    mode: Mode,
-) -> ChainingValue {
-    merge_subtrees_inner(left_child, right_child, mode).chaining_value()
-}
-
-/// Compute the root hash, similar to [`Hasher::finalize`](crate::Hasher::finalize).
-pub fn merge_subtrees_root(
-    left_child: &ChainingValue,
-    right_child: &ChainingValue,
-    mode: Mode,
-) -> crate::Hash {
-    merge_subtrees_inner(left_child, right_child, mode).root_hash()
-}
-
-/// Return a root [`OutputReader`](crate::OutputReader), similar to
-/// [`Hasher::finalize_xof`](crate::Hasher::finalize_xof).
-pub fn merge_subtrees_xof(
-    left_child: &ChainingValue,
-    right_child: &ChainingValue,
-    mode: Mode,
-) -> crate::OutputReader {
-    crate::OutputReader::new(merge_subtrees_inner(left_child, right_child, mode))
-}
-
-pub fn context_key(context: &str) -> [u8; crate::KEY_LEN] {
-    crate::hash_all_at_once::<crate::join::SerialJoin>(
-        context.as_bytes(),
-        IV,
-        crate::DERIVE_KEY_CONTEXT,
-        0,
-    )
-    .root_hash()
-    .0
-}
-
-pub trait HasherExt {
-    fn new_from_context_key(context_key: &[u8; KEY_LEN]) -> Self;
-    fn set_input_offset(&mut self, offset: u64) -> &mut Self;
-    fn finalize_non_root(&self) -> ChainingValue;
-}
-
-impl HasherExt for Hasher {
-    fn new_from_context_key(context_key: &[u8; KEY_LEN]) -> Hasher {
-        let context_key_words = crate::platform::words_from_le_bytes_32(context_key);
-        Hasher::new_internal(&context_key_words, crate::DERIVE_KEY_MATERIAL)
-    }
-
-    fn set_input_offset(&mut self, offset: u64) -> &mut Hasher {
-        assert_eq!(self.count(), 0, "hasher has already accepted input");
-        assert_eq!(
-            offset % CHUNK_LEN as u64,
-            0,
-            "offset ({offset}) must be a chunk boundary (divisible by {CHUNK_LEN})",
-        );
-        let counter = offset / CHUNK_LEN as u64;
-        self.chunk_state.chunk_counter = counter;
-        self.initial_chunk_counter = counter;
-        self
-    }
-
-    fn finalize_non_root(&self) -> ChainingValue {
-        assert_ne!(self.count(), 0, "empty subtrees are never valid");
-        self.final_output().chaining_value()
-    }
-}
-
 #[cfg(test)]
 mod test {
     use super::*;
 
     #[test]
-    #[allow(deprecated)]
     fn test_chunk() {
         assert_eq!(
             crate::hash(b"foo"),
@@ -343,9 +73,8 @@ mod test {
     }
 
     #[test]
-    #[allow(deprecated)]
     fn test_parents() {
-        let mut hasher = Hasher::new();
+        let mut hasher = crate::Hasher::new();
         let mut buf = [0; crate::CHUNK_LEN];
 
         buf[0] = 'a' as u8;
@@ -362,134 +91,5 @@ mod test {
         let parent = parent_cv(&chunk0_cv, &chunk1_cv, false);
         let root = parent_cv(&parent, &chunk2_cv, true);
         assert_eq!(hasher.finalize(), root);
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_empty_subtree_should_panic() {
-        Hasher::new().finalize_non_root();
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_unaligned_offset_should_panic() {
-        Hasher::new().set_input_offset(1);
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_hasher_already_accepted_input_should_panic() {
-        Hasher::new().update(b"x").set_input_offset(0);
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_too_much_input_should_panic() {
-        Hasher::new()
-            .set_input_offset(CHUNK_LEN as u64)
-            .update(&[0; CHUNK_LEN + 1]);
-    }
-
-    #[test]
-    fn test_grouped_hash() {
-        const MAX_CHUNKS: usize = (crate::test::TEST_CASES_MAX + 1) / CHUNK_LEN;
-        let mut input_buf = [0; crate::test::TEST_CASES_MAX];
-        crate::test::paint_test_input(&mut input_buf);
-        for subtree_chunks in [1, 2, 4, 8, 16, 32] {
-            #[cfg(feature = "std")]
-            dbg!(subtree_chunks);
-            let subtree_len = subtree_chunks * CHUNK_LEN;
-            for &case in crate::test::TEST_CASES {
-                if case <= subtree_len {
-                    continue;
-                }
-                #[cfg(feature = "std")]
-                dbg!(case);
-                let input = &input_buf[..case];
-                let expected_hash = crate::hash(input);
-
-                // Collect all the group chaining values.
-                let mut chaining_values = arrayvec::ArrayVec::<ChainingValue, MAX_CHUNKS>::new();
-                let mut subtree_offset = 0;
-                while subtree_offset < input.len() {
-                    let take = core::cmp::min(subtree_len, input.len() - subtree_offset);
-                    let subtree_input = &input[subtree_offset..][..take];
-                    let subtree_cv = Hasher::new()
-                        .set_input_offset(subtree_offset as u64)
-                        .update(subtree_input)
-                        .finalize_non_root();
-                    chaining_values.push(subtree_cv);
-                    subtree_offset += take;
-                }
-
-                // Compress all the chaining_values together, layer by layer.
-                assert!(chaining_values.len() >= 2);
-                while chaining_values.len() > 2 {
-                    let n = chaining_values.len();
-                    // Merge each side-by-side pair in place, overwriting the front half of the
-                    // array with the merged results. This moves us "up one level" in the tree.
-                    for i in 0..(n / 2) {
-                        chaining_values[i] = merge_subtrees_non_root(
-                            &chaining_values[2 * i],
-                            &chaining_values[2 * i + 1],
-                            Mode::Hash,
-                        );
-                    }
-                    // If there's an odd CV out, it moves up.
-                    if n % 2 == 1 {
-                        chaining_values[n / 2] = chaining_values[n - 1];
-                    }
-                    chaining_values.truncate(n / 2 + n % 2);
-                }
-                assert_eq!(chaining_values.len(), 2);
-                let root_hash =
-                    merge_subtrees_root(&chaining_values[0], &chaining_values[1], Mode::Hash);
-                assert_eq!(expected_hash, root_hash);
-            }
-        }
-    }
-
-    #[test]
-    fn test_keyed_hash_xof() {
-        let group0 = &[42; 4096];
-        let group1 = &[43; 4095];
-        let mut input = [0; 8191];
-        input[..4096].copy_from_slice(group0);
-        input[4096..].copy_from_slice(group1);
-        let key = &[44; 32];
-
-        let mut expected_output = [0; 100];
-        Hasher::new_keyed(&key)
-            .update(&input)
-            .finalize_xof()
-            .fill(&mut expected_output);
-
-        let mut guts_output = [0; 100];
-        let left = Hasher::new_keyed(key).update(group0).finalize_non_root();
-        let right = Hasher::new_keyed(key)
-            .set_input_offset(group0.len() as u64)
-            .update(group1)
-            .finalize_non_root();
-        merge_subtrees_xof(&left, &right, Mode::KeyedHash(&key)).fill(&mut guts_output);
-        assert_eq!(expected_output, guts_output);
-    }
-
-    #[test]
-    fn test_derive_key() {
-        let context = "foo";
-        let mut input = [0; 1025];
-        crate::test::paint_test_input(&mut input);
-        let expected = crate::derive_key(context, &input);
-
-        let cx_key = context_key(context);
-        let left = Hasher::new_from_context_key(&cx_key)
-            .update(&input[..1024])
-            .finalize_non_root();
-        let right = Hasher::new_from_context_key(&cx_key)
-            .set_input_offset(1024)
-            .update(&input[1024..])
-            .finalize_non_root();
-        let derived_key = merge_subtrees_root(&left, &right, Mode::DeriveKeyMaterial(&cx_key)).0;
-        assert_eq!(expected, derived_key);
     }
 }

--- a/src/guts.rs
+++ b/src/guts.rs
@@ -6,21 +6,26 @@
 //! We could stabilize something like this module in the future. If you have a
 //! use case for it, please let us know by filing a GitHub issue.
 
+use crate::platform::Platform;
+use crate::{CVBytes, CVWords, Hash, IV, KEY_LEN};
+
 pub const BLOCK_LEN: usize = 64;
 pub const CHUNK_LEN: usize = 1024;
 
+#[deprecated]
 #[derive(Clone, Debug)]
 pub struct ChunkState(crate::ChunkState);
 
+#[allow(deprecated)]
 impl ChunkState {
     // Currently this type only supports the regular hash mode. If an
     // incremental user needs keyed_hash or derive_key, we can add that.
     pub fn new(chunk_counter: u64) -> Self {
         Self(crate::ChunkState::new(
-            crate::IV,
+            IV,
             chunk_counter,
             0,
-            crate::platform::Platform::detect(),
+            Platform::detect(),
         ))
     }
 
@@ -35,7 +40,7 @@ impl ChunkState {
         self
     }
 
-    pub fn finalize(&self, is_root: bool) -> crate::Hash {
+    pub fn finalize(&self, is_root: bool) -> Hash {
         let output = self.0.output();
         if is_root {
             output.root_hash()
@@ -47,17 +52,14 @@ impl ChunkState {
 
 // As above, this currently assumes the regular hash mode. If an incremental
 // user needs keyed_hash or derive_key, we can add that.
-pub fn parent_cv(
-    left_child: &crate::Hash,
-    right_child: &crate::Hash,
-    is_root: bool,
-) -> crate::Hash {
+#[deprecated]
+pub fn parent_cv(left_child: &Hash, right_child: &Hash, is_root: bool) -> Hash {
     let output = crate::parent_node_output(
         left_child.as_bytes(),
         right_child.as_bytes(),
-        crate::IV,
+        IV,
         0,
-        crate::platform::Platform::detect(),
+        Platform::detect(),
     );
     if is_root {
         output.root_hash()
@@ -66,11 +68,137 @@ pub fn parent_cv(
     }
 }
 
+#[derive(Copy, Clone, Debug)]
+pub enum Mode<'a> {
+    Hash,
+    KeyedHash(&'a [u8; KEY_LEN]),
+    DeriveKeyContext,
+    DeriveKeyMaterial,
+}
+
+impl<'a> Mode<'a> {
+    #[inline(always)]
+    fn key_words(&self) -> CVWords {
+        match self {
+            Mode::KeyedHash(key) => crate::platform::words_from_le_bytes_32(key),
+            _ => *IV,
+        }
+    }
+
+    fn flags_byte(&self) -> u8 {
+        match self {
+            Mode::Hash => 0,
+            Mode::KeyedHash(_) => crate::KEYED_HASH,
+            Mode::DeriveKeyContext => crate::DERIVE_KEY_CONTEXT,
+            Mode::DeriveKeyMaterial => crate::DERIVE_KEY_MATERIAL,
+        }
+    }
+}
+
+// In the diagram below, the subtree that starts with chunk 2 includes chunk 3 but not chunk 4. The
+// subtree that starts with chunk 4 includes chunk 7 but (if the tree was bigger) would not include
+// chunk 8. For a subtree starting at chunk index N, the maximum number of chunks in the tree is
+// 2 ^ (trailing zero bits of N). If you try to hash more input than this in a subtree, you'll
+// merge parent nodes that should never be merged, and your output will be garbage.
+//                 .
+//              /    \
+//          .           .
+//        /   \       /   \
+//       .     .     .     .
+//      / \   / \   / \   / \
+//     0  1  2  3  4  5  6  7
+fn max_subtree_len(counter: u64) -> u64 {
+    debug_assert_ne!(counter, 0);
+    (1 << counter.trailing_zeros()) * CHUNK_LEN as u64
+}
+
+#[test]
+fn test_max_subtree_len() {
+    // (chunk index, max chunks)
+    let cases = [
+        (1, 1),
+        (2, 2),
+        (3, 1),
+        (4, 4),
+        (5, 1),
+        (6, 2),
+        (7, 1),
+        (8, 8),
+    ];
+    for (counter, chunks) in cases {
+        assert_eq!(max_subtree_len(counter), chunks * CHUNK_LEN as u64);
+    }
+}
+
+fn hash_subtree_inner<J: crate::join::Join>(input: &[u8], offset: u64, mode: Mode) -> CVBytes {
+    debug_assert!(input.len() != 0, "empty subtrees are never valid");
+    debug_assert_eq!(
+        offset % CHUNK_LEN as u64,
+        0,
+        "offset ({offset}) must be a chunk boundary (divisible by {CHUNK_LEN})",
+    );
+    let counter = offset / CHUNK_LEN as u64;
+    if counter != 0 {
+        let max = max_subtree_len(counter);
+        debug_assert!(
+            input.len() as u64 <= max,
+            "the subtree starting at {offset} contains at most {max} bytes (found {})",
+            input.len(),
+        );
+    }
+    crate::hash_all_at_once::<J>(input, &mode.key_words(), 0, 0).chaining_value()
+}
+
+/// This always returns a non-root chaining value. It's never correct to cast this function's
+/// return value to Hash. If offset is 0, there must be more input to merge.
+pub fn hash_subtree(input: &[u8], offset: u64, mode: Mode) -> CVBytes {
+    hash_subtree_inner::<crate::join::SerialJoin>(input, offset, mode)
+}
+
+/// This always returns a non-root chaining value. It's never correct to cast this function's
+/// return value to Hash. If offset is 0, there must be more input to merge.
+#[cfg(feature = "rayon")]
+pub fn hash_subtree_rayon(input: &[u8], offset: u64, mode: Mode) -> CVBytes {
+    hash_subtree_inner::<crate::join::RayonJoin>(input, offset, mode)
+}
+
+fn merge_subtrees_inner(left_hash: &CVBytes, right_hash: &CVBytes, mode: Mode) -> crate::Output {
+    crate::parent_node_output(
+        left_hash,
+        right_hash,
+        &mode.key_words(),
+        mode.flags_byte(),
+        Platform::detect(),
+    )
+}
+
+/// Compute a non-root chaining value. It's never correct to cast this function's return value to
+/// Hash.
+pub fn merge_subtrees_non_root(left_hash: &CVBytes, right_hash: &CVBytes, mode: Mode) -> CVBytes {
+    merge_subtrees_inner(left_hash, right_hash, mode).chaining_value()
+}
+
+/// Compute the root hash, similar to [`Hasher::finalize`](crate::Hasher::finalize).
+pub fn merge_subtrees_root(left_hash: &CVBytes, right_hash: &CVBytes, mode: Mode) -> crate::Hash {
+    merge_subtrees_inner(left_hash, right_hash, mode).root_hash()
+}
+
+/// Return a root [`OutputReader`](crate::OutputReader), similar to
+/// [`Hasher::finalize_xof`](crate::Hasher::finalize_xof).
+pub fn merge_subtrees_xof(
+    left_hash: &CVBytes,
+    right_hash: &CVBytes,
+    mode: Mode,
+) -> crate::OutputReader {
+    crate::OutputReader::new(merge_subtrees_inner(left_hash, right_hash, mode))
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
 
     #[test]
+    #[allow(deprecated)]
     fn test_chunk() {
         assert_eq!(
             crate::hash(b"foo"),
@@ -79,6 +207,7 @@ mod test {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_parents() {
         let mut hasher = crate::Hasher::new();
         let mut buf = [0; crate::CHUNK_LEN];
@@ -97,5 +226,26 @@ mod test {
         let parent = parent_cv(&chunk0_cv, &chunk1_cv, false);
         let root = parent_cv(&parent, &chunk2_cv, true);
         assert_eq!(hasher.finalize(), root);
+    }
+
+    #[test]
+    #[should_panic]
+    #[cfg(debug_assertions)]
+    fn test_empty_subtree_should_panic() {
+        hash_subtree(b"", 0, Mode::Hash);
+    }
+
+    #[test]
+    #[should_panic]
+    #[cfg(debug_assertions)]
+    fn test_unaligned_offset_should_panic() {
+        hash_subtree(b"x", 1, Mode::Hash);
+    }
+
+    #[test]
+    #[should_panic]
+    #[cfg(debug_assertions)]
+    fn test_too_much_input_should_panic() {
+        hash_subtree(&[0; CHUNK_LEN + 1], CHUNK_LEN as u64, Mode::Hash);
     }
 }

--- a/src/guts.rs
+++ b/src/guts.rs
@@ -293,6 +293,15 @@ mod test {
     #[test]
     #[should_panic]
     #[cfg(debug_assertions)]
+    fn test_hasher_already_accepted_input_should_panic() {
+        let mut hasher = crate::Hasher::new();
+        hasher.update(b"x");
+        set_input_offset(&mut hasher, 0);
+    }
+
+    #[test]
+    #[should_panic]
+    #[cfg(debug_assertions)]
     fn test_atonce_too_much_input_should_panic() {
         hash_subtree(&[0; CHUNK_LEN + 1], CHUNK_LEN as u64, Mode::Hash);
     }

--- a/src/guts.rs
+++ b/src/guts.rs
@@ -155,6 +155,7 @@ impl<'a> Mode<'a> {
 //       .     .     .     .
 //      / \   / \   / \   / \
 //     0  1  2  3  4  5  6  7
+#[cfg(debug_assertions)]
 pub(crate) fn max_subtree_len(counter: u64) -> u64 {
     debug_assert_ne!(counter, 0);
     (1 << counter.trailing_zeros()) * CHUNK_LEN as u64

--- a/src/guts.rs
+++ b/src/guts.rs
@@ -1,7 +1,6 @@
 //! Deprecated in favor of [`hazmat`](crate::hazmat)
 
-pub const BLOCK_LEN: usize = 64;
-pub const CHUNK_LEN: usize = 1024;
+pub use crate::{BLOCK_LEN, CHUNK_LEN};
 
 #[derive(Clone, Debug)]
 pub struct ChunkState(crate::ChunkState);

--- a/src/guts.rs
+++ b/src/guts.rs
@@ -59,37 +59,3 @@ pub fn parent_cv(
         output.chaining_value().into()
     }
 }
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn test_chunk() {
-        assert_eq!(
-            crate::hash(b"foo"),
-            ChunkState::new(0).update(b"foo").finalize(true)
-        );
-    }
-
-    #[test]
-    fn test_parents() {
-        let mut hasher = crate::Hasher::new();
-        let mut buf = [0; crate::CHUNK_LEN];
-
-        buf[0] = 'a' as u8;
-        hasher.update(&buf);
-        let chunk0_cv = ChunkState::new(0).update(&buf).finalize(false);
-
-        buf[0] = 'b' as u8;
-        hasher.update(&buf);
-        let chunk1_cv = ChunkState::new(1).update(&buf).finalize(false);
-
-        hasher.update(b"c");
-        let chunk2_cv = ChunkState::new(2).update(b"c").finalize(false);
-
-        let parent = parent_cv(&chunk0_cv, &chunk1_cv, false);
-        let root = parent_cv(&parent, &chunk2_cv, true);
-        assert_eq!(hasher.finalize(), root);
-    }
-}

--- a/src/hazmat.rs
+++ b/src/hazmat.rs
@@ -1,10 +1,10 @@
 //! Low-level tree manipulations and other sharp tools
 //!
 //! The target audience for this module is projects like [Bao](https://github.com/oconnor663/bao),
-//! which work directly with the interior hashes ("chaining values") of chunks and subtrees. For
-//! example, you could implement a BitTorrent-like protocol using standard BLAKE3 root hashes, or
-//! you could compute the BLAKE3 hash of a file that's distributed across different machines. These
-//! use cases are very advanced, and most applications don't need anything in this module. Also:
+//! which work directly with the interior hashes ("chaining values") of BLAKE3 chunks and subtrees.
+//! For example, you could use these functions to implement a BitTorrent-like protocol using the
+//! BLAKE3 tree structure, or to hash an input that's distributed across different machines. These
+//! use cases are very advanced, and most applications don't need this module. Also:
 //!
 //! <div class="warning">
 //!

--- a/src/hazmat.rs
+++ b/src/hazmat.rs
@@ -422,18 +422,9 @@ impl<'a> Mode<'a> {
 
 /// "Chaining value" is the academic term for a non-root or non-final hash.
 ///
-/// Besides just sounding fancy, it turns out there are security reasons to be careful about the
-/// difference between (root/final) hashes and (non-root/non-final) chaining values. The BLAKE3
-/// "compression function" has an [internal `flags`
-/// parameter](https://github.com/BLAKE3-team/BLAKE3/blob/1.7.0/reference_impl/reference_impl.rs#L79)
-/// that it mixes with its other inputs, and we use different `flags` [for root
-/// hashes](https://github.com/BLAKE3-team/BLAKE3/blob/1.7.0/reference_impl/reference_impl.rs#L154).
-/// Without this, BLAKE3 would be vulnerable to [length extension
-/// attacks](https://en.wikipedia.org/wiki/Length_extension_attack).
-///
-/// For a formal treatment of this problem, and an even more important tree hashing problem
-/// involving internal collisions, see [Sufficient conditions for sound tree and sequential hashing
-/// modes](https://keccak.team/files/TreeHashing.pdf) by the Keccak team.
+/// Besides just sounding fancy, it turns out there are [security
+/// reasons](https://jacko.io/tree_hashing.html) to be careful about the difference between
+/// (root/final) hashes and (non-root/non-final) chaining values.
 pub type ChainingValue = [u8; OUT_LEN];
 
 fn merge_subtrees_inner(

--- a/src/hazmat.rs
+++ b/src/hazmat.rs
@@ -114,10 +114,7 @@
 //! [`blake3::hash`](crate::hash) or similar of the same input.
 
 use crate::platform::Platform;
-use crate::{CVWords, Hasher, IV, KEY_LEN, OUT_LEN};
-
-pub const BLOCK_LEN: usize = 64;
-pub const CHUNK_LEN: usize = 1024;
+use crate::{CVWords, Hasher, CHUNK_LEN, IV, KEY_LEN, OUT_LEN};
 
 #[derive(Copy, Clone, Debug)]
 pub enum Mode<'a> {
@@ -413,14 +410,14 @@ mod test {
             .finalize_xof()
             .fill(&mut expected_output);
 
-        let mut guts_output = [0; 100];
+        let mut hazmat_output = [0; 100];
         let left = Hasher::new_keyed(key).update(group0).finalize_non_root();
         let right = Hasher::new_keyed(key)
             .set_input_offset(group0.len() as u64)
             .update(group1)
             .finalize_non_root();
-        merge_subtrees_xof(&left, &right, Mode::KeyedHash(&key)).fill(&mut guts_output);
-        assert_eq!(expected_output, guts_output);
+        merge_subtrees_xof(&left, &right, Mode::KeyedHash(&key)).fill(&mut hazmat_output);
+        assert_eq!(expected_output, hazmat_output);
     }
 
     #[test]

--- a/src/hazmat.rs
+++ b/src/hazmat.rs
@@ -4,14 +4,14 @@
 //! which work directly with the interior hashes ("chaining values") of BLAKE3 chunks and subtrees.
 //! For example, you could use these functions to implement a BitTorrent-like protocol using the
 //! BLAKE3 tree structure, or to hash an input that's distributed across different machines. These
-//! use cases are very advanced, and most applications don't need this module. Also:
+//! use cases are advanced, and most applications don't need this module. Also:
 //!
 //! <div class="warning">
 //!
-//! **Warning:** This whole module is *hazardous material*. If you've heard folks say *don't roll
-//! your own crypto,* this is the sort of thing they're talking about. These functions have
-//! complicated requirements, and any mistakes will give you garbage output and/or break the
-//! security properties that BLAKE3 is supposed to have. Read section 2.1 of [the BLAKE3
+//! **Warning:** This module is *hazardous material*. If you've heard folks say *don't roll your
+//! own crypto,* this is the sort of thing they're talking about. These functions have complicated
+//! requirements, and any mistakes will give you garbage output and/or break the security
+//! properties that BLAKE3 is supposed to have. Read section 2.1 of [the BLAKE3
 //! paper](https://github.com/BLAKE3-team/BLAKE3-specs/blob/master/blake3.pdf) to understand the
 //! tree structure you need to maintain. Test your code against [`blake3::hash`](../fn.hash.html)
 //! and make sure you can get the same outputs for [lots of different

--- a/src/hazmat.rs
+++ b/src/hazmat.rs
@@ -533,7 +533,6 @@ pub fn hash_derive_key_context(context: &str) -> ContextKey {
         context.as_bytes(),
         IV,
         crate::DERIVE_KEY_CONTEXT,
-        0,
     )
     .root_hash()
     .0

--- a/src/hazmat.rs
+++ b/src/hazmat.rs
@@ -1,0 +1,403 @@
+//! Low-level tree manipulations and other sharp tools
+//!
+//! <div class="warning">
+//!
+//! **Warning:** This whole module is *hazardous material*. If you've heard folks say *don't roll
+//! your own crypto,* this is the sort of thing they were talking about. The rules for using these
+//! functions correctly are complicated, and tiny mistakes can give you garbage output and/or break
+//! the security properties that BLAKE3 is supposed to have. Read [the BLAKE3
+//! paper](https://github.com/BLAKE3-team/BLAKE3-specs/blob/master/blake3.pdf), particularly
+//! sections 2.1 and 5.1, to understand the tree structure that you need to maintain. Test your
+//! code against [`blake3::hash`](../fn.hash.html) and friends and make sure you can get the same
+//! output for [lots of different
+//! inputs](https://github.com/BLAKE3-team/BLAKE3/blob/master/test_vectors/test_vectors.json).
+//!
+//! **Encouragement:** Playing with these functions is a great way to learn how BLAKE3 works on the
+//! inside. Have fun!
+//!
+//! </div>
+//!
+//! # Examples
+//!
+//! Here's an example of computing all the interior hashes in a 3-chunk tree:
+//!
+//! ```text
+//!            root
+//!          /      \
+//!      parent      \
+//!    /       \      \
+//! chunk0  chunk1  chunk2
+//! ```
+//!
+//! ```
+//! # fn main() {
+//! use blake3::Hasher;
+//! use blake3::hazmat::{Mode, HasherExt, merge_subtrees_non_root, merge_subtrees_root};
+//!
+//! let chunk0 = [b'a'; 1024];
+//! let chunk1 = [b'b'; 1024];
+//! let chunk2 = [b'c'; 1024];
+//!
+//! // Hash all three chunks. Chunks or subtrees that don't begin at the start of the input use
+//! // `set_input_offset` to say where they begin.
+//! let chunk0_hash = Hasher::new().update(&chunk0).finalize_non_root();
+//! let chunk1_hash = Hasher::new().set_input_offset(1024).update(&chunk1).finalize_non_root();
+//! let chunk2_hash = Hasher::new().set_input_offset(2048).update(&chunk2).finalize_non_root();
+//!
+//! // Join the first two chunks with a parent node.
+//! let parent_hash = merge_subtrees_non_root(&chunk0_hash, &chunk1_hash, Mode::Hash);
+//!
+//! // Finish the tree by joining that parent node with the third chunk.
+//! let root_hash = merge_subtrees_root(&parent_hash, &chunk2_hash, Mode::Hash);
+//!
+//! // Double check that we got the right answer.
+//! let mut combined_input = [0; 1024 * 3];
+//! combined_input[..1024].copy_from_slice(&chunk0);
+//! combined_input[1024..2048].copy_from_slice(&chunk1);
+//! combined_input[2048..].copy_from_slice(&chunk2);
+//! assert_eq!(root_hash, blake3::hash(&combined_input));
+//! # }
+//! ```
+//!
+//! Hashing many chunks together is important for performance, because it allows the implementation
+//! to use SIMD parallelism internally. ([AVX-512](https://en.wikipedia.org/wiki/AVX-512) for
+//! example needs 16 chunks to really get going.) We can reproduce `parent_hash` by hashing
+//! `chunk0` and `chunk1` at the same time:
+//!
+//! ```
+//! # fn main() {
+//! # use blake3::Hasher;
+//! # use blake3::hazmat::{Mode, HasherExt, merge_subtrees_non_root, merge_subtrees_root};
+//! # let chunk0 = [b'a'; 1024];
+//! # let chunk1 = [b'b'; 1024];
+//! # let chunk2 = [b'c'; 1024];
+//! # let mut combined_input = [0; 1024 * 3];
+//! # combined_input[..1024].copy_from_slice(&chunk0);
+//! # combined_input[1024..2048].copy_from_slice(&chunk1);
+//! # combined_input[2048..].copy_from_slice(&chunk2);
+//! # let chunk0_hash = Hasher::new().update(&chunk0).finalize_non_root();
+//! # let chunk1_hash = Hasher::new().set_input_offset(1024).update(&chunk1).finalize_non_root();
+//! # let parent_hash = merge_subtrees_non_root(&chunk0_hash, &chunk1_hash, Mode::Hash);
+//! let left_subtree_hash = Hasher::new().update(&combined_input[..2048]).finalize_non_root();
+//! assert_eq!(left_subtree_hash, parent_hash);
+//! # }
+//! ```
+//!
+//! However, hashing multiple chunks together **must** respect the overall tree structure. Hashing
+//! `chunk0` and `chunk1` together is valid, but hashing `chunk1` and `chunk2` together is
+//! incorrect and gives a garbage result that will never match a standard BLAKE3 hash. The
+//! implementation includes a few best-effort asserts to catch some of these mistakes, but these
+//! checks aren't guaranteed. For example, this call to `update` currently panics:
+//!
+//! ```should_panic
+//! # fn main() {
+//! # use blake3::Hasher;
+//! # use blake3::hazmat::HasherExt;
+//! # let chunk0 = [b'a'; 1024];
+//! # let chunk1 = [b'b'; 1024];
+//! # let chunk2 = [b'c'; 1024];
+//! # let mut combined_input = [0; 1024 * 3];
+//! # combined_input[..1024].copy_from_slice(&chunk0);
+//! # combined_input[1024..2048].copy_from_slice(&chunk1);
+//! # combined_input[2048..].copy_from_slice(&chunk2);
+//! let oops = Hasher::new()
+//!     .set_input_offset(1024)
+//!     // PANIC: "the subtree starting at 1024 contains at most 1024 bytes"
+//!     .update(&combined_input[1024..])
+//!     .finalize_non_root();
+//! # }
+//! ```
+//!
+//! Note that the merging functions ([`merge_subtrees_non_root`] and friends) don't know the shape
+//! of the left and right subtrees you're giving them, and they can't help you catch mistakes. The
+//! only way to catch mistakes with those is to compare your root output to the
+//! [`blake3::hash`](crate::hash) or similar of the same input.
+
+use crate::platform::Platform;
+use crate::{CVWords, Hash, Hasher, IV, KEY_LEN, OUT_LEN};
+
+pub const BLOCK_LEN: usize = 64;
+pub const CHUNK_LEN: usize = 1024;
+
+#[derive(Copy, Clone, Debug)]
+pub enum Mode<'a> {
+    Hash,
+    KeyedHash(&'a [u8; KEY_LEN]),
+    DeriveKeyMaterial(&'a [u8; KEY_LEN]),
+}
+
+impl<'a> Mode<'a> {
+    #[inline(always)]
+    fn key_words(&self) -> CVWords {
+        match self {
+            Mode::Hash => *IV,
+            Mode::KeyedHash(key) => crate::platform::words_from_le_bytes_32(key),
+            Mode::DeriveKeyMaterial(cx_key) => crate::platform::words_from_le_bytes_32(cx_key),
+        }
+    }
+
+    fn flags_byte(&self) -> u8 {
+        match self {
+            Mode::Hash => 0,
+            Mode::KeyedHash(_) => crate::KEYED_HASH,
+            Mode::DeriveKeyMaterial(_) => crate::DERIVE_KEY_MATERIAL,
+        }
+    }
+}
+
+// In the diagram below, the subtree that starts with chunk 2 includes chunk 3 but not chunk 4. The
+// subtree that starts with chunk 4 includes chunk 7 but (if the tree was bigger) would not include
+// chunk 8. For a subtree starting at chunk index N, the maximum number of chunks in the tree is
+// 2 ^ (trailing zero bits of N). If you try to hash more input than this in a subtree, you'll
+// merge parent nodes that should never be merged, and your output will be garbage.
+//                .
+//            /       \
+//          .           .
+//        /   \       /   \
+//       .     .     .     .
+//      / \   / \   / \   / \
+//     0  1  2  3  4  5  6  7
+pub(crate) fn max_subtree_len(counter: u64) -> u64 {
+    assert_ne!(counter, 0);
+    (1 << counter.trailing_zeros()) * CHUNK_LEN as u64
+}
+
+/// "Chaining value" is the academic term for a non-root or non-final hash.
+pub type ChainingValue = [u8; OUT_LEN];
+
+#[test]
+fn test_max_subtree_len() {
+    // (chunk index, max chunks)
+    let cases = [
+        (1, 1),
+        (2, 2),
+        (3, 1),
+        (4, 4),
+        (5, 1),
+        (6, 2),
+        (7, 1),
+        (8, 8),
+    ];
+    for (counter, chunks) in cases {
+        assert_eq!(max_subtree_len(counter), chunks * CHUNK_LEN as u64);
+    }
+}
+
+fn merge_subtrees_inner(
+    left_child: &ChainingValue,
+    right_child: &ChainingValue,
+    mode: Mode,
+) -> crate::Output {
+    crate::parent_node_output(
+        &left_child,
+        &right_child,
+        &mode.key_words(),
+        mode.flags_byte(),
+        Platform::detect(),
+    )
+}
+
+/// Compute a non-root chaining value. It's never correct to cast this function's return value to
+/// Hash.
+pub fn merge_subtrees_non_root(
+    left_child: &ChainingValue,
+    right_child: &ChainingValue,
+    mode: Mode,
+) -> ChainingValue {
+    merge_subtrees_inner(left_child, right_child, mode).chaining_value()
+}
+
+/// Compute the root hash, similar to [`Hasher::finalize`](crate::Hasher::finalize).
+pub fn merge_subtrees_root(
+    left_child: &ChainingValue,
+    right_child: &ChainingValue,
+    mode: Mode,
+) -> crate::Hash {
+    merge_subtrees_inner(left_child, right_child, mode).root_hash()
+}
+
+/// Return a root [`OutputReader`](crate::OutputReader), similar to
+/// [`Hasher::finalize_xof`](crate::Hasher::finalize_xof).
+pub fn merge_subtrees_xof(
+    left_child: &ChainingValue,
+    right_child: &ChainingValue,
+    mode: Mode,
+) -> crate::OutputReader {
+    crate::OutputReader::new(merge_subtrees_inner(left_child, right_child, mode))
+}
+
+pub fn context_key(context: &str) -> [u8; crate::KEY_LEN] {
+    crate::hash_all_at_once::<crate::join::SerialJoin>(
+        context.as_bytes(),
+        IV,
+        crate::DERIVE_KEY_CONTEXT,
+        0,
+    )
+    .root_hash()
+    .0
+}
+
+pub trait HasherExt {
+    fn new_from_context_key(context_key: &[u8; KEY_LEN]) -> Self;
+    fn set_input_offset(&mut self, offset: u64) -> &mut Self;
+    fn finalize_non_root(&self) -> ChainingValue;
+}
+
+impl HasherExt for Hasher {
+    fn new_from_context_key(context_key: &[u8; KEY_LEN]) -> Hasher {
+        let context_key_words = crate::platform::words_from_le_bytes_32(context_key);
+        Hasher::new_internal(&context_key_words, crate::DERIVE_KEY_MATERIAL)
+    }
+
+    fn set_input_offset(&mut self, offset: u64) -> &mut Hasher {
+        assert_eq!(self.count(), 0, "hasher has already accepted input");
+        assert_eq!(
+            offset % CHUNK_LEN as u64,
+            0,
+            "offset ({offset}) must be a chunk boundary (divisible by {CHUNK_LEN})",
+        );
+        let counter = offset / CHUNK_LEN as u64;
+        self.chunk_state.chunk_counter = counter;
+        self.initial_chunk_counter = counter;
+        self
+    }
+
+    fn finalize_non_root(&self) -> ChainingValue {
+        assert_ne!(self.count(), 0, "empty subtrees are never valid");
+        self.final_output().chaining_value()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    #[should_panic]
+    fn test_empty_subtree_should_panic() {
+        Hasher::new().finalize_non_root();
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_unaligned_offset_should_panic() {
+        Hasher::new().set_input_offset(1);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_hasher_already_accepted_input_should_panic() {
+        Hasher::new().update(b"x").set_input_offset(0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_too_much_input_should_panic() {
+        Hasher::new()
+            .set_input_offset(CHUNK_LEN as u64)
+            .update(&[0; CHUNK_LEN + 1]);
+    }
+
+    #[test]
+    fn test_grouped_hash() {
+        const MAX_CHUNKS: usize = (crate::test::TEST_CASES_MAX + 1) / CHUNK_LEN;
+        let mut input_buf = [0; crate::test::TEST_CASES_MAX];
+        crate::test::paint_test_input(&mut input_buf);
+        for subtree_chunks in [1, 2, 4, 8, 16, 32] {
+            #[cfg(feature = "std")]
+            dbg!(subtree_chunks);
+            let subtree_len = subtree_chunks * CHUNK_LEN;
+            for &case in crate::test::TEST_CASES {
+                if case <= subtree_len {
+                    continue;
+                }
+                #[cfg(feature = "std")]
+                dbg!(case);
+                let input = &input_buf[..case];
+                let expected_hash = crate::hash(input);
+
+                // Collect all the group chaining values.
+                let mut chaining_values = arrayvec::ArrayVec::<ChainingValue, MAX_CHUNKS>::new();
+                let mut subtree_offset = 0;
+                while subtree_offset < input.len() {
+                    let take = core::cmp::min(subtree_len, input.len() - subtree_offset);
+                    let subtree_input = &input[subtree_offset..][..take];
+                    let subtree_cv = Hasher::new()
+                        .set_input_offset(subtree_offset as u64)
+                        .update(subtree_input)
+                        .finalize_non_root();
+                    chaining_values.push(subtree_cv);
+                    subtree_offset += take;
+                }
+
+                // Compress all the chaining_values together, layer by layer.
+                assert!(chaining_values.len() >= 2);
+                while chaining_values.len() > 2 {
+                    let n = chaining_values.len();
+                    // Merge each side-by-side pair in place, overwriting the front half of the
+                    // array with the merged results. This moves us "up one level" in the tree.
+                    for i in 0..(n / 2) {
+                        chaining_values[i] = merge_subtrees_non_root(
+                            &chaining_values[2 * i],
+                            &chaining_values[2 * i + 1],
+                            Mode::Hash,
+                        );
+                    }
+                    // If there's an odd CV out, it moves up.
+                    if n % 2 == 1 {
+                        chaining_values[n / 2] = chaining_values[n - 1];
+                    }
+                    chaining_values.truncate(n / 2 + n % 2);
+                }
+                assert_eq!(chaining_values.len(), 2);
+                let root_hash =
+                    merge_subtrees_root(&chaining_values[0], &chaining_values[1], Mode::Hash);
+                assert_eq!(expected_hash, root_hash);
+            }
+        }
+    }
+
+    #[test]
+    fn test_keyed_hash_xof() {
+        let group0 = &[42; 4096];
+        let group1 = &[43; 4095];
+        let mut input = [0; 8191];
+        input[..4096].copy_from_slice(group0);
+        input[4096..].copy_from_slice(group1);
+        let key = &[44; 32];
+
+        let mut expected_output = [0; 100];
+        Hasher::new_keyed(&key)
+            .update(&input)
+            .finalize_xof()
+            .fill(&mut expected_output);
+
+        let mut guts_output = [0; 100];
+        let left = Hasher::new_keyed(key).update(group0).finalize_non_root();
+        let right = Hasher::new_keyed(key)
+            .set_input_offset(group0.len() as u64)
+            .update(group1)
+            .finalize_non_root();
+        merge_subtrees_xof(&left, &right, Mode::KeyedHash(&key)).fill(&mut guts_output);
+        assert_eq!(expected_output, guts_output);
+    }
+
+    #[test]
+    fn test_derive_key() {
+        let context = "foo";
+        let mut input = [0; 1025];
+        crate::test::paint_test_input(&mut input);
+        let expected = crate::derive_key(context, &input);
+
+        let cx_key = context_key(context);
+        let left = Hasher::new_from_context_key(&cx_key)
+            .update(&input[..1024])
+            .finalize_non_root();
+        let right = Hasher::new_from_context_key(&cx_key)
+            .set_input_offset(1024)
+            .update(&input[1024..])
+            .finalize_non_root();
+        let derived_key = merge_subtrees_root(&left, &right, Mode::DeriveKeyMaterial(&cx_key)).0;
+        assert_eq!(expected, derived_key);
+    }
+}

--- a/src/hazmat.rs
+++ b/src/hazmat.rs
@@ -57,26 +57,26 @@
 //! let chunk1 = [b'b'; CHUNK_LEN];
 //! let chunk2 = [b'c'; 42]; // The final chunk can be short.
 //!
-//! // Hash all three chunks. Chunks or subtrees that don't begin at the start of the input use
-//! // `set_input_offset` to say where they begin.
-//! let chunk0_hash = Hasher::new()
+//! // Compute the non-root hashes ("chaining values") of all three chunks. Chunks or subtrees
+//! // that don't begin at the start of the input use `set_input_offset` to say where they begin.
+//! let chunk0_cv = Hasher::new()
 //!     // .set_input_offset(0) is the default.
 //!     .update(&chunk0)
 //!     .finalize_non_root();
-//! let chunk1_hash = Hasher::new()
+//! let chunk1_cv = Hasher::new()
 //!     .set_input_offset(CHUNK_LEN as u64)
 //!     .update(&chunk1)
 //!     .finalize_non_root();
-//! let chunk2_hash = Hasher::new()
+//! let chunk2_cv = Hasher::new()
 //!     .set_input_offset(2 * CHUNK_LEN as u64)
 //!     .update(&chunk2)
 //!     .finalize_non_root();
 //!
-//! // Join the first two chunks with a non-root parent node.
-//! let parent_hash = merge_subtrees_non_root(&chunk0_hash, &chunk1_hash, Mode::Hash);
+//! // Join the first two chunks with a non-root parent node and compute its chaining value.
+//! let parent_cv = merge_subtrees_non_root(&chunk0_cv, &chunk1_cv, Mode::Hash);
 //!
-//! // Join that parent node and the third chunk at the root of the tree.
-//! let root_hash = merge_subtrees_root(&parent_hash, &chunk2_hash, Mode::Hash);
+//! // Join that parent node and the third chunk with a root parent node and compute the hash.
+//! let root_hash = merge_subtrees_root(&parent_cv, &chunk2_cv, Mode::Hash);
 //!
 //! // Double check that we got the right answer.
 //! let mut combined_input = Vec::new();
@@ -89,8 +89,8 @@
 //!
 //! Hashing many chunks together is important for performance, because it allows the implementation
 //! to use SIMD parallelism internally. ([AVX-512](https://en.wikipedia.org/wiki/AVX-512) for
-//! example needs 16 chunks to really get going.) We can reproduce `parent_hash` by hashing
-//! `chunk0` and `chunk1` at the same time:
+//! example needs 16 chunks to really get going.) We can reproduce `parent_cv` by hashing `chunk0`
+//! and `chunk1` at the same time:
 //!
 //! ```
 //! # fn main() {
@@ -98,24 +98,24 @@
 //! # use blake3::hazmat::{Mode, HasherExt, merge_subtrees_non_root, merge_subtrees_root};
 //! # let chunk0 = [b'a'; CHUNK_LEN];
 //! # let chunk1 = [b'b'; CHUNK_LEN];
-//! # let chunk0_hash = Hasher::new().update(&chunk0).finalize_non_root();
-//! # let chunk1_hash = Hasher::new().set_input_offset(CHUNK_LEN as u64).update(&chunk1).finalize_non_root();
-//! # let parent_hash = merge_subtrees_non_root(&chunk0_hash, &chunk1_hash, Mode::Hash);
+//! # let chunk0_cv = Hasher::new().update(&chunk0).finalize_non_root();
+//! # let chunk1_cv = Hasher::new().set_input_offset(CHUNK_LEN as u64).update(&chunk1).finalize_non_root();
+//! # let parent_cv = merge_subtrees_non_root(&chunk0_cv, &chunk1_cv, Mode::Hash);
 //! # let mut combined_input = Vec::new();
 //! # combined_input.extend_from_slice(&chunk0);
 //! # combined_input.extend_from_slice(&chunk1);
-//! let left_subtree_hash = Hasher::new()
+//! let left_subtree_cv = Hasher::new()
 //!     // .set_input_offset(0) is the default.
 //!     .update(&combined_input[..2 * CHUNK_LEN])
 //!     .finalize_non_root();
-//! assert_eq!(left_subtree_hash, parent_hash);
+//! assert_eq!(left_subtree_cv, parent_cv);
 //!
 //! // Using multiple updates gives the same answer, though it's not as efficient.
 //! let mut subtree_hasher = Hasher::new();
 //! // Again, .set_input_offset(0) is the default.
 //! subtree_hasher.update(&chunk0);
 //! subtree_hasher.update(&chunk1);
-//! assert_eq!(left_subtree_hash, subtree_hasher.finalize_non_root());
+//! assert_eq!(left_subtree_cv, subtree_hasher.finalize_non_root());
 //! # }
 //! ```
 //!
@@ -239,7 +239,7 @@ impl HasherExt for Hasher {
     }
 }
 
-/// Compute the maximum length of a subtree in bytes, given its starting offset in bytes.
+/// The maximum length of a subtree in bytes, given its starting offset in bytes
 ///
 /// If you try to hash more than this many bytes as one subtree, you'll end up merging parent nodes
 /// that shouldn't be merged, and your output will be garbage. [`Hasher::update`] will currently
@@ -322,7 +322,7 @@ fn test_max_subtree_len() {
 }
 
 /// Given the length in bytes of either a complete input or a subtree input, return the number of
-/// bytes that belong to the left child subtree. The rest belong to the right child subtree.
+/// bytes that belong to its left child subtree. The rest belong to its right child subtree.
 ///
 /// Concretely, this function returns the largest power-of-two number of bytes that's strictly less
 /// than `input_len`. This leads to a tree where all left subtrees are "complete" and at least as
@@ -354,14 +354,14 @@ fn test_max_subtree_len() {
 /// // us exactly where to split the input. Any other split would either panic (if we're lucky) or
 /// // lead to an incorrect root hash.
 /// let left_len = left_subtree_len(input_len as u64) as usize;
-/// let left_subtree_hash = Hasher::new()
+/// let left_subtree_cv = Hasher::new()
 ///     .update(&input[..left_len])
 ///     .finalize_non_root();
-/// let right_subtree_hash = Hasher::new()
+/// let right_subtree_cv = Hasher::new()
 ///     .set_input_offset(left_len as u64)
 ///     .update(&input[left_len..])
 ///     .finalize_non_root();
-/// let root_hash = merge_subtrees_root(&left_subtree_hash, &right_subtree_hash, Mode::Hash);
+/// let root_hash = merge_subtrees_root(&left_subtree_cv, &right_subtree_cv, Mode::Hash);
 ///
 /// // Double check the answer.
 /// assert_eq!(root_hash, blake3::hash(&input));
@@ -421,6 +421,19 @@ impl<'a> Mode<'a> {
 }
 
 /// "Chaining value" is the academic term for a non-root or non-final hash.
+///
+/// Besides just sounding fancy, it turns out there are security reasons to be careful about the
+/// difference between (root/final) hashes and (non-root/non-final) chaining values. The BLAKE3
+/// "compression function" has an [internal `flags`
+/// parameter](https://github.com/BLAKE3-team/BLAKE3/blob/1.7.0/reference_impl/reference_impl.rs#L79)
+/// that it mixes with its other inputs, and we use different `flags` [for root
+/// hashes](https://github.com/BLAKE3-team/BLAKE3/blob/1.7.0/reference_impl/reference_impl.rs#L154).
+/// Without this, BLAKE3 would be vulnerable to [length extension
+/// attacks](https://en.wikipedia.org/wiki/Length_extension_attack).
+///
+/// For a formal treatment of this problem, and an even more important tree hashing problem
+/// involving internal collisions, see [Sufficient conditions for sound tree and sequential hashing
+/// modes](https://keccak.team/files/TreeHashing.pdf) by the Keccak team.
 pub type ChainingValue = [u8; OUT_LEN];
 
 fn merge_subtrees_inner(
@@ -437,8 +450,7 @@ fn merge_subtrees_inner(
     )
 }
 
-/// Compute a non-root chaining value, similar to
-/// [`Hasher::finalize_non_root`](HasherExt::finalize_non_root).
+/// Compute a non-root parent node chaining value from two child chaining values.
 ///
 /// See the [module level examples](index.html#examples), particularly the discussion of valid tree
 /// structures. The left and right child chaining values can come from either
@@ -453,12 +465,16 @@ pub fn merge_subtrees_non_root(
     merge_subtrees_inner(left_child, right_child, mode).chaining_value()
 }
 
-/// Compute a root hash, similar to [`Hasher::finalize`](crate::Hasher::finalize).
+/// Compute a root hash from two child chaining values.
 ///
 /// See the [module level examples](index.html#examples), particularly the discussion of valid tree
 /// structures. The left and right child chaining values can come from either
 /// [`Hasher::finalize_non_root`](HasherExt::finalize_non_root) or [`merge_subtrees_non_root`].
 /// "Chaining value" is the academic term for a non-root or non-final hash.
+///
+/// Note that inputs of [`CHUNK_LEN`] or less don't produce any parent nodes and can't be hashed
+/// using this function. In that case you must get the root hash from [`Hasher::finalize`] (or just
+/// [`blake3::hash`](crate::hash)).
 pub fn merge_subtrees_root(
     left_child: &ChainingValue,
     right_child: &ChainingValue,
@@ -467,13 +483,16 @@ pub fn merge_subtrees_root(
     merge_subtrees_inner(left_child, right_child, mode).root_hash()
 }
 
-/// Return a root [`OutputReader`](crate::OutputReader), similar to
-/// [`Hasher::finalize_xof`](crate::Hasher::finalize_xof).
+/// Build a root [`OutputReader`](crate::OutputReader) from two child chaining values.
 ///
 /// See also the [module level examples](index.html#examples), particularly the discussion of valid
 /// tree structures. The left and right child chaining values can come from either
 /// [`Hasher::finalize_non_root`](HasherExt::finalize_non_root) or [`merge_subtrees_non_root`].
 /// "Chaining value" is the academic term for a non-root or non-final hash.
+///
+/// Note that inputs of [`CHUNK_LEN`] or less don't produce any parent nodes and can't be hashed
+/// using this function. In that case you must get the `OutputReader` from
+/// [`Hasher::finalize_xof`].
 ///
 /// # Example
 ///
@@ -485,15 +504,16 @@ pub fn merge_subtrees_root(
 /// // the final chunk can be shorter than CHUNK_LEN.
 /// let chunk0 = &[42; CHUNK_LEN];
 /// let chunk1 = b"hello world";
-/// let chunk0_hash = Hasher::new()
+/// let chunk0_cv = Hasher::new()
 ///     .update(chunk0)
 ///     .finalize_non_root();
-/// let chunk1_hash = Hasher::new()
+/// let chunk1_cv = Hasher::new()
 ///     .set_input_offset(CHUNK_LEN as u64)
 ///     .update(chunk1)
 ///     .finalize_non_root();
+///
 /// // Obtain a blake3::OutputReader at the root and extract 1000 bytes.
-/// let mut output_reader = merge_subtrees_root_xof(&chunk0_hash, &chunk1_hash, Mode::Hash);
+/// let mut output_reader = merge_subtrees_root_xof(&chunk0_cv, &chunk1_cv, Mode::Hash);
 /// let mut output_bytes = [0; 1_000];
 /// output_reader.fill(&mut output_bytes);
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,10 @@ mod test;
 // and likely to keep working, but largely undocumented and not intended for
 // widespread use.
 #[doc(hidden)]
+#[deprecated(since = "1.8.0", note = "use the hazmat module instead")]
 pub mod guts;
+
+pub mod hazmat;
 
 /// Undocumented and unstable, for benchmarks only.
 #[doc(hidden)]
@@ -156,7 +159,7 @@ pub const OUT_LEN: usize = 32;
 pub const KEY_LEN: usize = 32;
 
 const MAX_DEPTH: usize = 54; // 2^54 * CHUNK_LEN = 2^64
-use guts::{BLOCK_LEN, CHUNK_LEN};
+use hazmat::{BLOCK_LEN, CHUNK_LEN};
 
 // While iterating the compression function within a chunk, the CV is
 // represented as words, to avoid doing two extra endianness conversions for
@@ -994,7 +997,7 @@ pub fn keyed_hash(key: &[u8; KEY_LEN], input: &[u8]) -> Hash {
 ///
 /// [Argon2]: https://en.wikipedia.org/wiki/Argon2
 pub fn derive_key(context: &str, key_material: &[u8]) -> [u8; OUT_LEN] {
-    let key = guts::context_key(context);
+    let key = hazmat::context_key(context);
     let key_words = platform::words_from_le_bytes_32(&key);
     hash_all_at_once::<join::SerialJoin>(key_material, &key_words, DERIVE_KEY_MATERIAL, 0)
         .root_hash()
@@ -1098,7 +1101,7 @@ impl Hasher {
     ///
     /// [`derive_key`]: fn.derive_key.html
     pub fn new_derive_key(context: &str) -> Self {
-        let key = guts::context_key(context);
+        let key = hazmat::context_key(context);
         let key_words = platform::words_from_le_bytes_32(&key);
         Self::new_internal(&key_words, DERIVE_KEY_MATERIAL)
     }
@@ -1197,7 +1200,7 @@ impl Hasher {
 
     fn update_with_join<J: join::Join>(&mut self, mut input: &[u8]) -> &mut Self {
         if self.initial_chunk_counter != 0 {
-            let max = guts::max_subtree_len(self.initial_chunk_counter);
+            let max = hazmat::max_subtree_len(self.initial_chunk_counter);
             let remaining = max - self.count();
             assert!(
                 input.len() as u64 <= remaining,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,7 +227,7 @@ fn counter_high(counter: u64) -> u32 {
 /// [`Display`]: https://doc.rust-lang.org/std/fmt/trait.Display.html
 /// [`FromStr`]: https://doc.rust-lang.org/std/str/trait.FromStr.html
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-#[derive(Clone, Copy, Hash)]
+#[derive(Clone, Copy, Hash, Eq)]
 pub struct Hash([u8; OUT_LEN]);
 
 impl Hash {
@@ -353,8 +353,6 @@ impl PartialEq<[u8]> for Hash {
         constant_time_eq::constant_time_eq(&self.0, other)
     }
 }
-
-impl Eq for Hash {}
 
 impl fmt::Display for Hash {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -996,11 +996,9 @@ pub fn keyed_hash(key: &[u8; KEY_LEN], input: &[u8]) -> Hash {
 ///
 /// [Argon2]: https://en.wikipedia.org/wiki/Argon2
 pub fn derive_key(context: &str, key_material: &[u8]) -> [u8; OUT_LEN] {
-    let context_key =
-        hash_all_at_once::<join::SerialJoin>(context.as_bytes(), IV, DERIVE_KEY_CONTEXT, 0)
-            .root_hash();
-    let context_key_words = platform::words_from_le_bytes_32(context_key.as_bytes());
-    hash_all_at_once::<join::SerialJoin>(key_material, &context_key_words, DERIVE_KEY_MATERIAL, 0)
+    let key = guts::context_key(context);
+    let key_words = platform::words_from_le_bytes_32(&key);
+    hash_all_at_once::<join::SerialJoin>(key_material, &key_words, DERIVE_KEY_MATERIAL, 0)
         .root_hash()
         .0
 }
@@ -1102,11 +1100,9 @@ impl Hasher {
     ///
     /// [`derive_key`]: fn.derive_key.html
     pub fn new_derive_key(context: &str) -> Self {
-        let context_key =
-            hash_all_at_once::<join::SerialJoin>(context.as_bytes(), IV, DERIVE_KEY_CONTEXT, 0)
-                .root_hash();
-        let context_key_words = platform::words_from_le_bytes_32(context_key.as_bytes());
-        Self::new_internal(&context_key_words, DERIVE_KEY_MATERIAL)
+        let key = guts::context_key(context);
+        let key_words = platform::words_from_le_bytes_32(&key);
+        Self::new_internal(&key_words, DERIVE_KEY_MATERIAL)
     }
 
     /// Reset the `Hasher` to its initial state.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -997,9 +997,9 @@ pub fn keyed_hash(key: &[u8; KEY_LEN], input: &[u8]) -> Hash {
 ///
 /// [Argon2]: https://en.wikipedia.org/wiki/Argon2
 pub fn derive_key(context: &str, key_material: &[u8]) -> [u8; OUT_LEN] {
-    let key = hazmat::context_key(context);
-    let key_words = platform::words_from_le_bytes_32(&key);
-    hash_all_at_once::<join::SerialJoin>(key_material, &key_words, DERIVE_KEY_MATERIAL, 0)
+    let context_key = hazmat::hash_derive_key_context(context);
+    let context_key_words = platform::words_from_le_bytes_32(&context_key);
+    hash_all_at_once::<join::SerialJoin>(key_material, &context_key_words, DERIVE_KEY_MATERIAL, 0)
         .root_hash()
         .0
 }
@@ -1101,9 +1101,9 @@ impl Hasher {
     ///
     /// [`derive_key`]: fn.derive_key.html
     pub fn new_derive_key(context: &str) -> Self {
-        let key = hazmat::context_key(context);
-        let key_words = platform::words_from_le_bytes_32(&key);
-        Self::new_internal(&key_words, DERIVE_KEY_MATERIAL)
+        let context_key = hazmat::hash_derive_key_context(context);
+        let context_key_words = platform::words_from_le_bytes_32(&context_key);
+        Self::new_internal(&context_key_words, DERIVE_KEY_MATERIAL)
     }
 
     /// Reset the `Hasher` to its initial state.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -885,9 +885,9 @@ fn hash_all_at_once<J: join::Join>(input: &[u8], key: &CVWords, flags: u8, count
     // compress_subtree_to_parent_node().
     Output {
         input_chaining_value: *key,
-        block: compress_subtree_to_parent_node::<J>(input, key, 0, flags, platform),
+        block: compress_subtree_to_parent_node::<J>(input, key, counter, flags, platform),
         block_len: BLOCK_LEN as u8,
-        counter,
+        counter: 0,
         flags: flags | PARENT,
         platform,
     }
@@ -1338,7 +1338,7 @@ impl Hasher {
         // also. Convert it directly into an Output. Otherwise, we need to
         // merge subtrees below.
         if self.cv_stack.is_empty() {
-            debug_assert_eq!(self.chunk_state.chunk_counter, 0);
+            debug_assert_eq!(self.chunk_state.chunk_counter, self.initial_chunk_counter);
             return self.chunk_state.output();
         }
 
@@ -1359,7 +1359,7 @@ impl Hasher {
         if self.chunk_state.count() > 0 {
             debug_assert_eq!(
                 self.cv_stack.len(),
-                self.chunk_state.chunk_counter.count_ones() as usize,
+                (self.chunk_state.chunk_counter - self.initial_chunk_counter).count_ones() as usize,
                 "cv stack does not need a merge",
             );
             output = self.chunk_state.output();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1196,11 +1196,10 @@ impl Hasher {
     }
 
     fn update_with_join<J: join::Join>(&mut self, mut input: &[u8]) -> &mut Self {
-        #[cfg(debug_assertions)]
         if self.initial_chunk_counter != 0 {
             let max = guts::max_subtree_len(self.initial_chunk_counter);
             let remaining = max - self.count();
-            debug_assert!(
+            assert!(
                 input.len() as u64 <= remaining,
                 "the subtree starting at {} contains at most {} bytes (found {})",
                 CHUNK_LEN as u64 * self.initial_chunk_counter,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1207,8 +1207,8 @@ impl Hasher {
     }
 
     fn update_with_join<J: join::Join>(&mut self, mut input: &[u8]) -> &mut Self {
-        if self.initial_chunk_counter != 0 {
-            let max = hazmat::max_subtree_len(self.initial_chunk_counter);
+        let input_offset = self.initial_chunk_counter * CHUNK_LEN as u64;
+        if let Some(max) = hazmat::max_subtree_len(input_offset) {
             let remaining = max - self.count();
             assert!(
                 input.len() as u64 <= remaining,
@@ -1397,6 +1397,10 @@ impl Hasher {
     /// This method is idempotent. Calling it twice will give the same result.
     /// You can also add more input and finalize again.
     pub fn finalize(&self) -> Hash {
+        assert_eq!(
+            self.initial_chunk_counter, 0,
+            "set_input_offset must be used with finalized_non_root",
+        );
         self.final_output().root_hash()
     }
 
@@ -1408,6 +1412,10 @@ impl Hasher {
     ///
     /// [`OutputReader`]: struct.OutputReader.html
     pub fn finalize_xof(&self) -> OutputReader {
+        assert_eq!(
+            self.initial_chunk_counter, 0,
+            "set_input_offset must be used with finalized_non_root",
+        );
         OutputReader::new(self.final_output())
     }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -801,6 +801,7 @@ fn test_zeroize() {
             flags: 42,
             platform: crate::Platform::Portable,
         },
+        initial_chunk_counter: 42,
         key: [42; 8],
         cv_stack: [[42; 32]; { crate::MAX_DEPTH + 1 }].into(),
     };
@@ -815,6 +816,7 @@ fn test_zeroize() {
         hasher.chunk_state.platform,
         crate::Platform::Portable
     ));
+    assert_eq!(hasher.initial_chunk_counter, 0);
     assert_eq!(hasher.key, [0; 8]);
     assert_eq!(&*hasher.cv_stack, &[[0u8; 32]; 0]);
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -328,22 +328,6 @@ fn test_largest_power_of_two_leq() {
 }
 
 #[test]
-fn test_left_len() {
-    let input_output = &[
-        (CHUNK_LEN + 1, CHUNK_LEN),
-        (2 * CHUNK_LEN - 1, CHUNK_LEN),
-        (2 * CHUNK_LEN, CHUNK_LEN),
-        (2 * CHUNK_LEN + 1, 2 * CHUNK_LEN),
-        (4 * CHUNK_LEN - 1, 2 * CHUNK_LEN),
-        (4 * CHUNK_LEN, 2 * CHUNK_LEN),
-        (4 * CHUNK_LEN + 1, 4 * CHUNK_LEN),
-    ];
-    for &(input, output) in input_output {
-        assert_eq!(crate::left_len(input), output);
-    }
-}
-
-#[test]
 fn test_compare_reference_impl() {
     const OUT: usize = 303; // more than 64, not a multiple of 4
     let mut input_buf = [0; TEST_CASES_MAX];

--- a/src/test.rs
+++ b/src/test.rs
@@ -38,8 +38,12 @@ pub const TEST_CASES: &[usize] = &[
     7 * CHUNK_LEN + 1,
     8 * CHUNK_LEN,
     8 * CHUNK_LEN + 1,
-    16 * CHUNK_LEN,  // AVX512's bandwidth
-    31 * CHUNK_LEN,  // 16 + 8 + 4 + 2 + 1
+    16 * CHUNK_LEN - 1,
+    16 * CHUNK_LEN, // AVX512's bandwidth
+    16 * CHUNK_LEN + 1,
+    31 * CHUNK_LEN - 1,
+    31 * CHUNK_LEN, // 16 + 8 + 4 + 2 + 1
+    31 * CHUNK_LEN + 1,
     100 * CHUNK_LEN, // subtrees larger than MAX_SIMD_DEGREE chunks
 ];
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -1022,3 +1022,40 @@ fn test_miri_smoketest() {
     reader.set_position(999999);
     reader.fill(&mut [0]);
 }
+
+// I had to move these tests out of the deprecated guts module, because leaving them there causes
+// an un-silenceable warning: https://github.com/rust-lang/rust/issues/47238
+#[cfg(test)]
+#[allow(deprecated)]
+mod guts_tests {
+    use crate::guts::*;
+
+    #[test]
+    fn test_chunk() {
+        assert_eq!(
+            crate::hash(b"foo"),
+            ChunkState::new(0).update(b"foo").finalize(true)
+        );
+    }
+
+    #[test]
+    fn test_parents() {
+        let mut hasher = crate::Hasher::new();
+        let mut buf = [0; crate::CHUNK_LEN];
+
+        buf[0] = 'a' as u8;
+        hasher.update(&buf);
+        let chunk0_cv = ChunkState::new(0).update(&buf).finalize(false);
+
+        buf[0] = 'b' as u8;
+        hasher.update(&buf);
+        let chunk1_cv = ChunkState::new(1).update(&buf).finalize(false);
+
+        hasher.update(b"c");
+        let chunk2_cv = ChunkState::new(2).update(b"c").finalize(false);
+
+        let parent = parent_cv(&chunk0_cv, &chunk1_cv, false);
+        let root = parent_cv(&parent, &chunk2_cv, true);
+        assert_eq!(hasher.finalize(), root);
+    }
+}

--- a/test_vectors/src/lib.rs
+++ b/test_vectors/src/lib.rs
@@ -1,4 +1,4 @@
-use blake3::guts::{BLOCK_LEN, CHUNK_LEN};
+use blake3::{BLOCK_LEN, CHUNK_LEN};
 use serde::{Deserialize, Serialize};
 
 // Reading files at runtime requires special configuration under WASM/WASI, so including this at


### PR DESCRIPTION
cc @rklaehn @qti3e

The main goal of this new API is to make it so that projects like Bao don't depend on [undocumented APIs](https://github.com/BLAKE3-team/BLAKE3/blob/83a60d9da6a44b719e258926e568c203d3b4dd36/src/guts.rs), and projects like Iroh don't need to maintain [their own BLAKE3 forks](https://github.com/n0-computer/iroh-blake3).

Some questions in my mind:
- Do we like the `Mode` enum that the merge subtrees functions take? Should it hold keys by value instead of by reference?
- The `max_subtree_len` and `left_subtree_len` functions aren't really necessary (most callers don't need the former, and the latter is easily replicated), but I included them because their doc comments seemed like the best place to talk about the rules for the tree structure. Is that valuable? Are there other things we should document?