### PR TITLE
Fix TBB transitive dependencies for libblake3

### DIFF
--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -334,16 +334,17 @@ endfunction()
 #
 # TODO: Replace function with list(JOIN) when updating to CMake 3.12
 function(join_pkg_config_requires requires)
-  list(LENGTH ${requires} len)
+  set(_requires "${${requires}}") # avoid shadowing issues, e.g. "${requires}"=len
+  list(LENGTH "${requires}" len)
   set(idx 1)
-  foreach(req ${${requires}})
-    string(APPEND acc ${req})
+  foreach(req IN LISTS _requires)
+    string(APPEND acc "${req}")
     if(idx LESS len)
       string(APPEND acc ", ")
     endif()
     math(EXPR idx "${idx} + 1")
   endforeach()
-  set(${requires} ${acc} PARENT_SCOPE)
+  set("${requires}" "${acc}" PARENT_SCOPE)
 endfunction()
 
 # calculate pkg-config requirements

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -330,6 +330,29 @@ function(join_paths joined_path first_path_segment)
     set(${joined_path} "${temp_path}" PARENT_SCOPE)
 endfunction()
 
+# In-place rewrite a list of strings `requires` into a comma separated string.
+#
+# TODO: Replace function with list(JOIN) when updating to CMake 3.12
+function(join_pkg_config_requires requires)
+  list(LENGTH ${requires} len)
+  set(idx 1)
+  foreach(req ${${requires}})
+    string(APPEND acc ${req})
+    if(idx LESS len)
+      string(APPEND acc ", ")
+    endif()
+    math(EXPR idx "${idx} + 1")
+  endforeach()
+  set(${requires} ${acc} PARENT_SCOPE)
+endfunction()
+
+# calculate pkg-config requirements
+if(BLAKE3_USE_TBB)
+  list(APPEND PKG_CONFIG_REQUIRES "tbb >= ${TBB_VERSION}")
+endif()
+
+# pkg-config support
+join_pkg_config_requires(PKG_CONFIG_REQUIRES)
 join_paths(PKG_CONFIG_INSTALL_LIBDIR "\${prefix}" "${CMAKE_INSTALL_LIBDIR}")
 join_paths(PKG_CONFIG_INSTALL_INCLUDEDIR "\${prefix}" "${CMAKE_INSTALL_INCLUDEDIR}")
 configure_file(libblake3.pc.in libblake3.pc @ONLY)

--- a/c/blake3-config.cmake.in
+++ b/c/blake3-config.cmake.in
@@ -1,5 +1,14 @@
 @PACKAGE_INIT@
 
+include(CMakeFindDependencyMacro)
+
+# Remember TBB option state
+set(BLAKE3_USE_TBB @BLAKE3_USE_TBB@)
+
+if(BLAKE3_USE_TBB)
+    find_dependency(TBB @TBB_VERSION@)
+endif()
+
 include("${CMAKE_CURRENT_LIST_DIR}/blake3-targets.cmake")
 
 check_required_components(blake3)

--- a/c/libblake3.pc.in
+++ b/c/libblake3.pc.in
@@ -7,6 +7,6 @@ Name: @PROJECT_NAME@
 Description: @PROJECT_DESCRIPTION@
 Version: @PROJECT_VERSION@
 
-Requires:
+Requires: @PKG_CONFIG_REQUIRES@
 Libs: -L"${libdir}" -lblake3
 Cflags: -I"${includedir}" @BLAKE3_PKGCONFIG_CFLAGS@


### PR DESCRIPTION
This PR fixes the transitive dependencies for TBB when `libblake3` is built with `BLAKE3_USE_TBB=1` which I unfortunately overlooked in the original PR.

This PR introduces two changes:

- when `BLAKE3_USE_TBB=1` then `tbb` is added to the `Requires:` field for `pkg-config`
- when `BLAKE3_USE_TBB=1` then CMake `find_package(blake3)` automatically finds and configures the `TBB::tbb` target

Additionally, TBB functionality can be specifically requested through the CMake config with the following (which will fail with an informative error if not available):

```cmake
find_package(blake3 COMPONENTS TBB)
```

An alternative design to this fix would be the approach suggested by @Ericson2314 in this [comment](https://github.com/NixOS/nix/pull/12676#discussion_r2021445539).