### PR TITLE
chore: Set `rust-version` field for `blake3` and `b3sum`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ license = "CC0-1.0 OR Apache-2.0 OR Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/blake3"
 readme = "README.md"
 edition = "2021"
+rust-version = "1.80.1"
 
 [features]
 default = ["std"]

--- a/b3sum/Cargo.toml
+++ b/b3sum/Cargo.toml
@@ -7,6 +7,7 @@ repository = "https://github.com/BLAKE3-team/BLAKE3"
 license = "CC0-1.0 OR Apache-2.0 OR Apache-2.0 WITH LLVM-exception"
 readme = "README.md"
 edition = "2021"
+rust-version = "1.80.1"
 
 [features]
 neon = ["blake3/neon"]


### PR DESCRIPTION
The `rust-version` field defines the MSRV of the crate. I think this is especially useful for library crates.