### PR TITLE
`impl Deref for Hash`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,6 +144,7 @@ use arrayref::{array_mut_ref, array_ref};
 use arrayvec::{ArrayString, ArrayVec};
 use core::cmp;
 use core::fmt;
+use core::ops::Deref;
 use platform::{Platform, MAX_SIMD_DEGREE, MAX_SIMD_DEGREE_OR_2};
 #[cfg(feature = "zeroize")]
 use zeroize::Zeroize;
@@ -241,9 +242,18 @@ fn counter_high(counter: u64) -> u32 {
 #[derive(Clone, Copy, Hash, Eq)]
 pub struct Hash([u8; OUT_LEN]);
 
+impl Deref for Hash {
+    type Target = [u8; OUT_LEN];
+
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 impl Hash {
     /// The raw bytes of the `Hash`. Note that byte arrays don't provide
-    /// constant-time equality checking, so if  you need to compare hashes,
+    /// constant-time equality checking, so if you need to compare hashes,
     /// prefer the `Hash` type.
     #[inline]
     pub const fn as_bytes(&self) -> &[u8; OUT_LEN] {


### PR DESCRIPTION
Something I found needing over and over again.

Allows to index hash with `hash[0]`, slice `&hash[..4]`, convert to `[u8; 32]` with `*hash`.

The regular methods are still useful because they are `const fn`, but `Deref` makes things so much easier in many cases.

I wasn't sure if you'd like `DerefMut`, so I didn't add it (should be a rare need anyway).