### PR TITLE
Fix pkg-config with multiple CFLAGS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,8 +258,8 @@ jobs:
     - run: docker run -v $(pwd):/io -w /io messense/cargo-xwin cargo xwin test --target x86_64-pc-windows-msvc --features=mmap,rayon,traits-preview,serde,zeroize
 
   # Currently only on x86.
-  c_tests:
-    name: C tests SIMD=${{ matrix.simd }} TBB=${{ matrix.use_tbb }}
+  cmake_c_tests:
+    name: CMake C tests SIMD=${{ matrix.simd }} TBB=${{ matrix.use_tbb }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -301,6 +301,28 @@ jobs:
     - run: |
         cmake --fresh -S c -B c/build -G Ninja -DBLAKE3_TESTING=ON -DBLAKE3_TESTING_CI=ON -DBLAKE3_EXAMPLES=ON "-DBLAKE3_USE_TBB=${{ matrix.use_tbb }}"
         cmake --build c/build --target blake3-example
+
+  # Currently only on x86.
+  pkg_config_c_tests:
+    name: pkg-config C tests TBB=${{ matrix.use_tbb }} BUILD_SHARED_LIBS=${{ matrix.shared_libs }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        use_tbb: ["OFF", "ON"]
+        shared_libs: ["OFF", "ON"]
+    steps:
+    - uses: actions/checkout@v4
+    - run: |
+        sudo apt-get update
+        sudo apt-get install ninja-build libtbb-dev libtbb12
+    - run: cmake --fresh -S c -B c/build -G Ninja -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/target "-DBLAKE3_USE_TBB=${{ matrix.use_tbb }}" "-DBUILD_SHARED_LIBS=${{ matrix.shared_libs }}"
+    - run: cmake --build c/build --target install
+    - run: mkdir -p ${{ github.workspace }}/target/bin
+    - run: echo "PKG_CONFIG_PATH=${{ github.workspace }}/target/lib/pkgconfig" >> $GITHUB_ENV
+    - run: gcc -O3 -o ${{ github.workspace }}/target/bin/blake3-example c/example.c $(pkg-config --cflags --libs libblake3) -lstdc++
+    - if: matrix.use_tbb == 'ON'
+      run: gcc -O3 -o ${{ github.workspace }}/target/bin/blake3-example-tbb c/example_tbb.c $(pkg-config --cflags --libs libblake3) -lstdc++
 
   # Note that this jobs builds AArch64 binaries from an x86_64 host.
   build_apple_silicon:

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -127,13 +127,13 @@ add_library(blake3
 add_library(BLAKE3::blake3 ALIAS blake3)
 
 # library configuration
-set(BLAKE3_PKGCONFIG_CFLAGS)
+set(PKG_CONFIG_CFLAGS)
 if (BUILD_SHARED_LIBS)
   target_compile_definitions(blake3
     PUBLIC BLAKE3_DLL
     PRIVATE BLAKE3_DLL_EXPORTS
   )
-  list(APPEND BLAKE3_PKGCONFIG_CFLAGS -DBLAKE3_DLL)
+  list(APPEND PKG_CONFIG_CFLAGS -DBLAKE3_DLL)
 endif()
 target_include_directories(blake3 PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
@@ -241,7 +241,7 @@ if(BLAKE3_USE_TBB)
         BLAKE3_USE_TBB)
   endif()
   list(APPEND PKG_CONFIG_REQUIRES "tbb >= ${TBB_VERSION}")
-  list(APPEND BLAKE3_PKGCONFIG_CFLAGS -DBLAKE3_USE_TBB)
+  list(APPEND PKG_CONFIG_CFLAGS -DBLAKE3_USE_TBB)
 endif()
 
 if(BLAKE3_USE_TBB)
@@ -332,17 +332,17 @@ function(join_paths joined_path first_path_segment)
     set(${joined_path} "${temp_path}" PARENT_SCOPE)
 endfunction()
 
-# In-place rewrite a list of strings `requires` into a comma separated string.
+# In-place rewrite a string and and join by `sep`.
 #
 # TODO: Replace function with list(JOIN) when updating to CMake 3.12
-function(join_pkg_config_requires requires)
+function(join_pkg_config_field sep requires)
   set(_requires "${${requires}}") # avoid shadowing issues, e.g. "${requires}"=len
   list(LENGTH "${requires}" len)
   set(idx 1)
   foreach(req IN LISTS _requires)
     string(APPEND acc "${req}")
     if(idx LESS len)
-      string(APPEND acc ", ")
+      string(APPEND acc "${sep}")
     endif()
     math(EXPR idx "${idx} + 1")
   endforeach()
@@ -350,7 +350,8 @@ function(join_pkg_config_requires requires)
 endfunction()
 
 # pkg-config support
-join_pkg_config_requires(PKG_CONFIG_REQUIRES)
+join_pkg_config_field(", " PKG_CONFIG_REQUIRES)
+join_pkg_config_field(" " PKG_CONFIG_CFLAGS)
 join_paths(PKG_CONFIG_INSTALL_LIBDIR "\${prefix}" "${CMAKE_INSTALL_LIBDIR}")
 join_paths(PKG_CONFIG_INSTALL_INCLUDEDIR "\${prefix}" "${CMAKE_INSTALL_INCLUDEDIR}")
 configure_file(libblake3.pc.in libblake3.pc @ONLY)

--- a/c/libblake3.pc.in
+++ b/c/libblake3.pc.in
@@ -9,4 +9,4 @@ Version: @PROJECT_VERSION@
 
 Requires: @PKG_CONFIG_REQUIRES@
 Libs: -L"${libdir}" -lblake3
-Cflags: -I"${includedir}" @BLAKE3_PKGCONFIG_CFLAGS@
+Cflags: -I"${includedir}" @PKG_CONFIG_CFLAGS@


### PR DESCRIPTION
This PR fixes the pkg-config CFLAGS when multiple features are enabled.

The problem is that CMake expands `PKG_CONFIG_CFLAGS` as a semi-colon separated list but this only occurs if there are multiple entries.

Unfortunately this didn't show up for me because `-DBUILD_SHARED_LIBS` was not enabled.

The fix is to re-use the same logic as for the `Requires` field to manually expand the field before substitution.

I've also added some CI tests which should catch some of this in the future.

Apologies for the churn around all of this.

@BurningEnlightenment @oconnor663 