### PR TITLE
Mark blake3_hash_neon as static

### DIFF
--- a/c/blake3_neon.c
+++ b/c/blake3_neon.c
@@ -243,6 +243,7 @@ INLINE void load_counters4(uint64_t counter, bool increment_counter,
       counter_high(counter + (mask & 2)), counter_high(counter + (mask & 3)));
 }
 
+static
 void blake3_hash4_neon(const uint8_t *const *inputs, size_t blocks,
                        const uint32_t key[8], uint64_t counter,
                        bool increment_counter, uint8_t flags,


### PR DESCRIPTION
This is an implementation detail, which should not be exported.

This avoids unnecessary symbol conflicts with vendored copies of blake3.