### PR TITLE
Relax Clang frontend variant detection

### DIFF
--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -23,6 +23,7 @@ option(BLAKE3_FETCH_TBB "Allow fetching oneTBB from GitHub if not found on syste
 include(CTest)
 include(FeatureSummary)
 include(GNUInstallDirs)
+include(BLAKE3/Utils)
 
 add_subdirectory(dependencies)
 
@@ -258,32 +259,19 @@ if(BLAKE3_USE_TBB)
     set(APPEND BLAKE3_CXX_STANDARD_FLAGS_GNU -std=c++20)
     set(APPEND BLAKE3_CXX_STANDARD_FLAGS_MSVC /std:c++20)
   endif()
+
   set(BLAKE3_CXXFLAGS_GNU "-fno-exceptions;-fno-rtti;${BLAKE3_CXX_STANDARD_FLAGS_GNU}" CACHE STRING "C++ flags used for compiling private BLAKE3 library components with GNU-like compiler frontends.")
   set(BLAKE3_CXXFLAGS_MSVC "/EHs-c-;/GR-;${BLAKE3_CXX_STANDARD_FLAGS_MSVC}" CACHE STRING "C++ flags used for compiling private BLAKE3 library components with MSVC-like compiler frontends.")
-  # Get the C++ compiler name without extension
-  get_filename_component(BLAKE3_CMAKE_CXX_COMPILER_NAME "${CMAKE_CXX_COMPILER}" NAME_WE)
-  # Strip any trailing versioning from the C++ compiler name
-  string(REGEX MATCH "^(clang\\+\\+|clang-cl)" BLAKE3_CMAKE_CXX_COMPILER_NAME "${BLAKE3_CMAKE_CXX_COMPILER_NAME}")
 
-  # TODO: Simplify with CMAKE_CXX_COMPILER_FRONTEND_VARIANT once min CMake version is 3.14.
-  if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+  if(BLAKE3_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "GNU")
     target_compile_options(blake3 PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${BLAKE3_CXXFLAGS_GNU}>)
-  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    if(BLAKE3_CMAKE_CXX_COMPILER_NAME STREQUAL "clang++")
-      target_compile_options(blake3 PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${BLAKE3_CXXFLAGS_GNU}>)
-    elseif(BLAKE3_CMAKE_CXX_COMPILER_NAME STREQUAL "clang-cl")
-      target_compile_options(blake3 PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${BLAKE3_CXXFLAGS_MSVC}>)
-    endif()
-  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    target_compile_options(blake3 PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${BLAKE3_CXXFLAGS_GNU}>)
-  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+  elseif(BLAKE3_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC")
     target_compile_options(blake3 PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${BLAKE3_CXXFLAGS_MSVC}>)
   endif()
 
   # Undefine scratch variables
   unset(BLAKE3_CXX_STANDARD_FLAGS_GNU)
   unset(BLAKE3_CXX_STANDARD_FLAGS_MSVC)
-  unset(BLAKE3_CMAKE_CXX_COMPILER_NAME)
   unset(BLAKE3_CXXFLAGS_GNU)
   unset(BLAKE3_CXXFLAGS_MSVC)
 endif()

--- a/c/cmake/BLAKE3/Utils.cmake
+++ b/c/cmake/BLAKE3/Utils.cmake
@@ -1,0 +1,21 @@
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.10)
+  include_guard(GLOBAL)
+endif()
+
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.14)
+  set(BLAKE3_CXX_COMPILER_FRONTEND_VARIANT ${CMAKE_CXX_COMPILER_FRONTEND_VARIANT})
+else()
+  # Get the C++ compiler name without extension
+  get_filename_component(BLAKE3_CMAKE_CXX_COMPILER_NAME "${CMAKE_CXX_COMPILER}" NAME_WE)
+  # Strip any trailing versioning from the C++ compiler name
+  string(REGEX MATCH "^.*(clang\\+\\+|clang-cl)" BLAKE3_CMAKE_CXX_COMPILER_NAME "${BLAKE3_CMAKE_CXX_COMPILER_NAME}")
+  # Guess the frontend variant from the C++ compiler name
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND BLAKE3_CMAKE_CXX_COMPILER_NAME STREQUAL "clang-cl")
+    set(BLAKE3_CXX_COMPILER_FRONTEND_VARIANT "MSVC")
+  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    set(BLAKE3_CXX_COMPILER_FRONTEND_VARIANT "MSVC")
+  else()
+    set(BLAKE3_CXX_COMPILER_FRONTEND_VARIANT "GNU")
+  endif()
+  unset(BLAKE3_CMAKE_CXX_COMPILER_NAME)
+endif()


### PR DESCRIPTION
This allows Clang frontend variant detection to work better in more scenarios such as when compiling with cross-compilers with platform prefixes.

In particular this fixes cross-compiles from Linux to FreeBSD for nix packaging.

It would be good to get this in the next patch release but probably isn't critical enough to warrant it's own release since it should only show up when using both Clang and specially named cross-compiler (which is somewhat unusual since Clang already supports multiple targets).

CC @Ericson2314
