### PR TITLE
b3sum: add system libblake3 backend

### DIFF
--- a/b3sum/Cargo.lock
+++ b/b3sum/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -76,6 +85,7 @@ version = "1.8.5"
 dependencies = [
  "anyhow",
  "blake3",
+ "blake3_c_rust_bindings",
  "clap",
  "duct",
  "hex",
@@ -102,6 +112,24 @@ dependencies = [
  "cpufeatures",
  "memmap2",
  "rayon-core",
+]
+
+[[package]]
+name = "blake3_c_rust_bindings"
+version = "0.0.0"
+dependencies = [
+ "cc",
+ "ignore",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
+dependencies = [
+ "memchr",
+ "serde_core",
 ]
 
 [[package]]
@@ -273,6 +301,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -304,6 +345,22 @@ name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "ignore"
+version = "0.4.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b915661dd01db3f05050265b2477bcc6527b3792388e2749b41623cc592be67d"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
 
 [[package]]
 name = "indexmap"
@@ -435,6 +492,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,6 +519,15 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -608,6 +691,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -666,6 +759,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3131afc8c575281e1e80f36ed6a092aa502c08b18ed7524e86fbbb12bb410e1"
 dependencies = [
  "glob",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/b3sum/Cargo.toml
+++ b/b3sum/Cargo.toml
@@ -9,13 +9,15 @@ readme = "README.md"
 edition = "2024"
 
 [features]
-neon = ["blake3/neon"]
-prefer_intrinsics = ["blake3/prefer_intrinsics"]
+system = ["dep:blake3_c_rust_bindings", "blake3_c_rust_bindings/system"]
+neon = ["blake3/neon", "blake3_c_rust_bindings?/neon"]
+prefer_intrinsics = ["blake3/prefer_intrinsics", "blake3_c_rust_bindings?/prefer_intrinsics"]
 pure = ["blake3/pure"]
 
 [dependencies]
 anyhow = "1.0.25"
 blake3 = { version = "1.8", path = "..", features = ["mmap", "rayon"] }
+blake3_c_rust_bindings = { path = "../c/blake3_c_rust_bindings", default-features = false, optional = true }
 clap = { version = "4.0.8", features = ["derive", "wrap_help"] }
 hex = "0.4.0"
 rayon-core = "1.12.1"

--- a/b3sum/src/main.rs
+++ b/b3sum/src/main.rs
@@ -19,6 +19,39 @@ const RAW_ARG: &str = "raw";
 const TAG_ARG: &str = "tag";
 const CHECK_ARG: &str = "check";
 
+#[cfg(feature = "system")]
+use blake3_c_rust_bindings as blake3;
+
+#[cfg(not(feature = "system"))]
+type OutputReader = blake3::OutputReader;
+
+#[cfg(feature = "system")]
+#[derive(Clone)]
+struct OutputReader {
+    hasher: blake3::Hasher,
+    position: u64,
+}
+
+#[cfg(feature = "system")]
+impl OutputReader {
+    fn new(hasher: blake3::Hasher, position: u64) -> Self {
+        Self { hasher, position }
+    }
+
+    fn fill(&mut self, buf: &mut [u8]) {
+        self.hasher.finalize_seek(self.position, buf);
+        self.position = self.position.wrapping_add(buf.len() as u64);
+    }
+}
+
+#[cfg(feature = "system")]
+impl Read for OutputReader {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.fill(buf);
+        Ok(buf.len())
+    }
+}
+
 #[derive(Parser)]
 #[command(version, max_term_width(100))]
 struct Inner {
@@ -121,7 +154,7 @@ impl Args {
             // `-` arguments. Input::open handles that case below.
             blake3::Hasher::new_keyed(&read_key_from_stdin()?)
         } else if let Some(ref context) = inner.derive_key {
-            blake3::Hasher::new_derive_key(context)
+            new_derive_key(context)
         } else {
             blake3::Hasher::new()
         };
@@ -173,25 +206,72 @@ impl Args {
     }
 }
 
-fn hash_path(args: &Args, path: &Path) -> anyhow::Result<blake3::OutputReader> {
+#[cfg(not(feature = "system"))]
+fn new_derive_key(context: &str) -> blake3::Hasher {
+    blake3::Hasher::new_derive_key(context)
+}
+
+#[cfg(feature = "system")]
+fn new_derive_key(context: &str) -> blake3::Hasher {
+    blake3::Hasher::new_derive_key_raw(context.as_bytes())
+}
+
+#[cfg(not(feature = "system"))]
+fn update_reader(
+    hasher: &mut blake3::Hasher,
+    reader: impl Read,
+) -> io::Result<()> {
+    hasher.update_reader(reader)?;
+    Ok(())
+}
+
+#[cfg(feature = "system")]
+fn update_reader(
+    hasher: &mut blake3::Hasher,
+    mut reader: impl Read,
+) -> io::Result<()> {
+    // Match the buffer size used by the root crate's update_reader helper.
+    let mut buffer = [0; 65536];
+    loop {
+        match reader.read(&mut buffer) {
+            Ok(0) => return Ok(()),
+            Ok(n) => {
+                hasher.update(&buffer[..n]);
+            }
+            Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
+            Err(e) => return Err(e),
+        }
+    }
+}
+
+fn hash_path(args: &Args, path: &Path) -> anyhow::Result<OutputReader> {
     let mut hasher = args.base_hasher.clone();
     if path == Path::new("-") {
         if args.keyed() {
             bail!("Cannot open `-` in keyed mode");
         }
-        hasher.update_reader(io::stdin().lock())?;
+        update_reader(&mut hasher, io::stdin().lock())?;
     } else if args.no_mmap() {
-        hasher.update_reader(File::open(path)?)?;
+        update_reader(&mut hasher, File::open(path)?)?;
     } else {
-        // The fast path: Try to mmap the file and hash it with multiple threads.
+        #[cfg(not(feature = "system"))]
         hasher.update_mmap_rayon(path)?;
+        #[cfg(feature = "system")]
+        update_reader(&mut hasher, File::open(path)?)?;
     }
-    let mut output_reader = hasher.finalize_xof();
-    output_reader.set_position(args.seek());
-    Ok(output_reader)
+    #[cfg(not(feature = "system"))]
+    {
+        let mut output_reader = hasher.finalize_xof();
+        output_reader.set_position(args.seek());
+        Ok(output_reader)
+    }
+    #[cfg(feature = "system")]
+    {
+        Ok(OutputReader::new(hasher, args.seek()))
+    }
 }
 
-fn write_hex_output(mut output: blake3::OutputReader, args: &Args) -> anyhow::Result<()> {
+fn write_hex_output(mut output: OutputReader, args: &Args) -> anyhow::Result<()> {
     // Encoding multiples of the 64 bytes is most efficient.
     // TODO: This computes each output block twice when the --seek argument isn't a multiple of 64.
     // We'll refactor all of this soon anyway, once SIMD optimizations are available for the XOF.
@@ -207,7 +287,7 @@ fn write_hex_output(mut output: blake3::OutputReader, args: &Args) -> anyhow::Re
     Ok(())
 }
 
-fn write_raw_output(output: blake3::OutputReader, args: &Args) -> anyhow::Result<()> {
+fn write_raw_output(output: OutputReader, args: &Args) -> anyhow::Result<()> {
     let mut output = output.take(args.len());
     let stdout = std::io::stdout();
     let mut handler = stdout.lock();

--- a/c/blake3_c_rust_bindings/Cargo.toml
+++ b/c/blake3_c_rust_bindings/Cargo.toml
@@ -10,6 +10,7 @@ description = "TESTING ONLY Rust bindings for the BLAKE3 C implementation"
 edition = "2024"
 
 [features]
+system = []
 # By default the x86-64 build uses assembly implementations. This feature makes
 # the build use the C intrinsics implementations instead.
 prefer_intrinsics = []

--- a/c/blake3_c_rust_bindings/build.rs
+++ b/c/blake3_c_rust_bindings/build.rs
@@ -1,4 +1,5 @@
 use std::env;
+use std::process::Command;
 
 fn defined(var: &str) -> bool {
     env::var_os(var).is_some()
@@ -102,7 +103,33 @@ fn c_dir_path(filename: &str) -> String {
     }
 }
 
+fn pkg_config(args: &[&str]) -> Option<String> {
+    let pkg_config = env::var_os("PKG_CONFIG").unwrap_or_else(|| "pkg-config".into());
+    let output = Command::new(pkg_config).args(args).output().ok()?;
+    if output.status.success() {
+        Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    } else {
+        None
+    }
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    if defined("CARGO_FEATURE_SYSTEM") {
+        println!("cargo::rerun-if-env-changed=PKG_CONFIG");
+        println!("cargo::rerun-if-env-changed=PKG_CONFIG_PATH");
+        println!("cargo::rerun-if-env-changed=PKG_CONFIG_LIBDIR");
+        println!("cargo::rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR");
+
+        if let Some(libdir) = pkg_config(&["--variable=libdir", "libblake3"]) {
+            if !libdir.is_empty() {
+                println!("cargo::rustc-link-search=native={libdir}");
+                println!("cargo::rustc-link-lib=blake3");
+                return Ok(());
+            }
+        }
+        return Err("pkg-config libblake3 lookup failed".into());
+    }
+
     let mut base_build = new_build();
     base_build.file(c_dir_path("blake3.c"));
     base_build.file(c_dir_path("blake3_dispatch.c"));

--- a/c/blake3_c_rust_bindings/src/lib.rs
+++ b/c/blake3_c_rust_bindings/src/lib.rs
@@ -11,7 +11,10 @@ mod test;
 
 pub const BLOCK_LEN: usize = 64;
 pub const CHUNK_LEN: usize = 1024;
+// The C header exposes the keyed API as a 32-byte key, but not a named constant.
+pub const KEY_LEN: usize = 32;
 pub const OUT_LEN: usize = 32;
+pub type Hash = [u8; OUT_LEN];
 
 // Feature detection functions for tests and benchmarks. Note that the C code
 // does its own feature detection in blake3_dispatch.c.


### PR DESCRIPTION
Many distributions ship libblake3.so as a separate installed package, see: https://repology.org/project/blake3/versions , so allow b3sum to link against that library with the system feature, rather than always relying on an embedded C build.

The default Rust backend remains unchanged.

With the system feature enabled, b3sum uses the C bindings as its Rust side API surface, while the bindings build script asks pkg-config for libblake3 and links the installed library instead of compiling the bundled C sources.