### PR TITLE
Use `panic = "abort"` in `b3sum`

### DIFF
--- a/b3sum/Cargo.toml
+++ b/b3sum/Cargo.toml
@@ -24,3 +24,11 @@ wild = "2.0.3"
 [dev-dependencies]
 duct = "1.0.0"
 tempfile = "3.1.0"
+
+# b3sum does not gracefully handle panics (nor does it make sense for it to do
+# that), so unwinding on panic would just be a minor performance loss and
+# binary size hog with no benefit
+[profile.dev]
+panic = "abort"
+[profile.release]
+panic = "abort"


### PR DESCRIPTION
As `b3sum` does not attempt to recover from panics (nor does it have any reason to attempt to do that), it has no use for Rust's default behavior of unwinding on panics. Switching `b3sum` to `panic = "abort"` makes the executable about 13% smaller (from 1.5 MiB to 1.3 MiB) and possibly provides more optimization opportunities to LLVM. Note that this does not impact the display of backtraces, which are still displayed using `libunwind` – the only features that are disabled are the ability to catch panics using `std::panic::catch_unwind` and the non-fatal nature of panics in non-main threads.