### PR TITLE
Remove compiler check for TBB feature

### DIFF
--- a/c/dependencies/tbb/CMakeLists.txt
+++ b/c/dependencies/tbb/CMakeLists.txt
@@ -1,8 +1,3 @@
-if(WIN32 AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  message(FATAL_ERROR "BLAKE3_USE_TBB requires building with Clang or MSVC on Windows")
-  set(BLAKE3_USE_TBB OFF)
-endif()
-
 find_package(TBB 2021.11.0 QUIET)
 
 if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.11)


### PR DESCRIPTION
Compilation may work with other configurations such as MinGW under the right circumstances.

Related: #467

CC @Ericson2314

@BurningEnlightenment @oconnor663 Would it be possible to make a new patch release with this and #464? That would help resolve some downstream issues for Nix:

- https://github.com/NixOS/nix/issues/12889#issuecomment-2787107051
- https://github.com/NixOS/nix/pull/12676