### PR TITLE
Add `BlockBytes` and `BlockWords` type aliases

### DIFF
--- a/src/ffi_avx512.rs
+++ b/src/ffi_avx512.rs
@@ -1,9 +1,9 @@
-use crate::{CVWords, IncrementCounter, BLOCK_LEN, OUT_LEN};
+use crate::{BlockBytes, CVWords, IncrementCounter, BLOCK_LEN, OUT_LEN};
 
 // Unsafe because this may only be called on platforms supporting AVX-512.
 pub unsafe fn compress_in_place(
     cv: &mut CVWords,
-    block: &[u8; BLOCK_LEN],
+    block: &BlockBytes,
     block_len: u8,
     counter: u64,
     flags: u8,
@@ -22,11 +22,11 @@ pub unsafe fn compress_in_place(
 // Unsafe because this may only be called on platforms supporting AVX-512.
 pub unsafe fn compress_xof(
     cv: &CVWords,
-    block: &[u8; BLOCK_LEN],
+    block: &BlockBytes,
     block_len: u8,
     counter: u64,
     flags: u8,
-) -> [u8; 64] {
+) -> BlockBytes {
     unsafe {
         let mut out = [0u8; 64];
         ffi::blake3_compress_xof_avx512(
@@ -76,7 +76,7 @@ pub unsafe fn hash_many<const N: usize>(
 #[cfg(unix)]
 pub unsafe fn xof_many(
     cv: &CVWords,
-    block: &[u8; BLOCK_LEN],
+    block: &BlockBytes,
     block_len: u8,
     counter: u64,
     flags: u8,

--- a/src/ffi_neon.rs
+++ b/src/ffi_neon.rs
@@ -1,4 +1,4 @@
-use crate::{CVWords, IncrementCounter, BLOCK_LEN, OUT_LEN};
+use crate::{BlockBytes, CVWords, IncrementCounter, BLOCK_LEN, OUT_LEN};
 
 // Unsafe because this may only be called on platforms supporting NEON.
 pub unsafe fn hash_many<const N: usize>(
@@ -44,7 +44,7 @@ pub extern "C" fn blake3_compress_in_place_portable(
     unsafe {
         crate::portable::compress_in_place(
             &mut *(cv as *mut [u32; 8]),
-            &*(block as *const [u8; 64]),
+            &*(block as *const BlockBytes),
             block_len,
             counter,
             flags,

--- a/src/ffi_sse2.rs
+++ b/src/ffi_sse2.rs
@@ -1,9 +1,9 @@
-use crate::{CVWords, IncrementCounter, BLOCK_LEN, OUT_LEN};
+use crate::{BlockBytes, CVWords, IncrementCounter, BLOCK_LEN, OUT_LEN};
 
 // Unsafe because this may only be called on platforms supporting SSE2.
 pub unsafe fn compress_in_place(
     cv: &mut CVWords,
-    block: &[u8; BLOCK_LEN],
+    block: &BlockBytes,
     block_len: u8,
     counter: u64,
     flags: u8,
@@ -22,11 +22,11 @@ pub unsafe fn compress_in_place(
 // Unsafe because this may only be called on platforms supporting SSE2.
 pub unsafe fn compress_xof(
     cv: &CVWords,
-    block: &[u8; BLOCK_LEN],
+    block: &BlockBytes,
     block_len: u8,
     counter: u64,
     flags: u8,
-) -> [u8; 64] {
+) -> BlockBytes {
     unsafe {
         let mut out = [0u8; 64];
         ffi::blake3_compress_xof_sse2(

--- a/src/ffi_sse41.rs
+++ b/src/ffi_sse41.rs
@@ -1,9 +1,9 @@
-use crate::{CVWords, IncrementCounter, BLOCK_LEN, OUT_LEN};
+use crate::{BlockBytes, CVWords, IncrementCounter, BLOCK_LEN, OUT_LEN};
 
 // Unsafe because this may only be called on platforms supporting SSE4.1.
 pub unsafe fn compress_in_place(
     cv: &mut CVWords,
-    block: &[u8; BLOCK_LEN],
+    block: &BlockBytes,
     block_len: u8,
     counter: u64,
     flags: u8,
@@ -22,11 +22,11 @@ pub unsafe fn compress_in_place(
 // Unsafe because this may only be called on platforms supporting SSE4.1.
 pub unsafe fn compress_xof(
     cv: &CVWords,
-    block: &[u8; BLOCK_LEN],
+    block: &BlockBytes,
     block_len: u8,
     counter: u64,
     flags: u8,
-) -> [u8; 64] {
+) -> BlockBytes {
     unsafe {
         let mut out = [0u8; 64];
         ffi::blake3_compress_xof_sse41(

--- a/src/rust_sse2.rs
+++ b/src/rust_sse2.rs
@@ -4,8 +4,8 @@ use core::arch::x86::*;
 use core::arch::x86_64::*;
 
 use crate::{
-    counter_high, counter_low, CVBytes, CVWords, IncrementCounter, BLOCK_LEN, IV, MSG_SCHEDULE,
-    OUT_LEN,
+    counter_high, counter_low, BlockBytes, CVBytes, CVWords, IncrementCounter, BLOCK_LEN, IV,
+    MSG_SCHEDULE, OUT_LEN,
 };
 use arrayref::{array_mut_ref, array_ref, mut_array_refs};
 
@@ -149,7 +149,7 @@ unsafe fn blend_epi16(a: __m128i, b: __m128i, imm8: i32) -> __m128i {
 #[inline(always)]
 unsafe fn compress_pre(
     cv: &CVWords,
-    block: &[u8; BLOCK_LEN],
+    block: &BlockBytes,
     block_len: u8,
     counter: u64,
     flags: u8,
@@ -335,7 +335,7 @@ unsafe fn compress_pre(
 #[target_feature(enable = "sse2")]
 pub unsafe fn compress_in_place(
     cv: &mut CVWords,
-    block: &[u8; BLOCK_LEN],
+    block: &BlockBytes,
     block_len: u8,
     counter: u64,
     flags: u8,
@@ -348,11 +348,11 @@ pub unsafe fn compress_in_place(
 #[target_feature(enable = "sse2")]
 pub unsafe fn compress_xof(
     cv: &CVWords,
-    block: &[u8; BLOCK_LEN],
+    block: &BlockBytes,
     block_len: u8,
     counter: u64,
     flags: u8,
-) -> [u8; 64] {
+) -> BlockBytes {
     let [mut row0, mut row1, mut row2, mut row3] =
         compress_pre(cv, block, block_len, counter, flags);
     row0 = xor(row0, row2);

--- a/src/rust_sse41.rs
+++ b/src/rust_sse41.rs
@@ -4,8 +4,8 @@ use core::arch::x86::*;
 use core::arch::x86_64::*;
 
 use crate::{
-    counter_high, counter_low, CVBytes, CVWords, IncrementCounter, BLOCK_LEN, IV, MSG_SCHEDULE,
-    OUT_LEN,
+    counter_high, counter_low, BlockBytes, CVBytes, CVWords, IncrementCounter, BLOCK_LEN, IV,
+    MSG_SCHEDULE, OUT_LEN,
 };
 use arrayref::{array_mut_ref, array_ref, mut_array_refs};
 
@@ -140,7 +140,7 @@ unsafe fn undiagonalize(row0: &mut __m128i, row2: &mut __m128i, row3: &mut __m12
 #[inline(always)]
 unsafe fn compress_pre(
     cv: &CVWords,
-    block: &[u8; BLOCK_LEN],
+    block: &BlockBytes,
     block_len: u8,
     counter: u64,
     flags: u8,
@@ -326,7 +326,7 @@ unsafe fn compress_pre(
 #[target_feature(enable = "sse4.1")]
 pub unsafe fn compress_in_place(
     cv: &mut CVWords,
-    block: &[u8; BLOCK_LEN],
+    block: &BlockBytes,
     block_len: u8,
     counter: u64,
     flags: u8,
@@ -339,11 +339,11 @@ pub unsafe fn compress_in_place(
 #[target_feature(enable = "sse4.1")]
 pub unsafe fn compress_xof(
     cv: &CVWords,
-    block: &[u8; BLOCK_LEN],
+    block: &BlockBytes,
     block_len: u8,
     counter: u64,
     flags: u8,
-) -> [u8; 64] {
+) -> BlockBytes {
     let [mut row0, mut row1, mut row2, mut row3] =
         compress_pre(cv, block, block_len, counter, flags);
     row0 = xor(row0, row2);

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,4 +1,4 @@
-use crate::{CVBytes, CVWords, IncrementCounter, BLOCK_LEN, CHUNK_LEN, OUT_LEN};
+use crate::{BlockBytes, CVBytes, CVWords, IncrementCounter, BLOCK_LEN, CHUNK_LEN, OUT_LEN};
 use arrayref::array_ref;
 use arrayvec::ArrayVec;
 use core::usize;
@@ -66,15 +66,15 @@ pub fn paint_test_input(buf: &mut [u8]) {
 }
 
 type CompressInPlaceFn =
-    unsafe fn(cv: &mut CVWords, block: &[u8; BLOCK_LEN], block_len: u8, counter: u64, flags: u8);
+    unsafe fn(cv: &mut CVWords, block: &BlockBytes, block_len: u8, counter: u64, flags: u8);
 
 type CompressXofFn = unsafe fn(
     cv: &CVWords,
-    block: &[u8; BLOCK_LEN],
+    block: &BlockBytes,
     block_len: u8,
     counter: u64,
     flags: u8,
-) -> [u8; 64];
+) -> BlockBytes;
 
 // A shared helper function for platform-specific tests.
 pub fn test_compress_fn(compress_in_place_fn: CompressInPlaceFn, compress_xof_fn: CompressXofFn) {
@@ -213,7 +213,7 @@ pub fn test_hash_many_fn(
 #[allow(unused)]
 type XofManyFunction = unsafe fn(
     cv: &CVWords,
-    block: &[u8; BLOCK_LEN],
+    block: &BlockBytes,
     block_len: u8,
     counter: u64,
     flags: u8,

--- a/src/wasm32_simd.rs
+++ b/src/wasm32_simd.rs
@@ -17,8 +17,8 @@
 use core::arch::wasm32::*;
 
 use crate::{
-    counter_high, counter_low, CVBytes, CVWords, IncrementCounter, BLOCK_LEN, IV, MSG_SCHEDULE,
-    OUT_LEN,
+    counter_high, counter_low, BlockBytes, CVBytes, CVWords, IncrementCounter, BLOCK_LEN, IV,
+    MSG_SCHEDULE, OUT_LEN,
 };
 use arrayref::{array_mut_ref, array_ref, mut_array_refs};
 
@@ -172,7 +172,7 @@ fn undiagonalize(row0: &mut v128, row2: &mut v128, row3: &mut v128) {
 #[inline(always)]
 fn compress_pre(
     cv: &CVWords,
-    block: &[u8; BLOCK_LEN],
+    block: &BlockBytes,
     block_len: u8,
     counter: u64,
     flags: u8,
@@ -360,7 +360,7 @@ fn compress_pre(
 #[target_feature(enable = "simd128")]
 pub fn compress_in_place(
     cv: &mut CVWords,
-    block: &[u8; BLOCK_LEN],
+    block: &BlockBytes,
     block_len: u8,
     counter: u64,
     flags: u8,
@@ -377,11 +377,11 @@ pub fn compress_in_place(
 #[target_feature(enable = "simd128")]
 pub fn compress_xof(
     cv: &CVWords,
-    block: &[u8; BLOCK_LEN],
+    block: &BlockBytes,
     block_len: u8,
     counter: u64,
     flags: u8,
-) -> [u8; 64] {
+) -> BlockBytes {
     let [mut row0, mut row1, mut row2, mut row3] =
         compress_pre(cv, block, block_len, counter, flags);
     row0 = xor(row0, row2);


### PR DESCRIPTION
I was looking to propose other changes, but noticed that there are both `[u8; 64]` and `[u8; BLOCK_LEN]` in various places, which gets tedious to write, so I decided to add type aliases for convenience and consistency.

I didn't touch the reference implementation though, LMK if it is welcome change there.