### PR TITLE
Add `Hash::as_slice()` for convenient serialization to bytes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,6 +253,14 @@ impl Hash {
         Self(bytes)
     }
 
+    /// The raw bytes of the `Hash`, as a slice. Useful for serialization. Note that byte arrays
+    /// don't provide constant-time equality checking, so if you need to compare hashes, prefer
+    /// the `Hash` type.
+    #[inline]
+    pub const fn as_slice(&self) -> &[u8] {
+        self.0.as_slice()
+    }
+
     /// Create a `Hash` from its raw bytes representation as a slice.
     ///
     /// Returns an error if the slice is not exactly 32 bytes long.

--- a/src/test.rs
+++ b/src/test.rs
@@ -756,6 +756,9 @@ fn test_hash_conversions() {
     let hash4 = crate::Hash::from_slice(slice1).expect("correct length");
     assert_eq!(hash1, hash4);
 
+    let slice2 = hash1.as_slice();
+    assert_eq!(slice1, slice2);
+
     assert!(crate::Hash::from_slice(&[]).is_err());
     assert!(crate::Hash::from_slice(&[42]).is_err());
     assert!(crate::Hash::from_slice([42; 31].as_slice()).is_err());


### PR DESCRIPTION
`Hash::as_bytes()` returns the hash as an array of bytes. However,
sometimes it's useful to have the hash as a slice of bytes instead, such
as for serialization via an API that takes `&[u8]`. While
`.as_bytes().as_slice()` works for this, it'd be more convenient to have
a direct `.as_slice()` on hashes.
