### PR TITLE
Add an optional `bytemuck` feature to implement `Pod` for `Hash`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,16 +42,16 @@ jobs:
       run: cargo run --quiet
       working-directory: ./tools/instruction_set_support
     # Default tests plus Rayon and trait implementations.
-    - run: cargo test --features=rayon,traits-preview,serde,zeroize
+    - run: cargo test --features=rayon,traits-preview,bytemuck,serde,zeroize
     # Same but with only one thread in the Rayon pool. This can find deadlocks.
     - name: "again with RAYON_NUM_THREADS=1"
-      run: cargo test --features=rayon,traits-preview,serde,zeroize
+      run: cargo test --features=rayon,traits-preview,bytemuck,serde,zeroize
       env:
         RAYON_NUM_THREADS: 1
     # The mmap feature by itself (update_mmap_rayon is omitted).
     - run: cargo test --features=mmap
     # All public features put together.
-    - run: cargo test --features=mmap,rayon,traits-preview,serde,zeroize
+    - run: cargo test --features=mmap,rayon,traits-preview,bytemuck,serde,zeroize
     # no_std tests.
     - run: cargo test --no-default-features
     - name: Make sure enabling LTO via CFLAGS doesn't break the build.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,9 @@ mmap = ["std", "dep:memmap2"]
 # Implement the zeroize::Zeroize trait for types in this crate.
 zeroize = ["dep:zeroize", "arrayvec/zeroize"]
 
+# Implement the `bytemuck::Pod` trait for the `blake3::Hash` type.
+bytemuck = ["dep:bytemuck"]
+
 # This crate implements traits from the RustCrypto project, exposed here as the
 # "traits-preview" feature. However, these traits aren't stable, and they're
 # expected to change in incompatible ways before they reach 1.0. For that
@@ -121,6 +124,7 @@ memmap2 = { version = "0.9", optional = true }
 rayon-core = { version = "1.12.1", optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 zeroize = { version = "1", default-features = false, optional = true }
+bytemuck = { version = "1.25.0", features = ["derive"], optional = true }
 
 [target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]
 cpufeatures = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ memmap2 = { version = "0.9", optional = true }
 rayon-core = { version = "1.12.1", optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 zeroize = { version = "1", default-features = false, optional = true }
-bytemuck = { version = "1.25.0", features = ["derive"], optional = true }
+bytemuck = { version = "1.25.0", features = ["derive", "must_cast"], optional = true }
 
 [target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]
 cpufeatures = "0.3.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,7 +236,9 @@ fn counter_high(counter: u64) -> u32 {
 /// [`Display`]: https://doc.rust-lang.org/std/fmt/trait.Display.html
 /// [`FromStr`]: https://doc.rust-lang.org/std/str/trait.FromStr.html
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
 #[derive(Clone, Copy, Hash, Eq)]
+#[repr(transparent)]
 pub struct Hash([u8; OUT_LEN]);
 
 impl Hash {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -255,6 +255,12 @@ impl Hash {
         Self(bytes)
     }
 
+    /// Create a references to a `Hash` from a reference to its raw bytes representation.
+    #[cfg(feature = "bytemuck")]
+    pub const fn from_bytes_ref(bytes: &[u8; OUT_LEN]) -> &Self {
+        bytemuck::must_cast_ref(bytes)
+    }
+
     /// The raw bytes of the `Hash`, as a slice. Useful for serialization. Note that byte arrays
     /// don't provide constant-time equality checking, so if you need to compare hashes, prefer
     /// the `Hash` type.


### PR DESCRIPTION
This allows, for instance, taking a `Vec<blake3::Hash>` and turning it
into a slice of bytes, in order to pass it to `Write` without making a
copy.
