### PR TITLE
Fix prefetch pointer addition that resulted in UB

### DIFF
--- a/src/rust_avx2.rs
+++ b/src/rust_avx2.rs
@@ -262,7 +262,10 @@ unsafe fn transpose_msg_vecs(inputs: &[*const u8; DEGREE], block_offset: usize) 
         loadu(inputs[7].add(block_offset + 1 * 4 * DEGREE)),
     ];
     for i in 0..DEGREE {
-        _mm_prefetch(inputs[i].add(block_offset + 256) as *const i8, _MM_HINT_T0);
+        _mm_prefetch(
+            inputs[i].wrapping_add(block_offset + 256) as *const i8,
+            _MM_HINT_T0,
+        );
     }
     let squares = mut_array_refs!(&mut vecs, DEGREE, DEGREE);
     transpose_vecs(squares.0);

--- a/src/rust_sse2.rs
+++ b/src/rust_sse2.rs
@@ -522,7 +522,10 @@ unsafe fn transpose_msg_vecs(inputs: &[*const u8; DEGREE], block_offset: usize) 
         loadu(inputs[3].add(block_offset + 3 * 4 * DEGREE)),
     ];
     for i in 0..DEGREE {
-        _mm_prefetch(inputs[i].add(block_offset + 256) as *const i8, _MM_HINT_T0);
+        _mm_prefetch(
+            inputs[i].wrapping_add(block_offset + 256) as *const i8,
+            _MM_HINT_T0,
+        );
     }
     let squares = mut_array_refs!(&mut vecs, DEGREE, DEGREE, DEGREE, DEGREE);
     transpose_vecs(squares.0);

--- a/src/rust_sse41.rs
+++ b/src/rust_sse41.rs
@@ -513,7 +513,10 @@ unsafe fn transpose_msg_vecs(inputs: &[*const u8; DEGREE], block_offset: usize) 
         loadu(inputs[3].add(block_offset + 3 * 4 * DEGREE)),
     ];
     for i in 0..DEGREE {
-        _mm_prefetch(inputs[i].add(block_offset + 256) as *const i8, _MM_HINT_T0);
+        _mm_prefetch(
+            inputs[i].wrapping_add(block_offset + 256) as *const i8,
+            _MM_HINT_T0,
+        );
     }
     let squares = mut_array_refs!(&mut vecs, DEGREE, DEGREE, DEGREE, DEGREE);
     transpose_vecs(squares.0);


### PR DESCRIPTION
This was discovered during my testing in https://github.com/BLAKE3-team/BLAKE3/issues/503#:~:text=Undefined%20Behavior, I just got to actually fixing it now.

The core issue is that it is UB to even create a pointer that is outside original memory allocation using `.add()`. But `.wrapping_add()` is allowed to create such a pointer, even though dereferencing it is still UB, but since it is used in an intrinsic, it no longer triggers UB in Miri.

Here is what UB looks like with BLAKE3's test suite (I used `cargo +nightly miri nextest run --features prefer_intrinsics,pure`):
<details>

```
error: Undefined Behavior: in-bounds pointer arithmetic failed: attempting to offset pointer by 1088 bytes, but got alloc1346+0xc00 which is only 1024 bytes from the end of the allocation
    --> src/rust_sse41.rs:516:22
     |
 516 |         _mm_prefetch(inputs[i].add(block_offset + 256) as *const i8, _MM_HINT_T0);
     |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
     |
     = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
     = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
     = note: BACKTRACE on thread `hazmat::test::t`:
     = note: inside `sse41::transpose_msg_vecs` at src/rust_sse41.rs:516:22: 516:55
note: inside `sse41::hash4`
    --> src/rust_sse41.rs:576:24
     |
 576 |         let msg_vecs = transpose_msg_vecs(inputs, block * BLOCK_LEN);
     |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: inside `sse41::hash_many::<1024>`
    --> src/rust_sse41.rs:682:9
     |
 682 | /         hash4(
 683 | |             input_ptrs,
 684 | |             blocks,
 685 | |             key,
...    |
 691 | |             array_mut_ref!(out, 0, DEGREE * OUT_LEN),
 692 | |         );
     | |_________^
note: inside `avx2::hash_many::<1024>`
    --> src/rust_avx2.rs:419:5
     |
 419 | /     crate::sse41::hash_many(
 420 | |         inputs,
 421 | |         key,
 422 | |         counter,
...    |
 427 | |         out,
 428 | |     );
     | |_____^
note: inside `platform::Platform::hash_many::<1024>`
    --> src/platform.rs:258:17
     |
 258 | /                 crate::avx2::hash_many(
 259 | |                     inputs,
 260 | |                     key,
 261 | |                     counter,
...    |
 266 | |                     out,
 267 | |                 )
     | |_________________^
note: inside `compress_chunks_parallel`
    --> src/lib.rs:682:5
     |
 682 | /     platform.hash_many(
 683 | |         &chunks_array,
 684 | |         key,
 685 | |         chunk_counter,
...    |
 690 | |         out,
 691 | |     );
     | |_____^
note: inside `compress_subtree_wide::<join::SerialJoin>`
    --> src/lib.rs:782:16
     |
 782 |         return compress_chunks_parallel(input, key, chunk_counter, flags, platform, out);
     |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: inside `compress_subtree_to_parent_node::<join::SerialJoin>`
    --> src/lib.rs:854:9
     |
 854 |         compress_subtree_wide::<J>(input, &key, chunk_counter, flags, platform, &mut cv_array);
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: inside `Hasher::update_with_join::<join::SerialJoin>`
    --> src/lib.rs:1296:31
     |
1296 |                   let cv_pair = compress_subtree_to_parent_node::<J>(
     |  _______________________________^
1297 | |                     &input[..subtree_len],
1298 | |                     &self.key,
1299 | |                     self.chunk_state.chunk_counter,
1300 | |                     self.chunk_state.flags,
1301 | |                     self.chunk_state.platform,
1302 | |                 );
     | |_________________^
note: inside `Hasher::update`
    --> src/lib.rs:1197:9
     |
1197 |         self.update_with_join::<join::SerialJoin>(input)
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: inside `hazmat::test::test_keyed_hash_xof`
    --> src/hazmat.rs:688:20
     |
 688 |         let left = Hasher::new_keyed(key).update(group0).finalize_non_root();
     |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: inside closure
    --> src/hazmat.rs:673:29
     |
 672 |     #[test]
     |     ------- in this procedural macro expansion
 673 |     fn test_keyed_hash_xof() {
     |                             ^

note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
```

</details>

With this PR it no longer happens.