### PR TITLE
Added Clickhouse to the adoption list

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ Here's a (non-exhaustive) list of protocols and software that use BLAKE3:
 * [Solana](https://docs.rs/solana-program/1.9.5/solana_program/blake3/index.html)
 * [Tekken 8](https://en.bandainamcoent.eu/tekken/tekken-8)
 * [Wasmer](https://github.com/wasmerio/wasmer/blob/4f935a8c162bf604df223003e434e4f7ca253688/lib/cache/src/hash.rs#L21)
+* [Clickhouse](https://github.com/ClickHouse/ClickHouse/blob/master/rust/chcache/Cargo.toml#L7)
 
 
 ## Miscellany


### PR DESCRIPTION
[Clickhouse uses BLAKE3](https://clickhouse.com/docs/sql-reference/functions/hash-functions#blake3)

It shows here in their [cargo.toml file](https://github.com/ClickHouse/ClickHouse/blob/master/rust/chcache/Cargo.toml#L7).

And they seem to be happy about it too

`BLAKE3 performs more than 2x faster than SHA224 or SHA256 and a bit faster than MD5. Also, BLAKE3 is secure, unlike MD5 and SHA-1 and protected against length extension, unlike SHA-2.`

More about their usage here - https://clickhouse.com/blog/more-than-2x-faster-hashing-in-clickhouse-using-rust