### PR TITLE
Fix Typo in Generic Arguments Comment in wasm32_simd.rs

### DIFF
--- a/src/wasm32_simd.rs
+++ b/src/wasm32_simd.rs
@@ -134,7 +134,7 @@ fn unpackhi_epi32(a: v128, b: v128) -> v128 {
 fn shuffle_epi32<const I3: usize, const I2: usize, const I1: usize, const I0: usize>(
     a: v128,
 ) -> v128 {
-    // Please note that generic arguments in delcaration and imlementation are in
+    // Please note that generic arguments in delcaration and implementation are in
     // different order.
     // second arg is actually ignored.
     i32x4_shuffle::<I0, I1, I2, I3>(a, a)


### PR DESCRIPTION


**Description:**  
This pull request corrects a minor typo in a comment regarding generic arguments in the `wasm32_simd.rs` file. The word "implementation" is now spelled correctly for improved code clarity and professionalism. No functional changes were made.