### PR TITLE
Fix Cygwin build by skipping blake3_xof_many_avx512

### DIFF
--- a/c/blake3_dispatch.c
+++ b/c/blake3_dispatch.c
@@ -235,7 +235,7 @@ void blake3_xof_many(const uint32_t cv[8],
 #if defined(IS_X86)
   const enum cpu_feature features = get_cpu_features();
   MAYBE_UNUSED(features);
-#if !defined(_WIN32) && !defined(BLAKE3_NO_AVX512)
+#if !defined(_WIN32) && !defined(__CYGWIN__) && !defined(BLAKE3_NO_AVX512)
   if (features & AVX512VL) {
     blake3_xof_many_avx512(cv, block, block_len, counter, flags, out, outblocks);
     return;

--- a/c/blake3_impl.h
+++ b/c/blake3_impl.h
@@ -309,7 +309,7 @@ void blake3_hash_many_avx512(const uint8_t *const *inputs, size_t num_inputs,
                              uint8_t flags, uint8_t flags_start,
                              uint8_t flags_end, uint8_t *out);
 
-#if !defined(_WIN32)
+#if !defined(_WIN32) && !defined(__CYGWIN__)
 void blake3_xof_many_avx512(const uint32_t cv[8],
                             const uint8_t block[BLAKE3_BLOCK_LEN],
                             uint8_t block_len, uint64_t counter, uint8_t flags,


### PR DESCRIPTION
Temporarily skip blake3_xof_many_avx512 on Cygwin, as is already done for _WIN32. This workaround should be removed when blake3_xof_many_avx512 is implemented in blake3_avx512_x86-64_windows_gnu.S .

fixes https://github.com/BLAKE3-team/BLAKE3/issues/494