### PR TITLE
Add  `rand` feature that implements RNG traits for `OutputReader`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,9 @@ mmap = ["std", "dep:memmap2"]
 # Implement the zeroize::Zeroize trait for types in this crate.
 zeroize = ["dep:zeroize", "arrayvec/zeroize"]
 
+# Implement the rand::TryRng trait for OutputReader.
+rand = ["dep:rand"]
+
 # This crate implements traits from the RustCrypto project, exposed here as the
 # "traits-preview" feature. However, these traits aren't stable, and they're
 # expected to change in incompatible ways before they reach 1.0. For that
@@ -121,6 +124,7 @@ memmap2 = { version = "0.9", optional = true }
 rayon-core = { version = "1.12.1", optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 zeroize = { version = "1", default-features = false, optional = true }
+rand = { version = "0.10.0", default-features = false, optional = true }
 
 [target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]
 cpufeatures = "0.3.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1866,3 +1866,24 @@ impl rand::TryRng for OutputReader {
 
 #[cfg(feature = "rand")]
 impl rand::TryCryptoRng for OutputReader {}
+
+#[cfg(feature = "rand")]
+impl rand::rand_core::block::Generator for OutputReader {
+    type Output = [u32; BLOCK_LEN / 4];
+
+    fn generate(&mut self, output: &mut Self::Output) {
+        let mut buf = [0u8; BLOCK_LEN];
+        self.fill(&mut buf);
+
+        // SAFETY: buf.len() is nonzero and exactly divides the slice length
+        let chunks = unsafe { buf.as_chunks_unchecked::<4>() };
+        for (out, chunk) in output.iter_mut().zip(chunks) {
+            *out = u32::from_le_bytes(*chunk);
+        }
+    }
+
+    #[cfg(feature = "zeroize")]
+    fn drop(&mut self, output: &mut Self::Output) {
+        output.zeroize();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,6 +143,8 @@ use arrayvec::{ArrayString, ArrayVec};
 use core::cmp;
 use core::fmt;
 use platform::{MAX_SIMD_DEGREE, MAX_SIMD_DEGREE_OR_2, Platform};
+#[cfg(feature = "rand")]
+use std::convert::Infallible;
 #[cfg(feature = "zeroize")]
 use zeroize::Zeroize;
 
@@ -1837,5 +1839,27 @@ impl Zeroize for OutputReader {
 
         inner.zeroize();
         position_within_block.zeroize();
+    }
+}
+
+#[cfg(feature = "rand")]
+impl rand::TryRng for OutputReader {
+    type Error = Infallible;
+
+    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+        let mut buf = [0u8; 4];
+        self.fill(&mut buf);
+        Ok(u32::from_le_bytes(buf))
+    }
+
+    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+        let mut buf = [0u8; 8];
+        self.fill(&mut buf);
+        Ok(u64::from_le_bytes(buf))
+    }
+
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Self::Error> {
+        self.fill(dest);
+        Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1875,8 +1875,8 @@ impl rand::rand_core::block::Generator for OutputReader {
         let mut buf = [0u8; BLOCK_LEN];
         self.fill(&mut buf);
 
-        // SAFETY: buf.len() is nonzero and exactly divides the slice length
-        let chunks = unsafe { buf.as_chunks_unchecked::<4>() };
+        let (chunks, tail) = buf.as_chunks::<4>();
+        assert!(tail.is_empty());
         for (out, chunk) in output.iter_mut().zip(chunks) {
             *out = u32::from_le_bytes(*chunk);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1863,3 +1863,6 @@ impl rand::TryRng for OutputReader {
         Ok(())
     }
 }
+
+#[cfg(feature = "rand")]
+impl rand::TryCryptoRng for OutputReader {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1875,8 +1875,8 @@ impl rand::rand_core::block::Generator for OutputReader {
         let mut buf = [0u8; BLOCK_LEN];
         self.fill(&mut buf);
 
-        let (chunks, tail) = buf.as_chunks::<4>();
-        assert!(tail.is_empty());
+        const _: () = assert!(BLOCK_LEN.is_multiple_of(4));
+        let (chunks, _) = buf.as_chunks::<4>();
         for (out, chunk) in output.iter_mut().zip(chunks) {
             *out = u32::from_le_bytes(*chunk);
         }


### PR DESCRIPTION
## Summary

This PR adds an optional `rand` feature that implements following traits for `blake3::OutputReader`:
- `rand::TryRng`
- `rand::TryCryptoRng`
- `rand::rand_core::block::Generator`

Implementing this I tried to follow the pattern of the existing optional `zeroize` feature.

## Motivation

I believe it would be natural for `OutputReader` to implement the `rand` traits so it can be used directly as a random number generator after `finalize_xof()`.

Example usage:
```rs
use blake3::Hasher;
use rand::{Rng, RngExt};

let mut hasher = Hasher::new();
hasher.update(b"seed data");
let mut reader = hasher.finalize_xof();

let my_num = reader.next_u64();
let my_range = reader.random_range(1..100);
```

This change is a minimal interop for these crates. While the separate `rand_blake3` crate exists, it appears to be orphaned (no updates since late 2023, and the Git repository is deleted) and implements more than just the core traits on `OutputReader`. Therefore I propose a very small, focused implementation, so that it's not a hassle to have in there.
