### PR TITLE
Check x86 features even in `no_std`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,11 +114,14 @@ arrayref = "0.3.5"
 arrayvec = { version = "0.7.4", default-features = false }
 constant_time_eq = { version = "0.3.1", default-features = false }
 cfg-if = "1.0.0"
-digest = { version = "0.10.1", features = [ "mac" ], optional = true }
+digest = { version = "0.10.1", features = ["mac"], optional = true }
 memmap2 = { version = "0.9", optional = true }
 rayon-core = { version = "1.12.1", optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 zeroize = { version = "1", default-features = false, optional = true }
+
+[target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]
+cpufeatures = "0.2.17"
 
 [dev-dependencies]
 hmac = "0.12.0"

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -408,7 +408,6 @@ impl Platform {
 #[cfg(blake3_avx512_ffi)]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[inline(always)]
-#[allow(unreachable_code)]
 pub fn avx512_detected() -> bool {
     if cfg!(miri) {
         return false;
@@ -418,24 +417,13 @@ pub fn avx512_detected() -> bool {
     if cfg!(feature = "no_avx512") {
         return false;
     }
-    // Static check, e.g. for building with target-cpu=native.
-    #[cfg(all(target_feature = "avx512f", target_feature = "avx512vl"))]
-    {
-        return true;
-    }
-    // Dynamic check, if std is enabled.
-    #[cfg(feature = "std")]
-    {
-        if is_x86_feature_detected!("avx512f") && is_x86_feature_detected!("avx512vl") {
-            return true;
-        }
-    }
-    false
+
+    cpufeatures::new!(has_avx512, "avx512f", "avx512vl");
+    has_avx512::get()
 }
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[inline(always)]
-#[allow(unreachable_code)]
 pub fn avx2_detected() -> bool {
     if cfg!(miri) {
         return false;
@@ -445,24 +433,13 @@ pub fn avx2_detected() -> bool {
     if cfg!(feature = "no_avx2") {
         return false;
     }
-    // Static check, e.g. for building with target-cpu=native.
-    #[cfg(target_feature = "avx2")]
-    {
-        return true;
-    }
-    // Dynamic check, if std is enabled.
-    #[cfg(feature = "std")]
-    {
-        if is_x86_feature_detected!("avx2") {
-            return true;
-        }
-    }
-    false
+
+    cpufeatures::new!(has_avx2, "avx2");
+    has_avx2::get()
 }
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[inline(always)]
-#[allow(unreachable_code)]
 pub fn sse41_detected() -> bool {
     if cfg!(miri) {
         return false;
@@ -472,24 +449,13 @@ pub fn sse41_detected() -> bool {
     if cfg!(feature = "no_sse41") {
         return false;
     }
-    // Static check, e.g. for building with target-cpu=native.
-    #[cfg(target_feature = "sse4.1")]
-    {
-        return true;
-    }
-    // Dynamic check, if std is enabled.
-    #[cfg(feature = "std")]
-    {
-        if is_x86_feature_detected!("sse4.1") {
-            return true;
-        }
-    }
-    false
+
+    cpufeatures::new!(has_sse41, "sse4.1");
+    has_sse41::get()
 }
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[inline(always)]
-#[allow(unreachable_code)]
 pub fn sse2_detected() -> bool {
     if cfg!(miri) {
         return false;
@@ -499,19 +465,9 @@ pub fn sse2_detected() -> bool {
     if cfg!(feature = "no_sse2") {
         return false;
     }
-    // Static check, e.g. for building with target-cpu=native.
-    #[cfg(target_feature = "sse2")]
-    {
-        return true;
-    }
-    // Dynamic check, if std is enabled.
-    #[cfg(feature = "std")]
-    {
-        if is_x86_feature_detected!("sse2") {
-            return true;
-        }
-    }
-    false
+
+    cpufeatures::new!(has_sse2, "sse2");
+    has_sse2::get()
 }
 
 #[inline(always)]


### PR DESCRIPTION
This makes it possible to use accelerated versions with runtime feature detection in `no_std` environment.

This is nice in projects where bare-metal implementation is needed or when most all the code is already `no_std` and requiring `std` just to get a faster version of blake3 is inconvenient.

I went with well known and well maintained `cpufeatures`, though eventually previously used macros should become usable from `::core`: https://github.com/rust-lang/rfcs/pull/2725

Note that `cpufeatures` already handles cases where features are enabled at compile time, so there is no need for explicit `#[cfg(target_feature = "X")]` blocks anymore.

The only thing that still depends on `std` feature now is `std::io`.