### PR TITLE
Add support for RVV 1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,11 +199,17 @@ jobs:
           # Big-endian targets. See https://twitter.com/burntsushi5/status/1695483429997945092.
           - powerpc64-unknown-linux-gnu
           - s390x-unknown-linux-gnu
+          # RISC-V target. The musl image has GCC 14 with RVV intrinsics support.
+          - riscv64gc-unknown-linux-musl
 
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
     - run: cargo install cross
+      if: "!startsWith(matrix.arch, 'riscv64')"
+    # RISC-V musl target requires the latest cross from git.
+    - run: cargo install cross --git https://github.com/cross-rs/cross
+      if: startsWith(matrix.arch, 'riscv64')
     # Test the portable implementation on everything.
     - run: cross test --target ${{ matrix.arch }}
     # Test building for ancient i386 processors without guaranteed SSE2 support.
@@ -215,12 +221,17 @@ jobs:
     # NEON is enabled by default on aarch64, disabling it through the no_neon feature.
     - run: cross test --target ${{ matrix.arch }} --features=no_neon
       if: startsWith(matrix.arch, 'aarch64-')
+    # Test the RVV implementation on RISC-V targets (force-enable, skip runtime detection).
+    - run: cross test --target ${{ matrix.arch }} --features=rvv
+      if: startsWith(matrix.arch, 'riscv64')
     # Test vectors. Note that this uses a hacky script due to path dependency limitations.
     - run: ./test_vectors/cross_test.sh --target ${{ matrix.arch }}
     # C code. Same issue with the hacky script.
     - run: ./c/blake3_c_rust_bindings/cross_test.sh --target ${{ matrix.arch }}
     - run: ./c/blake3_c_rust_bindings/cross_test.sh --target ${{ matrix.arch }} --features=neon
       if: startsWith(matrix.arch, 'armv7-') || startsWith(matrix.arch, 'aarch64-')
+    - run: ./c/blake3_c_rust_bindings/cross_test.sh --target ${{ matrix.arch }} --features=rvv
+      if: startsWith(matrix.arch, 'riscv64')
 
   wasm_tests:
     name: WASM tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,11 @@ default = ["std"]
 # implementation uses C intrinsics and requires a C compiler.
 neon = []
 
+# The RVV (RISC-V Vector) implementation does not participate in dynamic feature
+# detection. If "rvv" is on, RVV support is assumed. The RVV implementation uses
+# C intrinsics and requires a C compiler with RVV support.
+rvv = []
+
 # The Wasm SIMD implementation does not participate in dynamic feature detection,
 # which is currently x86-only. If "wasm_simd" is on, Wasm SIMD support is assumed.
 # Note that not all Wasm implementations support the Wasm SIMD specification.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,13 @@ default = ["std"]
 # implementation uses C intrinsics and requires a C compiler.
 neon = []
 
-# The RVV (RISC-V Vector) implementation does not participate in dynamic feature
-# detection. If "rvv" is on, RVV support is assumed. The RVV implementation uses
-# C intrinsics and requires a C compiler with RVV support.
+# The RVV (RISC-V Vector) implementation participates in dynamic feature
+# detection on Linux and FreeBSD (via getauxval/elf_aux_info). On riscv64
+# little-endian targets, RVV code is compiled automatically if the C compiler
+# supports it; runtime detection then determines whether to use it. Enabling
+# "rvv" will aussume that the compiler supports it and the compilation output 
+# will explicitly skip runtime detection and assume RVV is available, which
+# is useful for bare-metal targets.
 rvv = []
 
 # The Wasm SIMD implementation does not participate in dynamic feature detection,
@@ -111,6 +115,7 @@ no_sse41 = []
 no_avx2 = []
 no_avx512 = []
 no_neon = []
+no_rvv = []
 
 [package.metadata.docs.rs]
 # Document the rayon/mmap methods and the Serialize/Deserialize/Zeroize impls on docs.rs.

--- a/b3sum/Cargo.toml
+++ b/b3sum/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2024"
 
 [features]
 neon = ["blake3/neon"]
+rvv = ["blake3/rvv"]
 prefer_intrinsics = ["blake3/prefer_intrinsics"]
 pure = ["blake3/pure"]
 

--- a/build.rs
+++ b/build.rs
@@ -100,20 +100,77 @@ fn is_wasm32() -> bool {
 }
 
 fn is_riscv64() -> bool {
-    let arch = &target_components()[0];
-    arch == "riscv64gc" || arch == "riscv64a23"
+    target_components()[0].starts_with("riscv64")
+}
+
+fn is_cross_compiling() -> bool {
+    let host = env::var("HOST").unwrap();
+    let target = env::var("TARGET").unwrap();
+    host != target
+}
+
+fn test_rvv_runtime_support() -> bool {
+    use std::fs;
+    use std::io::Write;
+    use std::process::Command;
+
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let test_c = format!("{}/test_rvv.c", out_dir);
+    let test_bin = format!("{}/test_rvv", out_dir);
+
+    let test_code = b"
+#include <riscv_vector.h>
+int main() {
+  size_t vl = __riscv_vsetvlmax_e32m1();
+  return 0;
+}
+";
+
+    let mut f = match fs::File::create(&test_c) {
+        Ok(f) => f,
+        Err(e) => {
+            println!("cargo:warning=Failed to create RVV test file: {}", e);
+            return false;
+        }
+    };
+
+    if let Err(e) = f.write_all(test_code) {
+        println!("cargo:warning=Failed to write RVV test file: {}", e);
+        return false;
+    }
+
+    let cc = env::var("CC").unwrap_or_else(|_| "gcc".to_string());
+    let compile = Command::new(&cc)
+        .args(&["-march=rv64gcv", &test_c, "-o", &test_bin])
+        .output();
+
+    if !compile.is_ok() || !compile.unwrap().status.success() {
+        return false;
+    }
+
+    match Command::new(&test_bin).output() {
+        Ok(output) => output.status.success(),
+        Err(_) => false,
+    }
 }
 
 fn is_rvv() -> bool {
-    // Explicit RVV feature flag
     if defined("CARGO_FEATURE_RVV") {
         return true;
     }
 
-    // riscv64a23 target has built-in RVV support
-    let arch = &target_components()[0];
-    if arch == "riscv64a23" {
-        return true;
+    if !is_cross_compiling() && is_riscv64() {
+        if test_rvv_runtime_support() {
+            return true;
+        } else {
+            println!("cargo:warning=No RVV support detected, using portable implementation");
+            return false;
+        }
+    }
+
+    if is_cross_compiling() && is_riscv64() {
+        println!("cargo:warning=Cross-compiling for RISC-V: RVV disabled");
+        println!("cargo:warning=To enable: use --features=rvv");
     }
 
     false
@@ -322,20 +379,8 @@ fn build_wasm32_simd() {
 
 fn build_rvv_c_intrinsics() {
     let mut build = new_build();
-    // Note that blake3_rvv.c normally depends on the blake3_portable.c
-    // for the single-instance compression function, but we expose
-    // portable.rs over FFI instead. See ffi_rvv.rs.
     build.file("c/blake3_rvv.c");
-
-    // Try rva23u64 first (RVA23 profile includes RVV 1.0), then fall back to rv64gcv.
-    // This matches the priority in CMakeLists.txt.
-    let march_flag = if build.is_flag_supported("-march=rva23u64").unwrap_or(false) {
-        "-march=rva23u64"
-    } else {
-        "-march=rv64gcv"
-    };
-    build.flag(march_flag);
-
+    build.flag("-march=rv64gcv");
     build.compile("blake3_rvv");
 }
 

--- a/build.rs
+++ b/build.rs
@@ -103,91 +103,10 @@ fn is_riscv64() -> bool {
     target_components()[0].starts_with("riscv64")
 }
 
-fn is_cross_compiling() -> bool {
-    let host = env::var("HOST").unwrap();
-    let target = env::var("TARGET").unwrap();
-    host != target
-}
-
-fn test_rvv_runtime_support() -> bool {
-    use std::fs;
-    use std::io::Write;
-    use std::process::Command;
-
-    let out_dir = env::var("OUT_DIR").unwrap();
-    let test_c = format!("{}/test_rvv.c", out_dir);
-    let test_bin = format!("{}/test_rvv", out_dir);
-
-    let test_code = b"
-#include <riscv_vector.h>
-#include <stdint.h>
-
-int main() {
-  size_t vl = __riscv_vsetvlmax_e32m1();
-  if (vl == 0) return 1;
-
-  vuint32m1_t v32_a = __riscv_vmv_v_x_u32m1(42, vl);
-  vuint32m1_t v32_b = __riscv_vmv_v_x_u32m1(17, vl);
-  vuint32m1_t v32_sum = __riscv_vadd_vv_u32m1(v32_a, v32_b, vl);
-  vuint32m1_t v32_xor = __riscv_vxor_vv_u32m1(v32_a, v32_b, vl);
-  vuint32m1_t v32_or = __riscv_vor_vv_u32m1(v32_a, v32_b, vl);
-  vuint32m1_t v32_srl = __riscv_vsrl_vx_u32m1(v32_a, 4, vl);
-  vuint32m1_t v32_sll = __riscv_vsll_vx_u32m1(v32_a, 4, vl);
-
-  uint32_t data32[16] = {0};
-  vuint32m1_t v32_loaded = __riscv_vle32_v_u32m1(data32, vl);
-  __riscv_vsse32_v_u32m1(data32, sizeof(uint32_t) * 2, v32_sum, vl);
-
-  uint64_t data64[16] = {0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60};
-  vuint64m2_t v64 = __riscv_vle64_v_u64m2(data64, vl);
-  vuint64m2_t v64_add = __riscv_vadd_vx_u64m2(v64, 100, vl);
-
-  uint32_t src_data[16] = {10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160};
-  vuint32m1_t v32_indexed = __riscv_vluxei64_v_u32m1((const uint32_t *)src_data, v64, vl);
-
-  uint32_t result_sum[16] = {0};
-  uint32_t result_indexed[16] = {0};
-  __riscv_vse32_v_u32m1(result_sum, v32_sum, vl);
-  __riscv_vse32_v_u32m1(result_indexed, v32_indexed, vl);
-
-  if (result_sum[0] != 59) return 2;
-  if (result_indexed[0] != 10) return 3;
-  if (vl > 1 && result_indexed[1] != 20) return 4;
-
-  return 0;
-}
-";
-
-    let mut f = match fs::File::create(&test_c) {
-        Ok(f) => f,
-        Err(e) => {
-            println!("cargo:warning=Failed to create RVV test file: {}", e);
-            return false;
-        }
-    };
-
-    if let Err(e) = f.write_all(test_code) {
-        println!("cargo:warning=Failed to write RVV test file: {}", e);
-        return false;
-    }
-
-    drop(f);
-
-    let mut build = cc::Build::new();
-    build.flag("-march=rv64gcv");
-    let compiler = build.get_compiler();
-
-    let mut cmd = compiler.to_command();
-    cmd.arg(&test_c).arg("-o").arg(&test_bin);
-
-    if !cmd.status().map(|s| s.success()).unwrap_or(false) {
-        return false;
-    }
-
-    match Command::new(&test_bin).output() {
-        Ok(output) => output.status.success(),
-        Err(_) => false,
-    }
+// Test whether the C compiler supports -march=rv64imfdv (i.e. has RVV support).
+fn test_rvv_compile_support() -> bool {
+    let build = new_build();
+    build.is_flag_supported("-march=rv64imfdv").unwrap_or(false)
 }
 
 fn is_rvv() -> bool {
@@ -199,8 +118,11 @@ fn is_rvv() -> bool {
         return false;
     }
 
-    if !is_cross_compiling() && is_riscv64() && is_little_endian() {
-        return test_rvv_runtime_support();
+    // Auto-enable on riscv64 little-endian if the compiler supports RVV,
+    // similar to how NEON is auto-enabled on aarch64. Runtime detection
+    // in platform.rs handles the case where the hardware lacks V extension.
+    if is_riscv64() && is_little_endian() {
+        return test_rvv_compile_support();
     }
 
     false
@@ -409,9 +331,21 @@ fn build_wasm32_simd() {
 
 fn build_rvv_c_intrinsics() {
     let mut build = new_build();
+    // Note that blake3_rvv.c depends on blake3_portable.c for the single-instance
+    // compression function. On the Rust side, we expose portable.rs over FFI
+    // instead. See ffi_rvv.rs.
     build.file("c/blake3_rvv.c");
-    build.flag("-march=rv64gcv");
-    build.define("BLAKE3_USE_RVV", "1");
+    // blake3_rvv.c requires: I (base) + M (VLA stack mul) + V (vector).
+    // F+D are not used by our code but required by the lp64d ABI of all
+    // riscv64gc Rust targets. We spell out each extension explicitly
+    // rather than using 'g' (= imafd_zicsr_zifencei) to document the
+    // minimal set: A, C, Zicsr, Zifencei are not needed.
+    build.flag("-march=rv64imfdv");
+    // Workaround: cc crate infers -mabi=lp64 (soft-float) for bare-metal
+    // riscv64gc targets, but Rust uses lp64d. Override to avoid ABI mismatch.
+    if env::var("CARGO_CFG_TARGET_OS").unwrap_or_default() == "none" {
+        build.flag("-mabi=lp64d");
+    }
     build.compile("blake3_rvv");
 }
 
@@ -485,7 +419,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         panic!("The RVV implementation doesn't support big-endian RISC-V.")
     }
 
-    // Enable RVV if explicitly requested via feature flag
+    // Auto-enable RVV on riscv64 when the compiler supports it (similar to
+    // NEON on aarch64). Runtime detection in platform.rs will check for actual
+    // V extension support before using the RVV code path.
     if is_riscv64() && is_rvv() {
         println!("cargo:rustc-cfg=blake3_rvv");
         build_rvv_c_intrinsics();

--- a/build.rs
+++ b/build.rs
@@ -120,8 +120,40 @@ fn test_rvv_runtime_support() -> bool {
 
     let test_code = b"
 #include <riscv_vector.h>
+#include <stdint.h>
+
 int main() {
   size_t vl = __riscv_vsetvlmax_e32m1();
+  if (vl == 0) return 1;
+
+  vuint32m1_t v32_a = __riscv_vmv_v_x_u32m1(42, vl);
+  vuint32m1_t v32_b = __riscv_vmv_v_x_u32m1(17, vl);
+  vuint32m1_t v32_sum = __riscv_vadd_vv_u32m1(v32_a, v32_b, vl);
+  vuint32m1_t v32_xor = __riscv_vxor_vv_u32m1(v32_a, v32_b, vl);
+  vuint32m1_t v32_or = __riscv_vor_vv_u32m1(v32_a, v32_b, vl);
+  vuint32m1_t v32_srl = __riscv_vsrl_vx_u32m1(v32_a, 4, vl);
+  vuint32m1_t v32_sll = __riscv_vsll_vx_u32m1(v32_a, 4, vl);
+
+  uint32_t data32[16] = {0};
+  vuint32m1_t v32_loaded = __riscv_vle32_v_u32m1(data32, vl);
+  __riscv_vsse32_v_u32m1(data32, sizeof(uint32_t) * 2, v32_sum, vl);
+
+  uint64_t data64[16] = {0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60};
+  vuint64m2_t v64 = __riscv_vle64_v_u64m2(data64, vl);
+  vuint64m2_t v64_add = __riscv_vadd_vx_u64m2(v64, 100, vl);
+
+  uint32_t src_data[16] = {10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160};
+  vuint32m1_t v32_indexed = __riscv_vluxei64_v_u32m1((const uint32_t *)src_data, v64, vl);
+
+  uint32_t result_sum[16] = {0};
+  uint32_t result_indexed[16] = {0};
+  __riscv_vse32_v_u32m1(result_sum, v32_sum, vl);
+  __riscv_vse32_v_u32m1(result_indexed, v32_indexed, vl);
+
+  if (result_sum[0] != 59) return 2;
+  if (result_indexed[0] != 10) return 3;
+  if (vl > 1 && result_indexed[1] != 20) return 4;
+
   return 0;
 }
 ";
@@ -139,12 +171,16 @@ int main() {
         return false;
     }
 
-    let cc = env::var("CC").unwrap_or_else(|_| "gcc".to_string());
-    let compile = Command::new(&cc)
-        .args(&["-march=rv64gcv", &test_c, "-o", &test_bin])
-        .output();
+    drop(f);
 
-    if !compile.is_ok() || !compile.unwrap().status.success() {
+    let mut build = cc::Build::new();
+    build.flag("-march=rv64gcv");
+    let compiler = build.get_compiler();
+
+    let mut cmd = compiler.to_command();
+    cmd.arg(&test_c).arg("-o").arg(&test_bin);
+
+    if !cmd.status().map(|s| s.success()).unwrap_or(false) {
         return false;
     }
 
@@ -159,18 +195,12 @@ fn is_rvv() -> bool {
         return true;
     }
 
-    if !is_cross_compiling() && is_riscv64() {
-        if test_rvv_runtime_support() {
-            return true;
-        } else {
-            println!("cargo:warning=No RVV support detected, using portable implementation");
-            return false;
-        }
+    if is_pure() {
+        return false;
     }
 
-    if is_cross_compiling() && is_riscv64() {
-        println!("cargo:warning=Cross-compiling for RISC-V: RVV disabled");
-        println!("cargo:warning=To enable: use --features=rvv");
+    if !is_cross_compiling() && is_riscv64() && is_little_endian() {
+        return test_rvv_runtime_support();
     }
 
     false
@@ -381,6 +411,7 @@ fn build_rvv_c_intrinsics() {
     let mut build = new_build();
     build.file("c/blake3_rvv.c");
     build.flag("-march=rv64gcv");
+    build.define("BLAKE3_USE_RVV", "1");
     build.compile("blake3_rvv");
 }
 

--- a/build.rs
+++ b/build.rs
@@ -99,6 +99,26 @@ fn is_wasm32() -> bool {
     target_components()[0] == "wasm32"
 }
 
+fn is_riscv64() -> bool {
+    let arch = &target_components()[0];
+    arch == "riscv64gc" || arch == "riscv64a23"
+}
+
+fn is_rvv() -> bool {
+    // Explicit RVV feature flag
+    if defined("CARGO_FEATURE_RVV") {
+        return true;
+    }
+
+    // riscv64a23 target has built-in RVV support
+    let arch = &target_components()[0];
+    if arch == "riscv64a23" {
+        return true;
+    }
+
+    false
+}
+
 fn endianness() -> String {
     let endianness = env::var("CARGO_CFG_TARGET_ENDIAN").unwrap();
     assert!(endianness == "little" || endianness == "big");
@@ -300,6 +320,25 @@ fn build_wasm32_simd() {
     println!("cargo:rustc-cfg=blake3_wasm32_simd");
 }
 
+fn build_rvv_c_intrinsics() {
+    let mut build = new_build();
+    // Note that blake3_rvv.c normally depends on the blake3_portable.c
+    // for the single-instance compression function, but we expose
+    // portable.rs over FFI instead. See ffi_rvv.rs.
+    build.file("c/blake3_rvv.c");
+
+    // Try rva23u64 first (RVA23 profile includes RVV 1.0), then fall back to rv64gcv.
+    // This matches the priority in CMakeLists.txt.
+    let march_flag = if build.is_flag_supported("-march=rva23u64").unwrap_or(false) {
+        "-march=rva23u64"
+    } else {
+        "-march=rv64gcv"
+    };
+    build.flag(march_flag);
+
+    build.compile("blake3_rvv");
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // As of Rust 1.80, unrecognized config names are warnings. Give Cargo all of our config names.
     let all_cfgs = [
@@ -312,6 +351,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "blake3_avx512_ffi",
         "blake3_neon",
         "blake3_wasm32_simd",
+        "blake3_rvv",
     ];
     for cfg_name in all_cfgs {
         // TODO: Switch this whole file to the new :: syntax when our MSRV reaches 1.77.
@@ -325,6 +365,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     if is_no_neon() && is_neon() {
         panic!("It doesn't make sense to enable both \"no_neon\" and \"neon\".");
+    }
+
+    if is_pure() && is_rvv() {
+        panic!("It doesn't make sense to enable both \"pure\" and \"rvv\".");
     }
 
     if is_x86_64() || is_x86_32() {
@@ -359,6 +403,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     if is_wasm32() && is_wasm32_simd() {
         build_wasm32_simd();
+    }
+
+    if is_rvv() && is_big_endian() {
+        panic!("The RVV implementation doesn't support big-endian RISC-V.")
+    }
+
+    // Enable RVV if explicitly requested via feature flag
+    if is_riscv64() && is_rvv() {
+        println!("cargo:rustc-cfg=blake3_rvv");
+        build_rvv_c_intrinsics();
     }
 
     // The `cc` crate doesn't automatically emit rerun-if directives for the

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -86,38 +86,41 @@ elseif(CMAKE_C_COMPILER_ID STREQUAL "GNU"
   endif()
   
   if (CMAKE_SYSTEM_PROCESSOR IN_LIST BLAKE3_RISCV64_NAMES)
-    # RISC-V Vector Extension (RVV 1.0) - check if compiler supports it
-    # Try rva23u64 first (RVA23 profile with RVV), then rv64gcv
-    include(CheckCSourceCompiles)
-    
-    # Try rva23u64 first (RVA23 profile includes RVV 1.0)
-    set(CMAKE_REQUIRED_FLAGS "-march=rva23u64")
-    check_c_source_compiles("
-#include <riscv_vector.h>
-int main() {
-  size_t vl = __riscv_vsetvlmax_e32m1();
-  return 0;
-}
-" BLAKE3_COMPILER_SUPPORTS_RVA23U64)
-    set(CMAKE_REQUIRED_FLAGS)
-    
-    if(BLAKE3_COMPILER_SUPPORTS_RVA23U64)
-      set(BLAKE3_CFLAGS_RVV "-march=rva23u64" CACHE STRING "the compiler flags to enable RVV")
-    else()
-      # Fall back to rv64gcv
-      set(CMAKE_REQUIRED_FLAGS "-march=rv64gcv")
-      check_c_source_compiles("
-#include <riscv_vector.h>
-int main() {
-  size_t vl = __riscv_vsetvlmax_e32m1();
-  return 0;
-}
-" BLAKE3_COMPILER_SUPPORTS_RV64GCV)
-      set(CMAKE_REQUIRED_FLAGS)
+    if(DEFINED BLAKE3_CFLAGS_RVV)
+      message(STATUS "Using user-specified RVV flags: ${BLAKE3_CFLAGS_RVV}")
+    elseif(NOT CMAKE_CROSSCOMPILING)
+      message(STATUS "Native RISC-V build: testing RVV runtime support...")
       
-      if(BLAKE3_COMPILER_SUPPORTS_RV64GCV)
+      file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/test_rvv.c "
+#include <riscv_vector.h>
+int main() {
+  size_t vl = __riscv_vsetvlmax_e32m1();
+  return 0;
+}
+")
+      
+      try_run(
+        BLAKE3_RVV_RUN_RESULT
+        BLAKE3_RVV_COMPILE_RESULT
+        ${CMAKE_CURRENT_BINARY_DIR}/try_rvv
+        ${CMAKE_CURRENT_BINARY_DIR}/test_rvv.c
+        COMPILE_DEFINITIONS -march=rv64gcv
+        COMPILE_OUTPUT_VARIABLE BLAKE3_RVV_COMPILE_OUTPUT
+      )
+      
+      if(BLAKE3_RVV_COMPILE_RESULT AND BLAKE3_RVV_RUN_RESULT EQUAL 0)
         set(BLAKE3_CFLAGS_RVV "-march=rv64gcv" CACHE STRING "the compiler flags to enable RVV")
+        message(STATUS "RVV runtime support verified")
+      elseif(BLAKE3_RVV_COMPILE_RESULT)
+        message(STATUS "RVV compiled but failed to run (CPU doesn't support it)")
+      else()
+        message(STATUS "RVV compilation failed")
       endif()
+    else()
+      message(WARNING 
+        "Cross-compiling for RISC-V: Cannot auto-detect RVV support.\n"
+        "RVV will be DISABLED. To enable, specify:\n"
+        "  cmake -DBLAKE3_CFLAGS_RVV=\"-march=rv64gcv\" ..")
     endif()
   endif()
 endif()

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -88,71 +88,18 @@ elseif(CMAKE_C_COMPILER_ID STREQUAL "GNU"
   if (CMAKE_SYSTEM_PROCESSOR IN_LIST BLAKE3_RISCV64_NAMES)
     if(DEFINED BLAKE3_CFLAGS_RVV)
       message(STATUS "Using user-specified RVV flags: ${BLAKE3_CFLAGS_RVV}")
-    elseif(NOT CMAKE_CROSSCOMPILING)
-      message(STATUS "Native RISC-V build: testing RVV runtime support...")
-      
-      file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/test_rvv.c "
-#include <riscv_vector.h>
-#include <stdint.h>
-
-int main() {
-  size_t vl = __riscv_vsetvlmax_e32m1();
-  if (vl == 0) return 1;
-
-  vuint32m1_t v32_a = __riscv_vmv_v_x_u32m1(42, vl);
-  vuint32m1_t v32_b = __riscv_vmv_v_x_u32m1(17, vl);
-  vuint32m1_t v32_sum = __riscv_vadd_vv_u32m1(v32_a, v32_b, vl);
-  vuint32m1_t v32_xor = __riscv_vxor_vv_u32m1(v32_a, v32_b, vl);
-  vuint32m1_t v32_or = __riscv_vor_vv_u32m1(v32_a, v32_b, vl);
-  vuint32m1_t v32_srl = __riscv_vsrl_vx_u32m1(v32_a, 4, vl);
-  vuint32m1_t v32_sll = __riscv_vsll_vx_u32m1(v32_a, 4, vl);
-
-  uint32_t data32[16] = {0};
-  vuint32m1_t v32_loaded = __riscv_vle32_v_u32m1(data32, vl);
-  __riscv_vsse32_v_u32m1(data32, sizeof(uint32_t) * 2, v32_sum, vl);
-
-  uint64_t data64[16] = {0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60};
-  vuint64m2_t v64 = __riscv_vle64_v_u64m2(data64, vl);
-  vuint64m2_t v64_add = __riscv_vadd_vx_u64m2(v64, 100, vl);
-
-  uint32_t src_data[16] = {10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160};
-  vuint32m1_t v32_indexed = __riscv_vluxei64_v_u32m1((const uint32_t *)src_data, v64, vl);
-
-  uint32_t result_sum[16] = {0};
-  uint32_t result_indexed[16] = {0};
-  __riscv_vse32_v_u32m1(result_sum, v32_sum, vl);
-  __riscv_vse32_v_u32m1(result_indexed, v32_indexed, vl);
-
-  if (result_sum[0] != 59) return 2;
-  if (result_indexed[0] != 10) return 3;
-  if (vl > 1 && result_indexed[1] != 20) return 4;
-
-  return 0;
-}
-")
-      
-      try_run(
-        BLAKE3_RVV_RUN_RESULT
-        BLAKE3_RVV_COMPILE_RESULT
-        ${CMAKE_CURRENT_BINARY_DIR}/try_rvv
-        ${CMAKE_CURRENT_BINARY_DIR}/test_rvv.c
-        COMPILE_DEFINITIONS -march=rv64gcv
-        COMPILE_OUTPUT_VARIABLE BLAKE3_RVV_COMPILE_OUTPUT
-      )
-      
-      if(BLAKE3_RVV_COMPILE_RESULT AND BLAKE3_RVV_RUN_RESULT EQUAL 0)
-        set(BLAKE3_CFLAGS_RVV "-march=rv64gcv" CACHE STRING "the compiler flags to enable RVV")
-        message(STATUS "RVV runtime support verified")
-      elseif(BLAKE3_RVV_COMPILE_RESULT)
-        message(STATUS "RVV compiled but failed to run (CPU doesn't support it)")
-      else()
-        message(STATUS "RVV compilation failed")
-      endif()
     else()
-      message(WARNING 
-        "Cross-compiling for RISC-V: Cannot auto-detect RVV support.\n"
-        "RVV will be DISABLED. To enable, specify:\n"
-        "  cmake -DBLAKE3_CFLAGS_RVV=\"-march=rv64gcv\" ..")
+      message(STATUS "Testing RVV compiler support...")
+
+      include(CheckCCompilerFlag)
+      check_c_compiler_flag("-march=rv64imfdv" BLAKE3_RVV_SUPPORTED)
+
+      if(BLAKE3_RVV_SUPPORTED)
+        set(BLAKE3_CFLAGS_RVV "-march=rv64imfdv" CACHE STRING "the compiler flags to enable RVV")
+        message(STATUS "RVV compiler support verified")
+      else()
+        message(STATUS "RVV not supported (compiler does not accept -march=rv64imfdv)")
+      endif()
     endif()
   endif()
 endif()
@@ -295,19 +242,17 @@ elseif(BLAKE3_SIMD_TYPE STREQUAL "rvv-intrinsics")
     blake3_rvv.c
   )
   target_compile_definitions(blake3 PRIVATE
-    BLAKE3_USE_RVV=1
+    BLAKE3_BUILD_RVV=1
   )
 
   if (DEFINED BLAKE3_CFLAGS_RVV)
     set_source_files_properties(blake3_rvv.c PROPERTIES COMPILE_FLAGS "${BLAKE3_CFLAGS_RVV}")
-    # blake3_dispatch.c also needs RVV flags to call __riscv_vsetvlmax_e32m1()
-    set_source_files_properties(blake3_dispatch.c PROPERTIES COMPILE_FLAGS "${BLAKE3_CFLAGS_RVV}")
   endif()
 
 elseif(BLAKE3_SIMD_TYPE STREQUAL "none")
   target_compile_definitions(blake3 PRIVATE
     BLAKE3_USE_NEON=0
-    BLAKE3_USE_RVV=0
+    BLAKE3_BUILD_RVV=0
     BLAKE3_NO_SSE2
     BLAKE3_NO_SSE41
     BLAKE3_NO_AVX2

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -93,8 +93,40 @@ elseif(CMAKE_C_COMPILER_ID STREQUAL "GNU"
       
       file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/test_rvv.c "
 #include <riscv_vector.h>
+#include <stdint.h>
+
 int main() {
   size_t vl = __riscv_vsetvlmax_e32m1();
+  if (vl == 0) return 1;
+
+  vuint32m1_t v32_a = __riscv_vmv_v_x_u32m1(42, vl);
+  vuint32m1_t v32_b = __riscv_vmv_v_x_u32m1(17, vl);
+  vuint32m1_t v32_sum = __riscv_vadd_vv_u32m1(v32_a, v32_b, vl);
+  vuint32m1_t v32_xor = __riscv_vxor_vv_u32m1(v32_a, v32_b, vl);
+  vuint32m1_t v32_or = __riscv_vor_vv_u32m1(v32_a, v32_b, vl);
+  vuint32m1_t v32_srl = __riscv_vsrl_vx_u32m1(v32_a, 4, vl);
+  vuint32m1_t v32_sll = __riscv_vsll_vx_u32m1(v32_a, 4, vl);
+
+  uint32_t data32[16] = {0};
+  vuint32m1_t v32_loaded = __riscv_vle32_v_u32m1(data32, vl);
+  __riscv_vsse32_v_u32m1(data32, sizeof(uint32_t) * 2, v32_sum, vl);
+
+  uint64_t data64[16] = {0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60};
+  vuint64m2_t v64 = __riscv_vle64_v_u64m2(data64, vl);
+  vuint64m2_t v64_add = __riscv_vadd_vx_u64m2(v64, 100, vl);
+
+  uint32_t src_data[16] = {10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160};
+  vuint32m1_t v32_indexed = __riscv_vluxei64_v_u32m1((const uint32_t *)src_data, v64, vl);
+
+  uint32_t result_sum[16] = {0};
+  uint32_t result_indexed[16] = {0};
+  __riscv_vse32_v_u32m1(result_sum, v32_sum, vl);
+  __riscv_vse32_v_u32m1(result_indexed, v32_indexed, vl);
+
+  if (result_sum[0] != 59) return 2;
+  if (result_indexed[0] != 10) return 3;
+  if (vl > 1 && result_indexed[1] != 20) return 4;
+
   return 0;
 }
 ")

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -31,6 +31,7 @@ add_subdirectory(dependencies)
 set(BLAKE3_AMD64_NAMES amd64 AMD64 x86_64)
 set(BLAKE3_X86_NAMES i686 x86 X86)
 set(BLAKE3_ARMv8_NAMES aarch64 AArch64 arm64 ARM64 armv8 armv8a)
+set(BLAKE3_RISCV64_NAMES riscv64 RISCV64 rv64)
 # default SIMD compiler flag configuration (can be overriden by toolchains or CLI)
 if(MSVC)
   if (CMAKE_C_COMPILER_ID STREQUAL "Clang")
@@ -83,9 +84,45 @@ elseif(CMAKE_C_COMPILER_ID STREQUAL "GNU"
     # 32-bit ARMv8 needs NEON to be enabled explicitly
     set(BLAKE3_CFLAGS_NEON "-mfpu=neon" CACHE STRING "the compiler flags to enable NEON")
   endif()
+  
+  if (CMAKE_SYSTEM_PROCESSOR IN_LIST BLAKE3_RISCV64_NAMES)
+    # RISC-V Vector Extension (RVV 1.0) - check if compiler supports it
+    # Try rva23u64 first (RVA23 profile with RVV), then rv64gcv
+    include(CheckCSourceCompiles)
+    
+    # Try rva23u64 first (RVA23 profile includes RVV 1.0)
+    set(CMAKE_REQUIRED_FLAGS "-march=rva23u64")
+    check_c_source_compiles("
+#include <riscv_vector.h>
+int main() {
+  size_t vl = __riscv_vsetvlmax_e32m1();
+  return 0;
+}
+" BLAKE3_COMPILER_SUPPORTS_RVA23U64)
+    set(CMAKE_REQUIRED_FLAGS)
+    
+    if(BLAKE3_COMPILER_SUPPORTS_RVA23U64)
+      set(BLAKE3_CFLAGS_RVV "-march=rva23u64" CACHE STRING "the compiler flags to enable RVV")
+    else()
+      # Fall back to rv64gcv
+      set(CMAKE_REQUIRED_FLAGS "-march=rv64gcv")
+      check_c_source_compiles("
+#include <riscv_vector.h>
+int main() {
+  size_t vl = __riscv_vsetvlmax_e32m1();
+  return 0;
+}
+" BLAKE3_COMPILER_SUPPORTS_RV64GCV)
+      set(CMAKE_REQUIRED_FLAGS)
+      
+      if(BLAKE3_COMPILER_SUPPORTS_RV64GCV)
+        set(BLAKE3_CFLAGS_RVV "-march=rv64gcv" CACHE STRING "the compiler flags to enable RVV")
+      endif()
+    endif()
+  endif()
 endif()
 
-mark_as_advanced(BLAKE3_CFLAGS_SSE2 BLAKE3_CFLAGS_SSE4.1 BLAKE3_CFLAGS_AVX2 BLAKE3_CFLAGS_AVX512 BLAKE3_CFLAGS_NEON)
+mark_as_advanced(BLAKE3_CFLAGS_SSE2 BLAKE3_CFLAGS_SSE4.1 BLAKE3_CFLAGS_AVX2 BLAKE3_CFLAGS_AVX512 BLAKE3_CFLAGS_NEON BLAKE3_CFLAGS_RVV)
 mark_as_advanced(BLAKE3_AMD64_ASM_SOURCES)
 
 message(STATUS "BLAKE3 SIMD configuration: ${CMAKE_C_COMPILER_ARCHITECTURE_ID}")
@@ -119,6 +156,10 @@ elseif((CMAKE_SYSTEM_PROCESSOR IN_LIST BLAKE3_ARMv8_NAMES
         AND (DEFINED BLAKE3_CFLAGS_NEON
           OR CMAKE_SIZEOF_VOID_P EQUAL 8))
   set(BLAKE3_SIMD_TYPE "neon-intrinsics" CACHE STRING "the SIMD acceleration type to use")
+
+elseif(CMAKE_SYSTEM_PROCESSOR IN_LIST BLAKE3_RISCV64_NAMES
+        AND DEFINED BLAKE3_CFLAGS_RVV)
+  set(BLAKE3_SIMD_TYPE "rvv-intrinsics" CACHE STRING "the SIMD acceleration type to use")
 
 else()
   set(BLAKE3_SIMD_TYPE "none" CACHE STRING "the SIMD acceleration type to use")
@@ -212,9 +253,26 @@ elseif(BLAKE3_SIMD_TYPE STREQUAL "neon-intrinsics")
     set_source_files_properties(blake3_neon.c PROPERTIES COMPILE_FLAGS "${BLAKE3_CFLAGS_NEON}")
   endif()
 
+elseif(BLAKE3_SIMD_TYPE STREQUAL "rvv-intrinsics")
+  set(BLAKE3_SIMD_RVV_INTRINSICS ON)
+
+  target_sources(blake3 PRIVATE
+    blake3_rvv.c
+  )
+  target_compile_definitions(blake3 PRIVATE
+    BLAKE3_USE_RVV=1
+  )
+
+  if (DEFINED BLAKE3_CFLAGS_RVV)
+    set_source_files_properties(blake3_rvv.c PROPERTIES COMPILE_FLAGS "${BLAKE3_CFLAGS_RVV}")
+    # blake3_dispatch.c also needs RVV flags to call __riscv_vsetvlmax_e32m1()
+    set_source_files_properties(blake3_dispatch.c PROPERTIES COMPILE_FLAGS "${BLAKE3_CFLAGS_RVV}")
+  endif()
+
 elseif(BLAKE3_SIMD_TYPE STREQUAL "none")
   target_compile_definitions(blake3 PRIVATE
     BLAKE3_USE_NEON=0
+    BLAKE3_USE_RVV=0
     BLAKE3_NO_SSE2
     BLAKE3_NO_SSE41
     BLAKE3_NO_AVX2
@@ -372,6 +430,7 @@ install(FILES "${CMAKE_BINARY_DIR}/libblake3.pc"
 add_feature_info("AMD64 assembly" BLAKE3_SIMD_AMD64_ASM "The library uses hand written amd64 SIMD assembly.")
 add_feature_info("x86 SIMD intrinsics" BLAKE3_SIMD_X86_INTRINSICS "The library uses x86 SIMD intrinsics.")
 add_feature_info("NEON SIMD intrinsics" BLAKE3_SIMD_NEON_INTRINSICS "The library uses NEON SIMD intrinsics.")
+add_feature_info("RVV SIMD intrinsics" BLAKE3_SIMD_RVV_INTRINSICS "The library uses RISC-V Vector Extension (RVV) intrinsics.")
 add_feature_info("oneTBB parallelism" BLAKE3_USE_TBB "The library uses oneTBB parallelism.")
 feature_summary(WHAT ENABLED_FEATURES)
 

--- a/c/blake3_c_rust_bindings/Cargo.toml
+++ b/c/blake3_c_rust_bindings/Cargo.toml
@@ -16,6 +16,8 @@ prefer_intrinsics = []
 # Activate NEON bindings. We don't currently do any CPU feature detection for
 # this. If this Cargo feature is on, the NEON gets used.
 neon = []
+# Force-enable RVV (RISC-V Vector). Skips runtime detection.
+rvv = []
 # Enable TBB-based multithreading.
 tbb = []
 

--- a/c/blake3_c_rust_bindings/build.rs
+++ b/c/blake3_c_rust_bindings/build.rs
@@ -110,6 +110,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     if cfg!(feature = "tbb") {
         base_build.define("BLAKE3_USE_TBB", "1");
     }
+    if cfg!(feature = "rvv") {
+        base_build.define("BLAKE3_USE_RVV", "1");
+    }
     base_build.compile("blake3_base");
 
     if cfg!(feature = "tbb") {
@@ -221,6 +224,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             neon_build.flag("-mfloat-abi=hard");
         }
         neon_build.compile("blake3_neon");
+    }
+
+    if defined("CARGO_FEATURE_RVV") {
+        let mut rvv_build = new_build();
+        rvv_build.file(c_dir_path("blake3_rvv.c"));
+        rvv_build.flag("-march=rv64imfdv");
+        rvv_build.compile("blake3_rvv");
     }
 
     // The `cc` crate does not automatically emit rerun-if directives for the

--- a/c/blake3_c_rust_bindings/cross_test.sh
+++ b/c/blake3_c_rust_bindings/cross_test.sh
@@ -26,6 +26,7 @@ cat > Cross.toml << EOF
 [build.env]
 passthrough = [
     "BLAKE3_C_DIR_OVERRIDE",
+    "QEMU_CPU",
 ]
 EOF
 cross test "$@"

--- a/c/blake3_dispatch.c
+++ b/c/blake3_dispatch.c
@@ -18,8 +18,36 @@
 #endif
 #endif
 
+#if BLAKE3_BUILD_RVV == 1
+#if defined(__linux__)
+#include <sys/auxv.h>
+#elif defined(__FreeBSD__)
+#include <sys/auxv.h>
+#endif
+
+// Runtime detection of RISC-V V extension.
+static bool blake3_rvv_detected(void) {
 #if BLAKE3_USE_RVV == 1
-#include <riscv_vector.h>
+  // User explicitly forced RVV via BLAKE3_USE_RVV=1, skip detection.
+  return true;
+#elif defined(__linux__)
+  // RISC-V HWCAP bit for V extension (bit 21, letter 'V' - 'A')
+  const unsigned long COMPAT_HWCAP_ISA_V = 1UL << ('V' - 'A');
+  return (getauxval(AT_HWCAP) & COMPAT_HWCAP_ISA_V) != 0;
+#elif defined(__FreeBSD__)
+  const unsigned long COMPAT_HWCAP_ISA_V = 1UL << ('V' - 'A');
+  unsigned long hwcap = 0;
+  if (elf_aux_info(AT_HWCAP, &hwcap, sizeof(hwcap)) == 0) {
+    return (hwcap & COMPAT_HWCAP_ISA_V) != 0;
+  }
+  return false;
+#else
+  // Bare-metal / unknown OS: no safe way to detect V extension at runtime.
+  // Use BLAKE3_USE_RVV=1 to force-enable when the hardware is known to
+  // support it.
+  return false;
+#endif
+}
 #endif
 
 #if !defined(BLAKE3_ATOMICS)
@@ -298,10 +326,12 @@ void blake3_hash_many(const uint8_t *const *inputs, size_t num_inputs,
   return;
 #endif
 
-#if BLAKE3_USE_RVV == 1
-  blake3_hash_many_rvv(inputs, num_inputs, blocks, key, counter,
-                       increment_counter, flags, flags_start, flags_end, out);
-  return;
+#if BLAKE3_BUILD_RVV == 1
+  if (blake3_rvv_detected()) {
+    blake3_hash_many_rvv(inputs, num_inputs, blocks, key, counter,
+                         increment_counter, flags, flags_start, flags_end, out);
+    return;
+  }
 #endif
 
   blake3_hash_many_portable(inputs, num_inputs, blocks, key, counter,
@@ -338,9 +368,10 @@ size_t blake3_simd_degree(void) {
 #if BLAKE3_USE_NEON == 1
   return 4;
 #endif
-#if BLAKE3_USE_RVV == 1
-  // RVV vector length is dynamic, query it at runtime.
-  return __riscv_vsetvlmax_e32m1();
+#if BLAKE3_BUILD_RVV == 1
+  if (blake3_rvv_detected()) {
+    return blake3_rvv_simd_degree();
+  }
 #endif
   return 1;
 }

--- a/c/blake3_dispatch.c
+++ b/c/blake3_dispatch.c
@@ -18,6 +18,10 @@
 #endif
 #endif
 
+#if BLAKE3_USE_RVV == 1
+#include <riscv_vector.h>
+#endif
+
 #if !defined(BLAKE3_ATOMICS)
 #if defined(__has_include)
 #if __has_include(<stdatomic.h>) && !defined(_MSC_VER)
@@ -294,6 +298,12 @@ void blake3_hash_many(const uint8_t *const *inputs, size_t num_inputs,
   return;
 #endif
 
+#if BLAKE3_USE_RVV == 1
+  blake3_hash_many_rvv(inputs, num_inputs, blocks, key, counter,
+                       increment_counter, flags, flags_start, flags_end, out);
+  return;
+#endif
+
   blake3_hash_many_portable(inputs, num_inputs, blocks, key, counter,
                             increment_counter, flags, flags_start, flags_end,
                             out);
@@ -327,6 +337,10 @@ size_t blake3_simd_degree(void) {
 #endif
 #if BLAKE3_USE_NEON == 1
   return 4;
+#endif
+#if BLAKE3_USE_RVV == 1
+  // RVV vector length is dynamic, query it at runtime.
+  return __riscv_vsetvlmax_e32m1();
 #endif
   return 1;
 }

--- a/c/blake3_impl.h
+++ b/c/blake3_impl.h
@@ -71,11 +71,30 @@ enum blake3_flags {
   #endif
 #endif
 
+#if !defined(BLAKE3_USE_RVV)
+  #define BLAKE3_USE_RVV 0
+#endif
+
+// BLAKE3_USE_RVV implies BLAKE3_BUILD_RVV.
+#if BLAKE3_USE_RVV == 1 && !defined(BLAKE3_BUILD_RVV)
+  #define BLAKE3_BUILD_RVV 1
+#endif
+
+#if !defined(BLAKE3_BUILD_RVV)
+  // If BLAKE3_BUILD_RVV not manually set, autodetect based on __riscv_vector
+  // (defined by the compiler when V or Zve* extensions are enabled).
+  #if defined(__riscv_vector) && defined(__riscv) && (__riscv_xlen == 64)
+    #define BLAKE3_BUILD_RVV 1
+  #else
+    #define BLAKE3_BUILD_RVV 0
+  #endif
+#endif
+
 #if defined(IS_X86)
 #define MAX_SIMD_DEGREE 16
 #elif BLAKE3_USE_NEON == 1
 #define MAX_SIMD_DEGREE 4
-#elif BLAKE3_USE_RVV == 1
+#elif BLAKE3_BUILD_RVV == 1
 #define MAX_SIMD_DEGREE 64
 #else
 #define MAX_SIMD_DEGREE 1
@@ -328,12 +347,13 @@ void blake3_hash_many_neon(const uint8_t *const *inputs, size_t num_inputs,
                            uint8_t flags_end, uint8_t *out);
 #endif
 
-#if BLAKE3_USE_RVV == 1
+#if BLAKE3_BUILD_RVV == 1
 void blake3_hash_many_rvv(const uint8_t *const *inputs, size_t num_inputs,
                           size_t blocks, const uint32_t key[8],
                           uint64_t counter, bool increment_counter,
                           uint8_t flags, uint8_t flags_start,
                           uint8_t flags_end, uint8_t *out);
+size_t blake3_rvv_simd_degree(void);
 #endif
 
 #ifdef __cplusplus

--- a/c/blake3_impl.h
+++ b/c/blake3_impl.h
@@ -76,7 +76,7 @@ enum blake3_flags {
 #elif BLAKE3_USE_NEON == 1
 #define MAX_SIMD_DEGREE 4
 #elif BLAKE3_USE_RVV == 1
-#define MAX_SIMD_DEGREE 16
+#define MAX_SIMD_DEGREE 64
 #else
 #define MAX_SIMD_DEGREE 1
 #endif

--- a/c/blake3_impl.h
+++ b/c/blake3_impl.h
@@ -75,6 +75,8 @@ enum blake3_flags {
 #define MAX_SIMD_DEGREE 16
 #elif BLAKE3_USE_NEON == 1
 #define MAX_SIMD_DEGREE 4
+#elif BLAKE3_USE_RVV == 1
+#define MAX_SIMD_DEGREE 16
 #else
 #define MAX_SIMD_DEGREE 1
 #endif
@@ -324,6 +326,14 @@ void blake3_hash_many_neon(const uint8_t *const *inputs, size_t num_inputs,
                            uint64_t counter, bool increment_counter,
                            uint8_t flags, uint8_t flags_start,
                            uint8_t flags_end, uint8_t *out);
+#endif
+
+#if BLAKE3_USE_RVV == 1
+void blake3_hash_many_rvv(const uint8_t *const *inputs, size_t num_inputs,
+                          size_t blocks, const uint32_t key[8],
+                          uint64_t counter, bool increment_counter,
+                          uint8_t flags, uint8_t flags_start,
+                          uint8_t flags_end, uint8_t *out);
 #endif
 
 #ifdef __cplusplus

--- a/c/blake3_rvv.c
+++ b/c/blake3_rvv.c
@@ -129,71 +129,80 @@ INLINE void blake3_hash_vl_rvv(const uint8_t *const *inputs, size_t vl,
 
   uint8_t block_flags = flags | flags_start;
 
+  // Copy each input's block into an aligned buffer before gather loading.
+  // Input pointers are byte-aligned (&[u8]) and may not satisfy the u32
+  // alignment required by vluxei64_v_u32m1 on hardware without misaligned
+  // vector support (e.g. T-Head C920).
+  uint8_t aligned_blocks[vl][BLAKE3_BLOCK_LEN];
+
   for (size_t block = 0; block < blocks; block++) {
     if (block + 1 == blocks) {
       block_flags |= flags_end;
     }
 
-    // Load message words from vl different inputs using indexed load
-    // This uses RVV's vluxei64 instruction to gather data from multiple addresses
     size_t offset = block * BLAKE3_BLOCK_LEN;
-    
-    // Construct base address vector: addresses of each input's message block
+
+    // Copy vl input blocks into the aligned buffer
+    for (size_t i = 0; i < vl; i++) {
+      memcpy(aligned_blocks[i], &inputs[i][offset], BLAKE3_BLOCK_LEN);
+    }
+
+    // Construct base address vector from aligned buffer
     uint64_t base_addrs[vl];
     for (size_t i = 0; i < vl; i++) {
-      base_addrs[i] = (uint64_t)&inputs[i][offset];
+      base_addrs[i] = (uint64_t)aligned_blocks[i];
     }
     vuint64m2_t base_vec = __riscv_vle64_v_u64m2(base_addrs, vl);
-    
-    // Use indexed load to gather each message word from all inputs
-    // Fully unrolled for maximum performance
-    vuint64m2_t addr0 = base_vec;
-    vuint32m1_t m0 = __riscv_vluxei64_v_u32m1((const uint32_t *)0, addr0, vl);
-    
-    vuint64m2_t addr1 = __riscv_vadd_vx_u64m2(base_vec, 1 * sizeof(uint32_t), vl);
-    vuint32m1_t m1 = __riscv_vluxei64_v_u32m1((const uint32_t *)0, addr1, vl);
-    
-    vuint64m2_t addr2 = __riscv_vadd_vx_u64m2(base_vec, 2 * sizeof(uint32_t), vl);
-    vuint32m1_t m2 = __riscv_vluxei64_v_u32m1((const uint32_t *)0, addr2, vl);
-    
-    vuint64m2_t addr3 = __riscv_vadd_vx_u64m2(base_vec, 3 * sizeof(uint32_t), vl);
-    vuint32m1_t m3 = __riscv_vluxei64_v_u32m1((const uint32_t *)0, addr3, vl);
-    
-    vuint64m2_t addr4 = __riscv_vadd_vx_u64m2(base_vec, 4 * sizeof(uint32_t), vl);
-    vuint32m1_t m4 = __riscv_vluxei64_v_u32m1((const uint32_t *)0, addr4, vl);
-    
-    vuint64m2_t addr5 = __riscv_vadd_vx_u64m2(base_vec, 5 * sizeof(uint32_t), vl);
-    vuint32m1_t m5 = __riscv_vluxei64_v_u32m1((const uint32_t *)0, addr5, vl);
-    
-    vuint64m2_t addr6 = __riscv_vadd_vx_u64m2(base_vec, 6 * sizeof(uint32_t), vl);
-    vuint32m1_t m6 = __riscv_vluxei64_v_u32m1((const uint32_t *)0, addr6, vl);
-    
-    vuint64m2_t addr7 = __riscv_vadd_vx_u64m2(base_vec, 7 * sizeof(uint32_t), vl);
-    vuint32m1_t m7 = __riscv_vluxei64_v_u32m1((const uint32_t *)0, addr7, vl);
-    
-    vuint64m2_t addr8 = __riscv_vadd_vx_u64m2(base_vec, 8 * sizeof(uint32_t), vl);
-    vuint32m1_t m8 = __riscv_vluxei64_v_u32m1((const uint32_t *)0, addr8, vl);
-    
-    vuint64m2_t addr9 = __riscv_vadd_vx_u64m2(base_vec, 9 * sizeof(uint32_t), vl);
-    vuint32m1_t m9 = __riscv_vluxei64_v_u32m1((const uint32_t *)0, addr9, vl);
-    
-    vuint64m2_t addr10 = __riscv_vadd_vx_u64m2(base_vec, 10 * sizeof(uint32_t), vl);
-    vuint32m1_t m10 = __riscv_vluxei64_v_u32m1((const uint32_t *)0, addr10, vl);
-    
-    vuint64m2_t addr11 = __riscv_vadd_vx_u64m2(base_vec, 11 * sizeof(uint32_t), vl);
-    vuint32m1_t m11 = __riscv_vluxei64_v_u32m1((const uint32_t *)0, addr11, vl);
-    
-    vuint64m2_t addr12 = __riscv_vadd_vx_u64m2(base_vec, 12 * sizeof(uint32_t), vl);
-    vuint32m1_t m12 = __riscv_vluxei64_v_u32m1((const uint32_t *)0, addr12, vl);
-    
-    vuint64m2_t addr13 = __riscv_vadd_vx_u64m2(base_vec, 13 * sizeof(uint32_t), vl);
-    vuint32m1_t m13 = __riscv_vluxei64_v_u32m1((const uint32_t *)0, addr13, vl);
-    
-    vuint64m2_t addr14 = __riscv_vadd_vx_u64m2(base_vec, 14 * sizeof(uint32_t), vl);
-    vuint32m1_t m14 = __riscv_vluxei64_v_u32m1((const uint32_t *)0, addr14, vl);
-    
-    vuint64m2_t addr15 = __riscv_vadd_vx_u64m2(base_vec, 15 * sizeof(uint32_t), vl);
-    vuint32m1_t m15 = __riscv_vluxei64_v_u32m1((const uint32_t *)0, addr15, vl);
+
+    vuint64m2_t addr_vec;
+
+    addr_vec = base_vec;
+    vuint32m1_t m0 = __riscv_vluxei64_v_u32m1((const uint32_t *)0, addr_vec, vl);
+
+    addr_vec = __riscv_vadd_vx_u64m2(base_vec, 1 * sizeof(uint32_t), vl);
+    vuint32m1_t m1 = __riscv_vluxei64_v_u32m1((const uint32_t *)0, addr_vec, vl);
+
+    addr_vec = __riscv_vadd_vx_u64m2(base_vec, 2 * sizeof(uint32_t), vl);
+    vuint32m1_t m2 = __riscv_vluxei64_v_u32m1((const uint32_t *)0, addr_vec, vl);
+
+    addr_vec = __riscv_vadd_vx_u64m2(base_vec, 3 * sizeof(uint32_t), vl);
+    vuint32m1_t m3 = __riscv_vluxei64_v_u32m1((const uint32_t *)0, addr_vec, vl);
+
+    addr_vec = __riscv_vadd_vx_u64m2(base_vec, 4 * sizeof(uint32_t), vl);
+    vuint32m1_t m4 = __riscv_vluxei64_v_u32m1((const uint32_t *)0, addr_vec, vl);
+
+    addr_vec = __riscv_vadd_vx_u64m2(base_vec, 5 * sizeof(uint32_t), vl);
+    vuint32m1_t m5 = __riscv_vluxei64_v_u32m1((const uint32_t *)0, addr_vec, vl);
+
+    addr_vec = __riscv_vadd_vx_u64m2(base_vec, 6 * sizeof(uint32_t), vl);
+    vuint32m1_t m6 = __riscv_vluxei64_v_u32m1((const uint32_t *)0, addr_vec, vl);
+
+    addr_vec = __riscv_vadd_vx_u64m2(base_vec, 7 * sizeof(uint32_t), vl);
+    vuint32m1_t m7 = __riscv_vluxei64_v_u32m1((const uint32_t *)0, addr_vec, vl);
+
+    addr_vec = __riscv_vadd_vx_u64m2(base_vec, 8 * sizeof(uint32_t), vl);
+    vuint32m1_t m8 = __riscv_vluxei64_v_u32m1((const uint32_t *)0, addr_vec, vl);
+
+    addr_vec = __riscv_vadd_vx_u64m2(base_vec, 9 * sizeof(uint32_t), vl);
+    vuint32m1_t m9 = __riscv_vluxei64_v_u32m1((const uint32_t *)0, addr_vec, vl);
+
+    addr_vec = __riscv_vadd_vx_u64m2(base_vec, 10 * sizeof(uint32_t), vl);
+    vuint32m1_t m10 = __riscv_vluxei64_v_u32m1((const uint32_t *)0, addr_vec, vl);
+
+    addr_vec = __riscv_vadd_vx_u64m2(base_vec, 11 * sizeof(uint32_t), vl);
+    vuint32m1_t m11 = __riscv_vluxei64_v_u32m1((const uint32_t *)0, addr_vec, vl);
+
+    addr_vec = __riscv_vadd_vx_u64m2(base_vec, 12 * sizeof(uint32_t), vl);
+    vuint32m1_t m12 = __riscv_vluxei64_v_u32m1((const uint32_t *)0, addr_vec, vl);
+
+    addr_vec = __riscv_vadd_vx_u64m2(base_vec, 13 * sizeof(uint32_t), vl);
+    vuint32m1_t m13 = __riscv_vluxei64_v_u32m1((const uint32_t *)0, addr_vec, vl);
+
+    addr_vec = __riscv_vadd_vx_u64m2(base_vec, 14 * sizeof(uint32_t), vl);
+    vuint32m1_t m14 = __riscv_vluxei64_v_u32m1((const uint32_t *)0, addr_vec, vl);
+
+    addr_vec = __riscv_vadd_vx_u64m2(base_vec, 15 * sizeof(uint32_t), vl);
+    vuint32m1_t m15 = __riscv_vluxei64_v_u32m1((const uint32_t *)0, addr_vec, vl);
 
     vuint32m1_t v0 = h0;
     vuint32m1_t v1 = h1;

--- a/c/blake3_rvv.c
+++ b/c/blake3_rvv.c
@@ -1,0 +1,301 @@
+#include "blake3_impl.h"
+#include <riscv_vector.h>
+
+void blake3_compress_in_place_portable(uint32_t cv[8],
+                                       const uint8_t block[BLAKE3_BLOCK_LEN],
+                                       uint8_t block_len, uint64_t counter,
+                                       uint8_t flags);
+
+INLINE vuint32m1_t add(vuint32m1_t a, vuint32m1_t b, size_t vl) {
+  return __riscv_vadd_vv_u32m1(a, b, vl);
+}
+
+INLINE vuint32m1_t xor(vuint32m1_t a, vuint32m1_t b, size_t vl) {
+  return __riscv_vxor_vv_u32m1(a, b, vl);
+}
+
+INLINE vuint32m1_t set1(uint32_t x, size_t vl) {
+  return __riscv_vmv_v_x_u32m1(x, vl);
+}
+
+INLINE vuint32m1_t rot16(vuint32m1_t x, size_t vl) {
+  return __riscv_vor_vv_u32m1(__riscv_vsrl_vx_u32m1(x, 16, vl),
+                               __riscv_vsll_vx_u32m1(x, 16, vl), vl);
+}
+
+INLINE vuint32m1_t rot12(vuint32m1_t x, size_t vl) {
+  return __riscv_vor_vv_u32m1(__riscv_vsrl_vx_u32m1(x, 12, vl),
+                               __riscv_vsll_vx_u32m1(x, 20, vl), vl);
+}
+
+INLINE vuint32m1_t rot8(vuint32m1_t x, size_t vl) {
+  return __riscv_vor_vv_u32m1(__riscv_vsrl_vx_u32m1(x, 8, vl),
+                               __riscv_vsll_vx_u32m1(x, 24, vl), vl);
+}
+
+INLINE vuint32m1_t rot7(vuint32m1_t x, size_t vl) {
+  return __riscv_vor_vv_u32m1(__riscv_vsrl_vx_u32m1(x, 7, vl),
+                               __riscv_vsll_vx_u32m1(x, 25, vl), vl);
+}
+
+INLINE void g(vuint32m1_t *a, vuint32m1_t *b, vuint32m1_t *c, vuint32m1_t *d,
+              vuint32m1_t mx, vuint32m1_t my, size_t vl) {
+  *a = add(*a, add(*b, mx, vl), vl);
+  *d = rot16(xor(*d, *a, vl), vl);
+  *c = add(*c, *d, vl);
+  *b = rot12(xor(*b, *c, vl), vl);
+  *a = add(*a, add(*b, my, vl), vl);
+  *d = rot8(xor(*d, *a, vl), vl);
+  *c = add(*c, *d, vl);
+  *b = rot7(xor(*b, *c, vl), vl);
+}
+
+INLINE vuint32m1_t get_msg(vuint32m1_t m0, vuint32m1_t m1, vuint32m1_t m2, vuint32m1_t m3,
+                            vuint32m1_t m4, vuint32m1_t m5, vuint32m1_t m6, vuint32m1_t m7,
+                            vuint32m1_t m8, vuint32m1_t m9, vuint32m1_t m10, vuint32m1_t m11,
+                            vuint32m1_t m12, vuint32m1_t m13, vuint32m1_t m14, vuint32m1_t m15,
+                            size_t idx) {
+  switch(idx) {
+    case 0: return m0;
+    case 1: return m1;
+    case 2: return m2;
+    case 3: return m3;
+    case 4: return m4;
+    case 5: return m5;
+    case 6: return m6;
+    case 7: return m7;
+    case 8: return m8;
+    case 9: return m9;
+    case 10: return m10;
+    case 11: return m11;
+    case 12: return m12;
+    case 13: return m13;
+    case 14: return m14;
+    default: return m15;
+  }
+}
+
+INLINE void round_fn(vuint32m1_t *v0, vuint32m1_t *v1, vuint32m1_t *v2, vuint32m1_t *v3,
+                     vuint32m1_t *v4, vuint32m1_t *v5, vuint32m1_t *v6, vuint32m1_t *v7,
+                     vuint32m1_t *v8, vuint32m1_t *v9, vuint32m1_t *v10, vuint32m1_t *v11,
+                     vuint32m1_t *v12, vuint32m1_t *v13, vuint32m1_t *v14, vuint32m1_t *v15,
+                     vuint32m1_t m0, vuint32m1_t m1, vuint32m1_t m2, vuint32m1_t m3,
+                     vuint32m1_t m4, vuint32m1_t m5, vuint32m1_t m6, vuint32m1_t m7,
+                     vuint32m1_t m8, vuint32m1_t m9, vuint32m1_t m10, vuint32m1_t m11,
+                     vuint32m1_t m12, vuint32m1_t m13, vuint32m1_t m14, vuint32m1_t m15,
+                     size_t r, size_t vl) {
+  g(v0, v4, v8, v12, get_msg(m0,m1,m2,m3,m4,m5,m6,m7,m8,m9,m10,m11,m12,m13,m14,m15, MSG_SCHEDULE[r][0]),
+                     get_msg(m0,m1,m2,m3,m4,m5,m6,m7,m8,m9,m10,m11,m12,m13,m14,m15, MSG_SCHEDULE[r][1]), vl);
+  g(v1, v5, v9, v13, get_msg(m0,m1,m2,m3,m4,m5,m6,m7,m8,m9,m10,m11,m12,m13,m14,m15, MSG_SCHEDULE[r][2]),
+                     get_msg(m0,m1,m2,m3,m4,m5,m6,m7,m8,m9,m10,m11,m12,m13,m14,m15, MSG_SCHEDULE[r][3]), vl);
+  g(v2, v6, v10, v14, get_msg(m0,m1,m2,m3,m4,m5,m6,m7,m8,m9,m10,m11,m12,m13,m14,m15, MSG_SCHEDULE[r][4]),
+                      get_msg(m0,m1,m2,m3,m4,m5,m6,m7,m8,m9,m10,m11,m12,m13,m14,m15, MSG_SCHEDULE[r][5]), vl);
+  g(v3, v7, v11, v15, get_msg(m0,m1,m2,m3,m4,m5,m6,m7,m8,m9,m10,m11,m12,m13,m14,m15, MSG_SCHEDULE[r][6]),
+                      get_msg(m0,m1,m2,m3,m4,m5,m6,m7,m8,m9,m10,m11,m12,m13,m14,m15, MSG_SCHEDULE[r][7]), vl);
+  g(v0, v5, v10, v15, get_msg(m0,m1,m2,m3,m4,m5,m6,m7,m8,m9,m10,m11,m12,m13,m14,m15, MSG_SCHEDULE[r][8]),
+                      get_msg(m0,m1,m2,m3,m4,m5,m6,m7,m8,m9,m10,m11,m12,m13,m14,m15, MSG_SCHEDULE[r][9]), vl);
+  g(v1, v6, v11, v12, get_msg(m0,m1,m2,m3,m4,m5,m6,m7,m8,m9,m10,m11,m12,m13,m14,m15, MSG_SCHEDULE[r][10]),
+                      get_msg(m0,m1,m2,m3,m4,m5,m6,m7,m8,m9,m10,m11,m12,m13,m14,m15, MSG_SCHEDULE[r][11]), vl);
+  g(v2, v7, v8, v13, get_msg(m0,m1,m2,m3,m4,m5,m6,m7,m8,m9,m10,m11,m12,m13,m14,m15, MSG_SCHEDULE[r][12]),
+                     get_msg(m0,m1,m2,m3,m4,m5,m6,m7,m8,m9,m10,m11,m12,m13,m14,m15, MSG_SCHEDULE[r][13]), vl);
+  g(v3, v4, v9, v14, get_msg(m0,m1,m2,m3,m4,m5,m6,m7,m8,m9,m10,m11,m12,m13,m14,m15, MSG_SCHEDULE[r][14]),
+                     get_msg(m0,m1,m2,m3,m4,m5,m6,m7,m8,m9,m10,m11,m12,m13,m14,m15, MSG_SCHEDULE[r][15]), vl);
+}
+
+// Hash vl inputs in parallel using RVV
+INLINE void blake3_hash_vl_rvv(const uint8_t *const *inputs, size_t vl,
+                                size_t blocks, const uint32_t key[8],
+                                uint64_t counter, bool increment_counter,
+                                uint8_t flags, uint8_t flags_start,
+                                uint8_t flags_end, uint8_t *out) {
+  vuint32m1_t h0 = set1(key[0], vl);
+  vuint32m1_t h1 = set1(key[1], vl);
+  vuint32m1_t h2 = set1(key[2], vl);
+  vuint32m1_t h3 = set1(key[3], vl);
+  vuint32m1_t h4 = set1(key[4], vl);
+  vuint32m1_t h5 = set1(key[5], vl);
+  vuint32m1_t h6 = set1(key[6], vl);
+  vuint32m1_t h7 = set1(key[7], vl);
+
+  uint32_t low_vals[vl];
+  uint32_t high_vals[vl];
+  for (size_t i = 0; i < vl; i++) {
+    uint64_t c = counter + (increment_counter ? i : 0);
+    low_vals[i] = (uint32_t)c;
+    high_vals[i] = (uint32_t)(c >> 32);
+  }
+  vuint32m1_t counter_low = __riscv_vle32_v_u32m1(low_vals, vl);
+  vuint32m1_t counter_high = __riscv_vle32_v_u32m1(high_vals, vl);
+
+  uint8_t block_flags = flags | flags_start;
+
+  for (size_t block = 0; block < blocks; block++) {
+    if (block + 1 == blocks) {
+      block_flags |= flags_end;
+    }
+
+    // Load message words from vl different inputs using indexed load
+    // This uses RVV's vluxei64 instruction to gather data from multiple addresses
+    size_t offset = block * BLAKE3_BLOCK_LEN;
+    
+    // Construct base address vector: addresses of each input's message block
+    uint64_t base_addrs[vl];
+    for (size_t i = 0; i < vl; i++) {
+      base_addrs[i] = (uint64_t)&inputs[i][offset];
+    }
+    vuint64m2_t base_vec = __riscv_vle64_v_u64m2(base_addrs, vl);
+    
+    // Use indexed load to gather each message word from all inputs
+    // Fully unrolled for maximum performance
+    vuint64m2_t addr0 = base_vec;
+    vuint32m1_t m0 = __riscv_vluxei64_v_u32m1((const uint32_t *)0, addr0, vl);
+    
+    vuint64m2_t addr1 = __riscv_vadd_vx_u64m2(base_vec, 1 * sizeof(uint32_t), vl);
+    vuint32m1_t m1 = __riscv_vluxei64_v_u32m1((const uint32_t *)0, addr1, vl);
+    
+    vuint64m2_t addr2 = __riscv_vadd_vx_u64m2(base_vec, 2 * sizeof(uint32_t), vl);
+    vuint32m1_t m2 = __riscv_vluxei64_v_u32m1((const uint32_t *)0, addr2, vl);
+    
+    vuint64m2_t addr3 = __riscv_vadd_vx_u64m2(base_vec, 3 * sizeof(uint32_t), vl);
+    vuint32m1_t m3 = __riscv_vluxei64_v_u32m1((const uint32_t *)0, addr3, vl);
+    
+    vuint64m2_t addr4 = __riscv_vadd_vx_u64m2(base_vec, 4 * sizeof(uint32_t), vl);
+    vuint32m1_t m4 = __riscv_vluxei64_v_u32m1((const uint32_t *)0, addr4, vl);
+    
+    vuint64m2_t addr5 = __riscv_vadd_vx_u64m2(base_vec, 5 * sizeof(uint32_t), vl);
+    vuint32m1_t m5 = __riscv_vluxei64_v_u32m1((const uint32_t *)0, addr5, vl);
+    
+    vuint64m2_t addr6 = __riscv_vadd_vx_u64m2(base_vec, 6 * sizeof(uint32_t), vl);
+    vuint32m1_t m6 = __riscv_vluxei64_v_u32m1((const uint32_t *)0, addr6, vl);
+    
+    vuint64m2_t addr7 = __riscv_vadd_vx_u64m2(base_vec, 7 * sizeof(uint32_t), vl);
+    vuint32m1_t m7 = __riscv_vluxei64_v_u32m1((const uint32_t *)0, addr7, vl);
+    
+    vuint64m2_t addr8 = __riscv_vadd_vx_u64m2(base_vec, 8 * sizeof(uint32_t), vl);
+    vuint32m1_t m8 = __riscv_vluxei64_v_u32m1((const uint32_t *)0, addr8, vl);
+    
+    vuint64m2_t addr9 = __riscv_vadd_vx_u64m2(base_vec, 9 * sizeof(uint32_t), vl);
+    vuint32m1_t m9 = __riscv_vluxei64_v_u32m1((const uint32_t *)0, addr9, vl);
+    
+    vuint64m2_t addr10 = __riscv_vadd_vx_u64m2(base_vec, 10 * sizeof(uint32_t), vl);
+    vuint32m1_t m10 = __riscv_vluxei64_v_u32m1((const uint32_t *)0, addr10, vl);
+    
+    vuint64m2_t addr11 = __riscv_vadd_vx_u64m2(base_vec, 11 * sizeof(uint32_t), vl);
+    vuint32m1_t m11 = __riscv_vluxei64_v_u32m1((const uint32_t *)0, addr11, vl);
+    
+    vuint64m2_t addr12 = __riscv_vadd_vx_u64m2(base_vec, 12 * sizeof(uint32_t), vl);
+    vuint32m1_t m12 = __riscv_vluxei64_v_u32m1((const uint32_t *)0, addr12, vl);
+    
+    vuint64m2_t addr13 = __riscv_vadd_vx_u64m2(base_vec, 13 * sizeof(uint32_t), vl);
+    vuint32m1_t m13 = __riscv_vluxei64_v_u32m1((const uint32_t *)0, addr13, vl);
+    
+    vuint64m2_t addr14 = __riscv_vadd_vx_u64m2(base_vec, 14 * sizeof(uint32_t), vl);
+    vuint32m1_t m14 = __riscv_vluxei64_v_u32m1((const uint32_t *)0, addr14, vl);
+    
+    vuint64m2_t addr15 = __riscv_vadd_vx_u64m2(base_vec, 15 * sizeof(uint32_t), vl);
+    vuint32m1_t m15 = __riscv_vluxei64_v_u32m1((const uint32_t *)0, addr15, vl);
+
+    vuint32m1_t v0 = h0;
+    vuint32m1_t v1 = h1;
+    vuint32m1_t v2 = h2;
+    vuint32m1_t v3 = h3;
+    vuint32m1_t v4 = h4;
+    vuint32m1_t v5 = h5;
+    vuint32m1_t v6 = h6;
+    vuint32m1_t v7 = h7;
+    vuint32m1_t v8 = set1(IV[0], vl);
+    vuint32m1_t v9 = set1(IV[1], vl);
+    vuint32m1_t v10 = set1(IV[2], vl);
+    vuint32m1_t v11 = set1(IV[3], vl);
+    vuint32m1_t v12 = counter_low;
+    vuint32m1_t v13 = counter_high;
+    vuint32m1_t v14 = set1((uint32_t)BLAKE3_BLOCK_LEN, vl);
+    vuint32m1_t v15 = set1((uint32_t)block_flags, vl);
+
+    round_fn(&v0, &v1, &v2, &v3, &v4, &v5, &v6, &v7, &v8, &v9, &v10, &v11, &v12, &v13, &v14, &v15,
+             m0, m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, 0, vl);
+    round_fn(&v0, &v1, &v2, &v3, &v4, &v5, &v6, &v7, &v8, &v9, &v10, &v11, &v12, &v13, &v14, &v15,
+             m0, m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, 1, vl);
+    round_fn(&v0, &v1, &v2, &v3, &v4, &v5, &v6, &v7, &v8, &v9, &v10, &v11, &v12, &v13, &v14, &v15,
+             m0, m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, 2, vl);
+    round_fn(&v0, &v1, &v2, &v3, &v4, &v5, &v6, &v7, &v8, &v9, &v10, &v11, &v12, &v13, &v14, &v15,
+             m0, m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, 3, vl);
+    round_fn(&v0, &v1, &v2, &v3, &v4, &v5, &v6, &v7, &v8, &v9, &v10, &v11, &v12, &v13, &v14, &v15,
+             m0, m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, 4, vl);
+    round_fn(&v0, &v1, &v2, &v3, &v4, &v5, &v6, &v7, &v8, &v9, &v10, &v11, &v12, &v13, &v14, &v15,
+             m0, m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, 5, vl);
+    round_fn(&v0, &v1, &v2, &v3, &v4, &v5, &v6, &v7, &v8, &v9, &v10, &v11, &v12, &v13, &v14, &v15,
+             m0, m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, 6, vl);
+
+    h0 = xor(v0, v8, vl);
+    h1 = xor(v1, v9, vl);
+    h2 = xor(v2, v10, vl);
+    h3 = xor(v3, v11, vl);
+    h4 = xor(v4, v12, vl);
+    h5 = xor(v5, v13, vl);
+    h6 = xor(v6, v14, vl);
+    h7 = xor(v7, v15, vl);
+
+    block_flags = flags;
+  }
+
+  const ptrdiff_t out_stride = BLAKE3_OUT_LEN;
+  __riscv_vsse32_v_u32m1((uint32_t *)&out[0 * 4], out_stride, h0, vl);
+  __riscv_vsse32_v_u32m1((uint32_t *)&out[1 * 4], out_stride, h1, vl);
+  __riscv_vsse32_v_u32m1((uint32_t *)&out[2 * 4], out_stride, h2, vl);
+  __riscv_vsse32_v_u32m1((uint32_t *)&out[3 * 4], out_stride, h3, vl);
+  __riscv_vsse32_v_u32m1((uint32_t *)&out[4 * 4], out_stride, h4, vl);
+  __riscv_vsse32_v_u32m1((uint32_t *)&out[5 * 4], out_stride, h5, vl);
+  __riscv_vsse32_v_u32m1((uint32_t *)&out[6 * 4], out_stride, h6, vl);
+  __riscv_vsse32_v_u32m1((uint32_t *)&out[7 * 4], out_stride, h7, vl);
+}
+
+void blake3_hash_many_rvv(const uint8_t *const *inputs, size_t num_inputs,
+                          size_t blocks, const uint32_t key[8],
+                          uint64_t counter, bool increment_counter,
+                          uint8_t flags, uint8_t flags_start,
+                          uint8_t flags_end, uint8_t *out) {
+  size_t vl = __riscv_vsetvlmax_e32m1();
+  
+  while (num_inputs >= vl) {
+    blake3_hash_vl_rvv(inputs, vl, blocks, key, counter, increment_counter,
+                       flags, flags_start, flags_end, out);
+    
+    if (increment_counter) {
+      counter += vl;
+    }
+    inputs += vl;
+    num_inputs -= vl;
+    out += vl * BLAKE3_OUT_LEN;
+  }
+
+  while (num_inputs > 0) {
+    uint32_t cv[8];
+    memcpy(cv, key, BLAKE3_KEY_LEN);
+    uint8_t block_flags = flags | flags_start;
+
+    const uint8_t *input = inputs[0];
+    for (size_t block = 0; block < blocks; block++) {
+      if (block + 1 == blocks) {
+        block_flags |= flags_end;
+      }
+      blake3_compress_in_place_portable(cv, input, BLAKE3_BLOCK_LEN, counter,
+                                        block_flags);
+      input += BLAKE3_BLOCK_LEN;
+      block_flags = flags;
+    }
+
+    memcpy(out, cv, BLAKE3_OUT_LEN);
+
+    if (increment_counter) {
+      counter += 1;
+    }
+    inputs += 1;
+    num_inputs -= 1;
+    out += BLAKE3_OUT_LEN;
+  }
+}
+
+size_t blake3_rvv_simd_degree(void) {
+  return __riscv_vsetvlmax_e32m1();
+}

--- a/src/ffi_rvv.rs
+++ b/src/ffi_rvv.rs
@@ -1,0 +1,85 @@
+use crate::{CVWords, IncrementCounter, BLOCK_LEN, OUT_LEN};
+
+// Unsafe because this may only be called on platforms supporting RVV.
+pub unsafe fn hash_many<const N: usize>(
+    inputs: &[&[u8; N]],
+    key: &CVWords,
+    counter: u64,
+    increment_counter: IncrementCounter,
+    flags: u8,
+    flags_start: u8,
+    flags_end: u8,
+    out: &mut [u8],
+) {
+    // The Rust hash_many implementations do bounds checking on the `out`
+    // array, but the C implementations don't. Even though this is an unsafe
+    // function, assert the bounds here.
+    assert!(out.len() >= inputs.len() * OUT_LEN);
+    unsafe {
+        ffi::blake3_hash_many_rvv(
+            inputs.as_ptr() as *const *const u8,
+            inputs.len(),
+            N / BLOCK_LEN,
+            key.as_ptr(),
+            counter,
+            increment_counter.yes(),
+            flags,
+            flags_start,
+            flags_end,
+            out.as_mut_ptr(),
+        )
+    }
+}
+
+// blake3_rvv.c normally depends on blake3_portable.c, because the RVV
+// implementation only provides 4x compression, and it relies on the portable
+// implementation for 1x compression. However, we expose the portable Rust
+// implementation here instead, to avoid linking in unnecessary code.
+#[unsafe(no_mangle)]
+pub extern "C" fn blake3_compress_in_place_portable(
+    cv: *mut u32,
+    block: *const u8,
+    block_len: u8,
+    counter: u64,
+    flags: u8,
+) {
+    unsafe {
+        crate::portable::compress_in_place(
+            &mut *(cv as *mut [u32; 8]),
+            &*(block as *const [u8; 64]),
+            block_len,
+            counter,
+            flags,
+        )
+    }
+}
+
+pub mod ffi {
+    unsafe extern "C" {
+        pub fn blake3_hash_many_rvv(
+            inputs: *const *const u8,
+            num_inputs: usize,
+            blocks: usize,
+            key: *const u32,
+            counter: u64,
+            increment_counter: bool,
+            flags: u8,
+            flags_start: u8,
+            flags_end: u8,
+            out: *mut u8,
+        );
+        pub fn blake3_rvv_simd_degree() -> usize;
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_hash_many() {
+        // This entire file is gated on feature="rvv", so RVV support is
+        // assumed here.
+        crate::test::test_hash_many_fn(hash_many, hash_many);
+    }
+}

--- a/src/ffi_rvv.rs
+++ b/src/ffi_rvv.rs
@@ -1,6 +1,6 @@
 use crate::{CVWords, IncrementCounter, BLOCK_LEN, OUT_LEN};
 
-// Unsafe because this may only be called on platforms supporting RVV.
+// Unsafe because this may only be called after runtime detection confirms RVV support.
 pub unsafe fn hash_many<const N: usize>(
     inputs: &[&[u8; N]],
     key: &CVWords,
@@ -31,10 +31,6 @@ pub unsafe fn hash_many<const N: usize>(
     }
 }
 
-// blake3_rvv.c normally depends on blake3_portable.c, because the RVV
-// implementation only provides 4x compression, and it relies on the portable
-// implementation for 1x compression. However, we expose the portable Rust
-// implementation here instead, to avoid linking in unnecessary code.
 #[unsafe(no_mangle)]
 pub extern "C" fn blake3_compress_in_place_portable(
     cv: *mut u32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,6 +115,9 @@ mod avx512;
 #[path = "ffi_neon.rs"]
 mod neon;
 mod portable;
+#[cfg(blake3_rvv)]
+#[path = "ffi_rvv.rs"]
+mod rvv;
 #[cfg(blake3_sse2_rust)]
 #[path = "rust_sse2.rs"]
 mod sse2;

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -106,11 +106,13 @@ impl Platform {
         {
             return Platform::NEON;
         }
-        // We don't use dynamic feature detection for RVV. If the "rvv"
-        // feature is on, RVV is assumed to be supported.
+        // Runtime detection for RVV. The V extension may or may not be present
+        // on the current hardware, even though the binary includes RVV code.
         #[cfg(blake3_rvv)]
         {
-            return Platform::RVV;
+            if rvv_detected() {
+                return Platform::RVV;
+            }
         }
         #[cfg(blake3_wasm32_simd)]
         {
@@ -438,6 +440,15 @@ impl Platform {
         Some(Self::NEON)
     }
 
+    #[cfg(blake3_rvv)]
+    pub fn rvv() -> Option<Self> {
+        if rvv_detected() {
+            Some(Self::RVV)
+        } else {
+            None
+        }
+    }
+
     #[cfg(blake3_wasm32_simd)]
     pub fn wasm32_simd() -> Option<Self> {
         // Assumed to be safe if the "wasm32_simd" feature is on.
@@ -510,6 +521,76 @@ pub fn sse2_detected() -> bool {
 
     cpufeatures::new!(has_sse2, "sse2");
     has_sse2::get()
+}
+
+// Detect RVV support at runtime. The detection method depends on the target OS:
+// - Linux: getauxval(AT_HWCAP) checks the 'V' bit
+// - FreeBSD: elf_aux_info(AT_HWCAP) checks the 'V' bit
+// - Other (bare-metal, unknown OS): returns false; use --features=rvv to override
+#[cfg(blake3_rvv)]
+#[inline(always)]
+pub fn rvv_detected() -> bool {
+    if cfg!(miri) {
+        return false;
+    }
+
+    // A testing-only short-circuit.
+    if cfg!(feature = "no_rvv") {
+        return false;
+    }
+
+    // The "rvv" Cargo feature means "assume RVV is available, skip detection".
+    // This is useful when the user knows their hardware supports V.
+    if cfg!(feature = "rvv") {
+        return true;
+    }
+
+    rvv_detected_impl()
+}
+
+#[cfg(blake3_rvv)]
+#[cfg(target_os = "linux")]
+fn rvv_detected_impl() -> bool {
+    // RISC-V HWCAP bit for V extension (bit 21, corresponding to letter 'V')
+    const COMPAT_HWCAP_ISA_V: u64 = 1 << (b'V' - b'A');
+    const AT_HWCAP: u64 = 16;
+
+    unsafe extern "C" {
+        fn getauxval(type_: u64) -> u64;
+    }
+
+    let hwcap = unsafe { getauxval(AT_HWCAP) };
+    (hwcap & COMPAT_HWCAP_ISA_V) != 0
+}
+
+#[cfg(blake3_rvv)]
+#[cfg(target_os = "freebsd")]
+fn rvv_detected_impl() -> bool {
+    const COMPAT_HWCAP_ISA_V: u64 = 1 << (b'V' - b'A');
+    const AT_HWCAP: i32 = 16;
+
+    unsafe extern "C" {
+        fn elf_aux_info(aux: i32, buf: *mut core::ffi::c_void, buf_len: i32) -> i32;
+    }
+
+    let mut hwcap: u64 = 0;
+    let ret = unsafe {
+        elf_aux_info(
+            AT_HWCAP,
+            &mut hwcap as *mut _ as *mut core::ffi::c_void,
+            core::mem::size_of::<u64>() as i32,
+        )
+    };
+    ret == 0 && (hwcap & COMPAT_HWCAP_ISA_V) != 0
+}
+
+// For bare-metal or unknown OS: no safe way to detect V extension at runtime.
+// Reading misa requires M-mode; doing so from S/U-mode is an illegal instruction.
+// Use --features=rvv to force-enable when you know the hardware supports it.
+#[cfg(blake3_rvv)]
+#[cfg(not(any(target_os = "linux", target_os = "freebsd")))]
+fn rvv_detected_impl() -> bool {
+    false
 }
 
 #[inline(always)]

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -12,6 +12,16 @@ cfg_if::cfg_if! {
         }
     } else if #[cfg(blake3_neon)] {
         pub const MAX_SIMD_DEGREE: usize = 4;
+    } else if #[cfg(blake3_rvv)] {
+        // RVV is a variable-length vector architecture. The actual degree depends
+        // on VLEN (vector register length in bits):
+        // - VLEN=128: degree=4 (minimum required by spec)
+        // - VLEN=256: degree=8 (common in current implementations)
+        // - VLEN=512: degree=16 (high-performance implementations)
+        // - VLEN=1024+: degree=32+ (future implementations)
+        // We use 16 as the upper bound, when future hardwares with degree > 8 released
+        // alter this constant
+        pub const MAX_SIMD_DEGREE: usize = 16;
     } else if #[cfg(blake3_wasm32_simd)] {
         pub const MAX_SIMD_DEGREE: usize = 4;
     } else {
@@ -34,6 +44,8 @@ cfg_if::cfg_if! {
         }
     } else if #[cfg(blake3_neon)] {
         pub const MAX_SIMD_DEGREE_OR_2: usize = 4;
+    } else if #[cfg(blake3_rvv)] {
+        pub const MAX_SIMD_DEGREE_OR_2: usize = 16;
     } else if #[cfg(blake3_wasm32_simd)] {
         pub const MAX_SIMD_DEGREE_OR_2: usize = 4;
     } else {
@@ -55,6 +67,8 @@ pub enum Platform {
     AVX512,
     #[cfg(blake3_neon)]
     NEON,
+    #[cfg(blake3_rvv)]
+    RVV,
     #[cfg(blake3_wasm32_simd)]
     #[allow(non_camel_case_types)]
     WASM32_SIMD,
@@ -92,6 +106,12 @@ impl Platform {
         {
             return Platform::NEON;
         }
+        // We don't use dynamic feature detection for RVV. If the "rvv"
+        // feature is on, RVV is assumed to be supported.
+        #[cfg(blake3_rvv)]
+        {
+            return Platform::RVV;
+        }
         #[cfg(blake3_wasm32_simd)]
         {
             return Platform::WASM32_SIMD;
@@ -113,6 +133,8 @@ impl Platform {
             Platform::AVX512 => 16,
             #[cfg(blake3_neon)]
             Platform::NEON => 4,
+            #[cfg(blake3_rvv)]
+            Platform::RVV => unsafe { crate::rvv::ffi::blake3_rvv_simd_degree() },
             #[cfg(blake3_wasm32_simd)]
             Platform::WASM32_SIMD => 4,
         };
@@ -149,6 +171,9 @@ impl Platform {
             // No NEON compress_in_place() implementation yet.
             #[cfg(blake3_neon)]
             Platform::NEON => portable::compress_in_place(cv, block, block_len, counter, flags),
+            // No RVV compress_in_place() implementation yet.
+            #[cfg(blake3_rvv)]
+            Platform::RVV => portable::compress_in_place(cv, block, block_len, counter, flags),
             #[cfg(blake3_wasm32_simd)]
             Platform::WASM32_SIMD => {
                 crate::wasm32_simd::compress_in_place(cv, block, block_len, counter, flags)
@@ -185,6 +210,9 @@ impl Platform {
             // No NEON compress_xof() implementation yet.
             #[cfg(blake3_neon)]
             Platform::NEON => portable::compress_xof(cv, block, block_len, counter, flags),
+            // No RVV compress_xof() implementation yet.
+            #[cfg(blake3_rvv)]
+            Platform::RVV => portable::compress_xof(cv, block, block_len, counter, flags),
             #[cfg(blake3_wasm32_simd)]
             Platform::WASM32_SIMD => {
                 crate::wasm32_simd::compress_xof(cv, block, block_len, counter, flags)
@@ -285,6 +313,20 @@ impl Platform {
             #[cfg(blake3_neon)]
             Platform::NEON => unsafe {
                 crate::neon::hash_many(
+                    inputs,
+                    key,
+                    counter,
+                    increment_counter,
+                    flags,
+                    flags_start,
+                    flags_end,
+                    out,
+                )
+            },
+            // Assumed to be safe if the "rvv" feature is on.
+            #[cfg(blake3_rvv)]
+            Platform::RVV => unsafe {
+                crate::rvv::hash_many(
                     inputs,
                     key,
                     counter,

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -16,12 +16,12 @@ cfg_if::cfg_if! {
         // RVV is a variable-length vector architecture. The actual degree depends
         // on VLEN (vector register length in bits):
         // - VLEN=128: degree=4 (minimum required by spec)
-        // - VLEN=256: degree=8 (common in current implementations)
-        // - VLEN=512: degree=16 (high-performance implementations)
-        // - VLEN=1024+: degree=32+ (future implementations)
-        // We use 16 as the upper bound, when future hardwares with degree > 8 released
-        // alter this constant
-        pub const MAX_SIMD_DEGREE: usize = 16;
+        // - VLEN=256: degree=8
+        // - VLEN=512: degree=16
+        // - VLEN=1024: degree=32
+        // - VLEN=2048: degree=64 (maximum allowed by spec)
+        // We use 64 as the upper bound to cover all possible implementations.
+        pub const MAX_SIMD_DEGREE: usize = 64;
     } else if #[cfg(blake3_wasm32_simd)] {
         pub const MAX_SIMD_DEGREE: usize = 4;
     } else {
@@ -45,7 +45,7 @@ cfg_if::cfg_if! {
     } else if #[cfg(blake3_neon)] {
         pub const MAX_SIMD_DEGREE_OR_2: usize = 4;
     } else if #[cfg(blake3_rvv)] {
-        pub const MAX_SIMD_DEGREE_OR_2: usize = 16;
+        pub const MAX_SIMD_DEGREE_OR_2: usize = 64;
     } else if #[cfg(blake3_wasm32_simd)] {
         pub const MAX_SIMD_DEGREE_OR_2: usize = 4;
     } else {


### PR DESCRIPTION
Add support for RISC-V V extension backend.

The RVV-specific code is implemented with reference to the earlier ARM NEON version. It is mainly implemented in C since Rust RVV intrinsic hasn't been fully implemented yet. It may look weird when finding out all vectorized variables are defined separately instead of being defined as a 16-size array. That was because in RVV, `vuint32m1_t`s are sizeless types while in ARM NEON `uint32x4_t`s are 16-byte values and arrays are not allowed to be constructed with sizeless types.

RVV defines a variable-length vector register (VLEN is implementation-defined, not fixed by the ISA). This implementation adapts to the hardware's actual VLEN at runtime by querying vsetvlmax to determine the SIMD degree, rather than hardcoding a fixed lane count.

The current `MAX_SIMD_DEGREE` is set to 16, which covers VLEN up to 512-bit. If future hardware supports VLEN > 512, users will need to patch `MAX_SIMD_DEGREE` in `blake3_impl.h` (C side) and `platform.rs` (Rust side) accordingly and recompile.

The following tests are conducted on SG2044 SoC(with 64 T-HEAD C920 cores). The RVV speedup decreases as thread count grows (2.36x single-threaded → 1.55x at 64 threads), as threading overhead and memory bandwidth contention increasingly dominate over per-core compute gains.
| Threads | Size | Portable | Portable Thru | RVV | RVV Thru | Speedup |
|---------|------|----------|---------------|-----|----------|---------|
| 1 | 10M | 65 ms | 0.15 GB/s | 30 ms | 0.32 GB/s | 2.16x |
| 1 | 64M | 385 ms | 0.16 GB/s | 166 ms | 0.37 GB/s | 2.31x |
| 1 | 256M | 1520 ms | 0.16 GB/s | 647 ms | 0.38 GB/s | 2.35x |
| 1 | 1G | 6070 ms | 0.16 GB/s | 2570 ms | 0.38 GB/s | 2.36x |
| 4 | 256M | 395 ms | 0.63 GB/s | 180 ms | 1.38 GB/s | 2.19x |
| 4 | 1G | 1560 ms | 0.63 GB/s | 701 ms | 1.42 GB/s | 2.23x |
| 4 | 4G | 6270 ms | 0.63 GB/s | 2780 ms | 1.43 GB/s | 2.24x |
| 8 | 256M | 210 ms | 1.19 GB/s | 102 ms | 2.45 GB/s | 2.05x |
| 8 | 1G | 819 ms | 1.22 GB/s | 389 ms | 2.57 GB/s | 2.10x |
| 8 | 4G | 3240 ms | 1.23 GB/s | 1520 ms | 2.62 GB/s | 2.12x |
| 16 | 256M | 117 ms | 2.13 GB/s | 63 ms | 3.96 GB/s | 1.85x |
| 16 | 1G | 443 ms | 2.25 GB/s | 228 ms | 4.38 GB/s | 1.94x |
| 16 | 4G | 1720 ms | 2.31 GB/s | 875 ms | 4.57 GB/s | 1.97x |
| 32 | 256M | 74 ms | 3.37 GB/s | 46 ms | 5.43 GB/s | 1.60x |
| 32 | 1G | 257 ms | 3.89 GB/s | 150 ms | 6.66 GB/s | 1.71x |
| 32 | 4G | 974 ms | 4.10 GB/s | 545 ms | 7.33 GB/s | 1.78x |
| 64 | 256M | 59 ms | 4.23 GB/s | 46 ms | 5.43 GB/s | 1.28x |
| 64 | 1G | 179 ms | 5.58 GB/s | 119 ms | 8.40 GB/s | 1.50x |
| 64 | 4G | 619 ms | 6.46 GB/s | 398 ms | 10.05 GB/s | 1.55x |

<img width="2498" height="1019" alt="image" src="https://github.com/user-attachments/assets/ee52c911-c9fc-4600-8811-00ca22d9a881" />
