### PR TITLE
Fix mmap() conditions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1533,8 +1533,8 @@ impl Hasher {
     /// ```
     #[cfg(feature = "mmap")]
     pub fn update_mmap(&mut self, path: impl AsRef<std::path::Path>) -> std::io::Result<&mut Self> {
-        let file = std::fs::File::open(path.as_ref())?;
-        if let Some(mmap) = io::maybe_mmap_file(&file)? {
+        let mut file = std::fs::File::open(path.as_ref())?;
+        if let Some(mmap) = io::maybe_mmap_file(&mut file)? {
             self.update(&mmap);
         } else {
             io::copy_wide(&file, self)?;
@@ -1588,8 +1588,8 @@ impl Hasher {
         &mut self,
         path: impl AsRef<std::path::Path>,
     ) -> std::io::Result<&mut Self> {
-        let file = std::fs::File::open(path.as_ref())?;
-        if let Some(mmap) = io::maybe_mmap_file(&file)? {
+        let mut file = std::fs::File::open(path.as_ref())?;
+        if let Some(mmap) = io::maybe_mmap_file(&mut file)? {
             self.update_rayon(&mmap);
         } else {
             io::copy_wide(&file, self)?;


### PR DESCRIPTION
Get the file size from seeking to the end (canonical, equivalent to File::stream_len()) instead of fstat(); this is more real and unseekable files are unmappable (conversely, in the vast majority of cases, seekable files are mappable)

Always try to map (size permitting) instead of only mapping S_IFREGs and fall back to reading on failure (instead of hard-erroring). This means we can map devices and correctly fall back if the mapping failed for any number of inocuous reasons (mapping too big, too many mappings, whatever)

This also ends up faster (lseek()+mmap() instead of statx()+statx()+mmap())

Modelled after https://git.sr.ht/~nabijaczleweli/voreutils/commit/e4621ad93ae69d28c032932ad617c026790c0a40