### PR TITLE
Prepare for const

### DIFF
--- a/src/platform.rs
+++ b/src/platform.rs
@@ -1,5 +1,4 @@
 use crate::{portable, CVWords, IncrementCounter, BLOCK_LEN};
-use arrayref::{array_mut_ref, array_ref};
 
 cfg_if::cfg_if! {
     if #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {
@@ -514,74 +513,96 @@ pub fn sse2_detected() -> bool {
     false
 }
 
+macro_rules! extract_u32_from_byte_chunks {
+    ($src:ident, $chunk_index:literal) => {
+        u32::from_le_bytes([
+            $src[$chunk_index * 4 + 0],
+            $src[$chunk_index * 4 + 1],
+            $src[$chunk_index * 4 + 2],
+            $src[$chunk_index * 4 + 3],
+        ])
+    };
+}
+
+macro_rules! store_u32_to_by_chunks {
+    ($src:ident, $dst:ident, $chunk_index:literal) => {
+        [
+            $dst[$chunk_index * 4 + 0],
+            $dst[$chunk_index * 4 + 1],
+            $dst[$chunk_index * 4 + 2],
+            $dst[$chunk_index * 4 + 3],
+        ] = $src[$chunk_index].to_le_bytes();
+    };
+}
+
 #[inline(always)]
-pub fn words_from_le_bytes_32(bytes: &[u8; 32]) -> [u32; 8] {
+pub const fn words_from_le_bytes_32(bytes: &[u8; 32]) -> [u32; 8] {
     let mut out = [0; 8];
-    out[0] = u32::from_le_bytes(*array_ref!(bytes, 0 * 4, 4));
-    out[1] = u32::from_le_bytes(*array_ref!(bytes, 1 * 4, 4));
-    out[2] = u32::from_le_bytes(*array_ref!(bytes, 2 * 4, 4));
-    out[3] = u32::from_le_bytes(*array_ref!(bytes, 3 * 4, 4));
-    out[4] = u32::from_le_bytes(*array_ref!(bytes, 4 * 4, 4));
-    out[5] = u32::from_le_bytes(*array_ref!(bytes, 5 * 4, 4));
-    out[6] = u32::from_le_bytes(*array_ref!(bytes, 6 * 4, 4));
-    out[7] = u32::from_le_bytes(*array_ref!(bytes, 7 * 4, 4));
+    out[0] = extract_u32_from_byte_chunks!(bytes, 0);
+    out[1] = extract_u32_from_byte_chunks!(bytes, 1);
+    out[2] = extract_u32_from_byte_chunks!(bytes, 2);
+    out[3] = extract_u32_from_byte_chunks!(bytes, 3);
+    out[4] = extract_u32_from_byte_chunks!(bytes, 4);
+    out[5] = extract_u32_from_byte_chunks!(bytes, 5);
+    out[6] = extract_u32_from_byte_chunks!(bytes, 6);
+    out[7] = extract_u32_from_byte_chunks!(bytes, 7);
     out
 }
 
 #[inline(always)]
-pub fn words_from_le_bytes_64(bytes: &[u8; 64]) -> [u32; 16] {
+pub const fn words_from_le_bytes_64(bytes: &[u8; 64]) -> [u32; 16] {
     let mut out = [0; 16];
-    out[0] = u32::from_le_bytes(*array_ref!(bytes, 0 * 4, 4));
-    out[1] = u32::from_le_bytes(*array_ref!(bytes, 1 * 4, 4));
-    out[2] = u32::from_le_bytes(*array_ref!(bytes, 2 * 4, 4));
-    out[3] = u32::from_le_bytes(*array_ref!(bytes, 3 * 4, 4));
-    out[4] = u32::from_le_bytes(*array_ref!(bytes, 4 * 4, 4));
-    out[5] = u32::from_le_bytes(*array_ref!(bytes, 5 * 4, 4));
-    out[6] = u32::from_le_bytes(*array_ref!(bytes, 6 * 4, 4));
-    out[7] = u32::from_le_bytes(*array_ref!(bytes, 7 * 4, 4));
-    out[8] = u32::from_le_bytes(*array_ref!(bytes, 8 * 4, 4));
-    out[9] = u32::from_le_bytes(*array_ref!(bytes, 9 * 4, 4));
-    out[10] = u32::from_le_bytes(*array_ref!(bytes, 10 * 4, 4));
-    out[11] = u32::from_le_bytes(*array_ref!(bytes, 11 * 4, 4));
-    out[12] = u32::from_le_bytes(*array_ref!(bytes, 12 * 4, 4));
-    out[13] = u32::from_le_bytes(*array_ref!(bytes, 13 * 4, 4));
-    out[14] = u32::from_le_bytes(*array_ref!(bytes, 14 * 4, 4));
-    out[15] = u32::from_le_bytes(*array_ref!(bytes, 15 * 4, 4));
+    out[0] = extract_u32_from_byte_chunks!(bytes, 0);
+    out[1] = extract_u32_from_byte_chunks!(bytes, 1);
+    out[2] = extract_u32_from_byte_chunks!(bytes, 2);
+    out[3] = extract_u32_from_byte_chunks!(bytes, 3);
+    out[4] = extract_u32_from_byte_chunks!(bytes, 4);
+    out[5] = extract_u32_from_byte_chunks!(bytes, 5);
+    out[6] = extract_u32_from_byte_chunks!(bytes, 6);
+    out[7] = extract_u32_from_byte_chunks!(bytes, 7);
+    out[8] = extract_u32_from_byte_chunks!(bytes, 8);
+    out[9] = extract_u32_from_byte_chunks!(bytes, 9);
+    out[10] = extract_u32_from_byte_chunks!(bytes, 10);
+    out[11] = extract_u32_from_byte_chunks!(bytes, 11);
+    out[12] = extract_u32_from_byte_chunks!(bytes, 12);
+    out[13] = extract_u32_from_byte_chunks!(bytes, 13);
+    out[14] = extract_u32_from_byte_chunks!(bytes, 14);
+    out[15] = extract_u32_from_byte_chunks!(bytes, 15);
     out
 }
 
 #[inline(always)]
-pub fn le_bytes_from_words_32(words: &[u32; 8]) -> [u8; 32] {
+pub const fn le_bytes_from_words_32(words: &[u32; 8]) -> [u8; 32] {
     let mut out = [0; 32];
-    *array_mut_ref!(out, 0 * 4, 4) = words[0].to_le_bytes();
-    *array_mut_ref!(out, 1 * 4, 4) = words[1].to_le_bytes();
-    *array_mut_ref!(out, 2 * 4, 4) = words[2].to_le_bytes();
-    *array_mut_ref!(out, 3 * 4, 4) = words[3].to_le_bytes();
-    *array_mut_ref!(out, 4 * 4, 4) = words[4].to_le_bytes();
-    *array_mut_ref!(out, 5 * 4, 4) = words[5].to_le_bytes();
-    *array_mut_ref!(out, 6 * 4, 4) = words[6].to_le_bytes();
-    *array_mut_ref!(out, 7 * 4, 4) = words[7].to_le_bytes();
+    store_u32_to_by_chunks!(words, out, 0);
+    store_u32_to_by_chunks!(words, out, 1);
+    store_u32_to_by_chunks!(words, out, 2);
+    store_u32_to_by_chunks!(words, out, 3);
+    store_u32_to_by_chunks!(words, out, 4);
+    store_u32_to_by_chunks!(words, out, 5);
+    store_u32_to_by_chunks!(words, out, 6);
+    store_u32_to_by_chunks!(words, out, 7);
     out
 }
 
 #[inline(always)]
-pub fn le_bytes_from_words_64(words: &[u32; 16]) -> [u8; 64] {
+pub const fn le_bytes_from_words_64(words: &[u32; 16]) -> [u8; 64] {
     let mut out = [0; 64];
-    *array_mut_ref!(out, 0 * 4, 4) = words[0].to_le_bytes();
-    *array_mut_ref!(out, 1 * 4, 4) = words[1].to_le_bytes();
-    *array_mut_ref!(out, 2 * 4, 4) = words[2].to_le_bytes();
-    *array_mut_ref!(out, 3 * 4, 4) = words[3].to_le_bytes();
-    *array_mut_ref!(out, 4 * 4, 4) = words[4].to_le_bytes();
-    *array_mut_ref!(out, 5 * 4, 4) = words[5].to_le_bytes();
-    *array_mut_ref!(out, 6 * 4, 4) = words[6].to_le_bytes();
-    *array_mut_ref!(out, 7 * 4, 4) = words[7].to_le_bytes();
-    *array_mut_ref!(out, 8 * 4, 4) = words[8].to_le_bytes();
-    *array_mut_ref!(out, 9 * 4, 4) = words[9].to_le_bytes();
-    *array_mut_ref!(out, 10 * 4, 4) = words[10].to_le_bytes();
-    *array_mut_ref!(out, 11 * 4, 4) = words[11].to_le_bytes();
-    *array_mut_ref!(out, 12 * 4, 4) = words[12].to_le_bytes();
-    *array_mut_ref!(out, 13 * 4, 4) = words[13].to_le_bytes();
-    *array_mut_ref!(out, 14 * 4, 4) = words[14].to_le_bytes();
-    *array_mut_ref!(out, 15 * 4, 4) = words[15].to_le_bytes();
+    store_u32_to_by_chunks!(words, out, 0);
+    store_u32_to_by_chunks!(words, out, 1);
+    store_u32_to_by_chunks!(words, out, 2);
+    store_u32_to_by_chunks!(words, out, 3);
+    store_u32_to_by_chunks!(words, out, 4);
+    store_u32_to_by_chunks!(words, out, 5);
+    store_u32_to_by_chunks!(words, out, 6);
+    store_u32_to_by_chunks!(words, out, 7);
+    store_u32_to_by_chunks!(words, out, 8);
+    store_u32_to_by_chunks!(words, out, 9);
+    store_u32_to_by_chunks!(words, out, 10);
+    store_u32_to_by_chunks!(words, out, 11);
+    store_u32_to_by_chunks!(words, out, 12);
+    store_u32_to_by_chunks!(words, out, 13);
+    store_u32_to_by_chunks!(words, out, 14);
+    store_u32_to_by_chunks!(words, out, 15);
     out
 }


### PR DESCRIPTION
This is extracted from https://github.com/BLAKE3-team/BLAKE3/pull/439.

`arrayref` usage was reduced due to API being non-`const` and honestly a bit confusing to use. With a few trivial macros it can be removed in many places (I only touched those relevant to https://github.com/BLAKE3-team/BLAKE3/pull/439) and expanded code is much easier to read.

Portable implementation was refactored a bit to make functions `const fn`-friendly, but not marked as `const fn` just yet.

Hopefully these changes are not too controversial.