### PR TITLE
Add an SVE2 backend for AArch64 that fuses xor+rotate with XAR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,22 @@ jobs:
     - name: cargo test C bindings intrinsics
       run: cargo test --features=prefer_intrinsics
       working-directory: ./c/blake3_c_rust_bindings
+    # SVE2 is AArch64-only and needs its own -march flags, so this is restricted to
+    # the arm64 runner. GitHub's Arm-hosted runners are Neoverse N2 with a 128-bit
+    # vector length, so the backend is reached rather than falling back to NEON.
+    - name: cargo test C bindings SVE2
+      if: matrix.target.os == 'ubuntu-24.04-arm'
+      run: cargo test --features=sve2
+      working-directory: ./c/blake3_c_rust_bindings
+    # BLAKE3_USE_SVE2 has to reach blake3_dispatch.c as well as blake3_sve2.c. If it
+    # only reaches the latter, everything above still passes while the backend is
+    # never called, so check the objects rather than trusting a green run.
+    - name: check that the SVE2 backend is reachable
+      if: matrix.target.os == 'ubuntu-24.04-arm'
+      working-directory: ./c/blake3_c_rust_bindings
+      run: |
+        objdump -d $(find target -name '*blake3_sve2.o') | grep -q '\bxar\b'
+        objdump -d $(find target -name '*blake3_dispatch.o') | grep -q 'bl.*<getauxval'
     - name: cargo test C bindings no AVX-512
       run: cargo test
       working-directory: ./c/blake3_c_rust_bindings
@@ -271,6 +287,7 @@ jobs:
     - run: docker run -v $(pwd):/io -w /io messense/cargo-xwin cargo xwin test --target x86_64-pc-windows-msvc --features=mmap,rayon,traits-preview,serde,zeroize
 
   # Currently only on x86.
+
   cmake_c_tests:
     name: CMake C tests SIMD=${{ matrix.simd }} TBB=${{ matrix.use_tbb }}
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,10 @@ jobs:
       working-directory: ./c/blake3_c_rust_bindings
       env:
         CFLAGS: -DBLAKE3_NO_AVX512 -DBLAKE3_NO_AVX2 -DBLAKE3_NO_SSE41 -DBLAKE3_NO_SSE2
+    - name: cargo test C bindings SVE2
+      if: matrix.target.os == 'ubuntu-24.04-arm'
+      run: cargo test --features=sve2
+      working-directory: ./c/blake3_c_rust_bindings
     # Reference impl doc test.
     - name: reference impl doc test
       run: cargo test

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -85,7 +85,14 @@ elseif(CMAKE_C_COMPILER_ID STREQUAL "GNU"
   endif()
 endif()
 
-mark_as_advanced(BLAKE3_CFLAGS_SSE2 BLAKE3_CFLAGS_SSE4.1 BLAKE3_CFLAGS_AVX2 BLAKE3_CFLAGS_AVX512 BLAKE3_CFLAGS_NEON)
+# SVE2 is an opt-in extra on top of the NEON backend: it needs a compiler that
+# understands SVE2 intrinsics, and it is only dispatched to at runtime when the
+# CPU reports HWCAP2_SVE2 with a 128-bit vector length. Off by default so that
+# builds keep working with older toolchains.
+option(BLAKE3_USE_SVE2 "use the SVE2 backend on AArch64 when the CPU supports it" OFF)
+set(BLAKE3_CFLAGS_SVE2 "-march=armv8-a+sve2 -msve-vector-bits=128" CACHE STRING "the compiler flags to enable SVE2")
+
+mark_as_advanced(BLAKE3_CFLAGS_SSE2 BLAKE3_CFLAGS_SSE4.1 BLAKE3_CFLAGS_AVX2 BLAKE3_CFLAGS_AVX512 BLAKE3_CFLAGS_NEON BLAKE3_CFLAGS_SVE2)
 mark_as_advanced(BLAKE3_AMD64_ASM_SOURCES)
 
 message(STATUS "BLAKE3 SIMD configuration: ${CMAKE_C_COMPILER_ARCHITECTURE_ID}")
@@ -210,6 +217,16 @@ elseif(BLAKE3_SIMD_TYPE STREQUAL "neon-intrinsics")
 
   if (DEFINED BLAKE3_CFLAGS_NEON)
     set_source_files_properties(blake3_neon.c PROPERTIES COMPILE_FLAGS "${BLAKE3_CFLAGS_NEON}")
+  endif()
+
+  if (BLAKE3_USE_SVE2)
+    target_sources(blake3 PRIVATE
+      blake3_sve2.c
+    )
+    target_compile_definitions(blake3 PRIVATE
+      BLAKE3_USE_SVE2=1
+    )
+    set_source_files_properties(blake3_sve2.c PROPERTIES COMPILE_FLAGS "${BLAKE3_CFLAGS_SVE2}")
   endif()
 
 elseif(BLAKE3_SIMD_TYPE STREQUAL "none")

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -85,7 +85,12 @@ elseif(CMAKE_C_COMPILER_ID STREQUAL "GNU"
   endif()
 endif()
 
-mark_as_advanced(BLAKE3_CFLAGS_SSE2 BLAKE3_CFLAGS_SSE4.1 BLAKE3_CFLAGS_AVX2 BLAKE3_CFLAGS_AVX512 BLAKE3_CFLAGS_NEON)
+# Needs a compiler with SVE2 intrinsics, so off by default.
+option(BLAKE3_USE_SVE2 "use the SVE2 backend on AArch64 when the CPU supports it" OFF)
+# armv8-a+sve2 rather than armv9-a, which needs GCC 12.
+set(BLAKE3_CFLAGS_SVE2 "-march=armv8-a+sve2 -msve-vector-bits=128" CACHE STRING "the compiler flags to enable SVE2")
+
+mark_as_advanced(BLAKE3_CFLAGS_SSE2 BLAKE3_CFLAGS_SSE4.1 BLAKE3_CFLAGS_AVX2 BLAKE3_CFLAGS_AVX512 BLAKE3_CFLAGS_NEON BLAKE3_CFLAGS_SVE2)
 mark_as_advanced(BLAKE3_AMD64_ASM_SOURCES)
 
 message(STATUS "BLAKE3 SIMD configuration: ${CMAKE_C_COMPILER_ARCHITECTURE_ID}")
@@ -210,6 +215,16 @@ elseif(BLAKE3_SIMD_TYPE STREQUAL "neon-intrinsics")
 
   if (DEFINED BLAKE3_CFLAGS_NEON)
     set_source_files_properties(blake3_neon.c PROPERTIES COMPILE_FLAGS "${BLAKE3_CFLAGS_NEON}")
+  endif()
+
+  if (BLAKE3_USE_SVE2)
+    target_sources(blake3 PRIVATE
+      blake3_sve2.c
+    )
+    target_compile_definitions(blake3 PRIVATE
+      BLAKE3_USE_SVE2=1
+    )
+    set_source_files_properties(blake3_sve2.c PROPERTIES COMPILE_FLAGS "${BLAKE3_CFLAGS_SVE2}")
   endif()
 
 elseif(BLAKE3_SIMD_TYPE STREQUAL "none")

--- a/c/Makefile.testing
+++ b/c/Makefile.testing
@@ -46,6 +46,11 @@ ifdef BLAKE3_NO_NEON
 EXTRAFLAGS += -DBLAKE3_USE_NEON=0
 endif
 
+ifdef BLAKE3_USE_SVE2
+EXTRAFLAGS += -DBLAKE3_USE_SVE2=1
+TARGETS += blake3_sve2.o
+endif
+
 all: blake3.c blake3_dispatch.c blake3_portable.c main.c $(TARGETS)
 	$(CC) $(CFLAGS) $(EXTRAFLAGS) $^ -o $(NAME) $(LDFLAGS)
 
@@ -63,6 +68,9 @@ blake3_avx512.o: blake3_avx512.c
 
 blake3_neon.o: blake3_neon.c
 	$(CC) $(CFLAGS) $(EXTRAFLAGS) -c $^ -o $@
+
+blake3_sve2.o: blake3_sve2.c
+	$(CC) $(CFLAGS) $(EXTRAFLAGS) -c $^ -o $@ -march=armv8-a+sve2 -msve-vector-bits=128
 
 test: CFLAGS += -DBLAKE3_TESTING -fsanitize=address,undefined
 test: all

--- a/c/README.md
+++ b/c/README.md
@@ -353,6 +353,34 @@ gcc -shared -O3 -o libblake3.so -DBLAKE3_USE_NEON=1 blake3.c blake3_dispatch.c \
     blake3_portable.c blake3_neon.c
 ```
 
+On AArch64 CPUs that implement SVE2 (Neoverse V2/V3 and Cortex-X2 and later,
+which covers AWS Graviton4/5, Google Axion, Microsoft Cobalt and NVIDIA Grace),
+an additional backend is available that uses the SVE2 `XAR` instruction to fuse
+each of BLAKE3's xor-then-rotate steps into a single instruction. It is
+opt-in, because it needs a compiler that supports SVE2 intrinsics:
+
+```bash
+gcc -shared -O3 -o libblake3.so -DBLAKE3_USE_NEON=1 -DBLAKE3_USE_SVE2=1 \
+    blake3.c blake3_dispatch.c blake3_portable.c blake3_neon.c \
+    $(: blake3_sve2.c needs its own flags, so compile it separately) &&
+gcc -O3 -DBLAKE3_USE_SVE2=1 -march=armv8-a+sve2 -msve-vector-bits=128 \
+    -c blake3_sve2.c
+```
+
+A binary built this way still runs on AArch64 CPUs without SVE2: the backend is
+selected at runtime and falls back to NEON otherwise. Runtime detection currently
+only works on Linux and Android; on other platforms the SVE2 backend is compiled
+out.
+
+Note that `blake3_sve2.c` is compiled with `-msve-vector-bits=128` so that its
+vectors can be used as array elements, which means it is only valid when the
+hardware vector length is exactly 128 bits. Every SVE2 implementation shipping
+today is 128 bits wide, but the architecture allows up to 2048, so the runtime
+check requires both `HWCAP2_SVE2` and a 128-bit vector length; on a wider machine
+it falls back to NEON rather than misbehaving. A vector-length-agnostic
+implementation that could use wider vectors would need to avoid arrays of
+vectors, and is not attempted here.
+
 To explicitiy disable using NEON instructions on AArch64, set
 `BLAKE3_USE_NEON=0`.
 

--- a/c/README.md
+++ b/c/README.md
@@ -373,6 +373,21 @@ in call to always_inline ‘vaddq_u32’: target specific option mismatch
 ...then you may need to add something like `-mfpu=neon-vfpv4
 -mfloat-abi=hard`.
 
+### ARM SVE2
+
+The SVE2 implementation is off by default, since it needs a compiler with SVE2
+intrinsics. To enable it, set `BLAKE3_USE_SVE2=1`; it is then used at runtime
+when the CPU has SVE2 with a 128-bit vector length, and NEON otherwise. Here's
+an example of building a shared library on AArch64 Linux with SVE2 support,
+where `blake3_sve2.c` needs its own flags:
+
+```bash
+gcc -O3 -DBLAKE3_USE_SVE2=1 -march=armv8-a+sve2 -msve-vector-bits=128 \
+    -c blake3_sve2.c
+gcc -shared -O3 -o libblake3.so -DBLAKE3_USE_NEON=1 -DBLAKE3_USE_SVE2=1 \
+    blake3.c blake3_dispatch.c blake3_portable.c blake3_neon.c blake3_sve2.o
+```
+
 ### Other Platforms
 
 The portable implementation should work on most other architectures. For

--- a/c/blake3_c_rust_bindings/Cargo.toml
+++ b/c/blake3_c_rust_bindings/Cargo.toml
@@ -16,6 +16,10 @@ prefer_intrinsics = []
 # Activate NEON bindings. We don't currently do any CPU feature detection for
 # this. If this Cargo feature is on, the NEON gets used.
 neon = []
+# Activate SVE2 bindings, for benchmarking the SVE2 backend against NEON. Unlike
+# "neon" this does do feature detection, because SVE2 is not universal on
+# AArch64 and the backend additionally requires a 128-bit vector length.
+sve2 = []
 # Enable TBB-based multithreading.
 tbb = []
 

--- a/c/blake3_c_rust_bindings/Cargo.toml
+++ b/c/blake3_c_rust_bindings/Cargo.toml
@@ -16,6 +16,8 @@ prefer_intrinsics = []
 # Activate NEON bindings. We don't currently do any CPU feature detection for
 # this. If this Cargo feature is on, the NEON gets used.
 neon = []
+# Activate SVE2 bindings. Unlike "neon", these do CPU feature detection.
+sve2 = []
 # Enable TBB-based multithreading.
 tbb = []
 

--- a/c/blake3_c_rust_bindings/benches/bench.rs
+++ b/c/blake3_c_rust_bindings/benches/bench.rs
@@ -94,6 +94,7 @@ fn bench_single_compression_sse41(b: &mut Bencher) {
 }
 
 #[bench]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 fn bench_single_compression_avx512(b: &mut Bencher) {
     if !blake3_c_rust_bindings::avx512_detected() {
         return;
@@ -186,6 +187,7 @@ fn bench_many_chunks_avx2(b: &mut Bencher) {
 }
 
 #[bench]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 fn bench_many_chunks_avx512(b: &mut Bencher) {
     if !blake3_c_rust_bindings::avx512_detected() {
         return;
@@ -194,6 +196,19 @@ fn bench_many_chunks_avx512(b: &mut Bencher) {
         b,
         blake3_c_rust_bindings::ffi::x86::blake3_hash_many_avx512,
         16,
+    );
+}
+
+#[bench]
+#[cfg(all(feature = "sve2", target_arch = "aarch64"))]
+fn bench_many_chunks_sve2(b: &mut Bencher) {
+    if !blake3_c_rust_bindings::sve2_detected() {
+        return;
+    }
+    bench_many_chunks_fn(
+        b,
+        blake3_c_rust_bindings::ffi::sve2::blake3_hash_many_sve2,
+        4,
     );
 }
 
@@ -278,6 +293,7 @@ fn bench_many_parents_avx2(b: &mut Bencher) {
 }
 
 #[bench]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 fn bench_many_parents_avx512(b: &mut Bencher) {
     if !blake3_c_rust_bindings::avx512_detected() {
         return;
@@ -286,6 +302,19 @@ fn bench_many_parents_avx512(b: &mut Bencher) {
         b,
         blake3_c_rust_bindings::ffi::x86::blake3_hash_many_avx512,
         16,
+    );
+}
+
+#[bench]
+#[cfg(all(feature = "sve2", target_arch = "aarch64"))]
+fn bench_many_parents_sve2(b: &mut Bencher) {
+    if !blake3_c_rust_bindings::sve2_detected() {
+        return;
+    }
+    bench_many_parents_fn(
+        b,
+        blake3_c_rust_bindings::ffi::sve2::blake3_hash_many_sve2,
+        4,
     );
 }
 

--- a/c/blake3_c_rust_bindings/benches/bench.rs
+++ b/c/blake3_c_rust_bindings/benches/bench.rs
@@ -93,6 +93,7 @@ fn bench_single_compression_sse41(b: &mut Bencher) {
 }
 
 #[bench]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 fn bench_single_compression_avx512(b: &mut Bencher) {
     if !blake3_c_rust_bindings::avx512_detected() {
         return;
@@ -185,6 +186,7 @@ fn bench_many_chunks_avx2(b: &mut Bencher) {
 }
 
 #[bench]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 fn bench_many_chunks_avx512(b: &mut Bencher) {
     if !blake3_c_rust_bindings::avx512_detected() {
         return;
@@ -193,6 +195,19 @@ fn bench_many_chunks_avx512(b: &mut Bencher) {
         b,
         blake3_c_rust_bindings::ffi::x86::blake3_hash_many_avx512,
         16,
+    );
+}
+
+#[bench]
+#[cfg(all(feature = "sve2", target_arch = "aarch64"))]
+fn bench_many_chunks_sve2(b: &mut Bencher) {
+    if !blake3_c_rust_bindings::sve2_detected() {
+        return;
+    }
+    bench_many_chunks_fn(
+        b,
+        blake3_c_rust_bindings::ffi::sve2::blake3_hash_many_sve2,
+        4,
     );
 }
 
@@ -277,6 +292,7 @@ fn bench_many_parents_avx2(b: &mut Bencher) {
 }
 
 #[bench]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 fn bench_many_parents_avx512(b: &mut Bencher) {
     if !blake3_c_rust_bindings::avx512_detected() {
         return;
@@ -285,6 +301,19 @@ fn bench_many_parents_avx512(b: &mut Bencher) {
         b,
         blake3_c_rust_bindings::ffi::x86::blake3_hash_many_avx512,
         16,
+    );
+}
+
+#[bench]
+#[cfg(all(feature = "sve2", target_arch = "aarch64"))]
+fn bench_many_parents_sve2(b: &mut Bencher) {
+    if !blake3_c_rust_bindings::sve2_detected() {
+        return;
+    }
+    bench_many_parents_fn(
+        b,
+        blake3_c_rust_bindings::ffi::sve2::blake3_hash_many_sve2,
+        4,
     );
 }
 

--- a/c/blake3_c_rust_bindings/build.rs
+++ b/c/blake3_c_rust_bindings/build.rs
@@ -53,6 +53,10 @@ fn is_armv7() -> bool {
     target_components()[0] == "armv7"
 }
 
+fn is_little_endian() -> bool {
+    env::var("CARGO_CFG_TARGET_ENDIAN").unwrap() == "little"
+}
+
 fn is_aarch64() -> bool {
     target_components()[0] == "aarch64"
 }
@@ -107,6 +111,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     base_build.file(c_dir_path("blake3.c"));
     base_build.file(c_dir_path("blake3_dispatch.c"));
     base_build.file(c_dir_path("blake3_portable.c"));
+    if defined("CARGO_FEATURE_SVE2") && is_aarch64() && is_little_endian() {
+        base_build.define("BLAKE3_USE_SVE2", "1");
+    }
     if cfg!(feature = "tbb") {
         base_build.define("BLAKE3_USE_TBB", "1");
     }
@@ -221,6 +228,24 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             neon_build.flag("-mfloat-abi=hard");
         }
         neon_build.compile("blake3_neon");
+    }
+
+    // Opt-in even on aarch64, because SVE2 isn't universal there and this needs a
+    // compiler with SVE2 intrinsics. Gated on the target too, unlike "neon", which
+    // is also valid on 32-bit ARM.
+    //
+    // Note that BLAKE3_USE_SVE2 is defined for base_build above as well. If it only
+    // reached this build, blake3_dispatch.c would preprocess away the call and the
+    // backend would be compiled but never used.
+    if defined("CARGO_FEATURE_SVE2") && is_aarch64() && is_little_endian() {
+        let mut sve2_build = new_build();
+        sve2_build.file(c_dir_path("blake3_sve2.c"));
+        sve2_build.define("BLAKE3_USE_SVE2", "1");
+        // blake3_sve2.c requires exactly 128-bit vectors; see the comment at the
+        // top of that file.
+        sve2_build.flag("-march=armv8-a+sve2");
+        sve2_build.flag("-msve-vector-bits=128");
+        sve2_build.compile("blake3_sve2");
     }
 
     // The `cc` crate does not automatically emit rerun-if directives for the

--- a/c/blake3_c_rust_bindings/build.rs
+++ b/c/blake3_c_rust_bindings/build.rs
@@ -107,6 +107,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     base_build.file(c_dir_path("blake3.c"));
     base_build.file(c_dir_path("blake3_dispatch.c"));
     base_build.file(c_dir_path("blake3_portable.c"));
+    if defined("CARGO_FEATURE_SVE2") && is_aarch64() {
+        base_build.define("BLAKE3_USE_SVE2", "1");
+    }
     if cfg!(feature = "tbb") {
         base_build.define("BLAKE3_USE_TBB", "1");
     }
@@ -221,6 +224,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             neon_build.flag("-mfloat-abi=hard");
         }
         neon_build.compile("blake3_neon");
+    }
+
+    // BLAKE3_USE_SVE2 must also reach base_build above, or blake3_dispatch.c
+    // never calls this.
+    if defined("CARGO_FEATURE_SVE2") && is_aarch64() {
+        let mut sve2_build = new_build();
+        sve2_build.file(c_dir_path("blake3_sve2.c"));
+        sve2_build.define("BLAKE3_USE_SVE2", "1");
+        // armv8-a+sve2 rather than armv9-a, which needs GCC 12.
+        sve2_build.flag("-march=armv8-a+sve2");
+        sve2_build.flag("-msve-vector-bits=128");
+        sve2_build.compile("blake3_sve2");
     }
 
     // The `cc` crate does not automatically emit rerun-if directives for the

--- a/c/blake3_c_rust_bindings/src/lib.rs
+++ b/c/blake3_c_rust_bindings/src/lib.rs
@@ -15,6 +15,27 @@ pub const OUT_LEN: usize = 32;
 
 // Feature detection functions for tests and benchmarks. Note that the C code
 // does its own feature detection in blake3_dispatch.c.
+// The backend needs SVE2 and a 128-bit vector length; see blake3_dispatch.c. std
+// has no is_aarch64_feature_detected! for SVE2 on stable, so read the kernel's view
+// directly rather than calling svcntb(), which the compiler would fold to a
+// constant under -msve-vector-bits=128.
+#[cfg(all(feature = "sve2", target_arch = "aarch64", target_os = "linux"))]
+pub fn sve2_detected() -> bool {
+    let vl = std::fs::read_to_string("/proc/sys/abi/sve_default_vector_length")
+        .ok()
+        .and_then(|s| s.trim().parse::<usize>().ok());
+    vl == Some(16) && std::fs::read_to_string("/proc/cpuinfo").is_ok_and(|s| {
+        s.lines()
+            .find(|l| l.starts_with("Features"))
+            .is_some_and(|l| l.split_whitespace().any(|f| f == "sve2"))
+    })
+}
+
+#[cfg(all(feature = "sve2", target_arch = "aarch64", not(target_os = "linux")))]
+pub fn sve2_detected() -> bool {
+    false
+}
+
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub fn sse2_detected() -> bool {
     is_x86_feature_detected!("sse2")
@@ -308,6 +329,25 @@ pub mod ffi {
                 flags: u8,
                 out: *mut u8,
                 outblocks: usize,
+            );
+        }
+    }
+
+    #[cfg(all(feature = "sve2", target_arch = "aarch64"))]
+    pub mod sve2 {
+        unsafe extern "C" {
+            // SVE2 low level functions
+            pub fn blake3_hash_many_sve2(
+                inputs: *const *const u8,
+                num_inputs: usize,
+                blocks: usize,
+                key: *const u32,
+                counter: u64,
+                increment_counter: bool,
+                flags: u8,
+                flags_start: u8,
+                flags_end: u8,
+                out: *mut u8,
             );
         }
     }

--- a/c/blake3_c_rust_bindings/src/lib.rs
+++ b/c/blake3_c_rust_bindings/src/lib.rs
@@ -15,6 +15,21 @@ pub const OUT_LEN: usize = 32;
 
 // Feature detection functions for tests and benchmarks. Note that the C code
 // does its own feature detection in blake3_dispatch.c.
+
+// Also needs a 128-bit vector length; see sve2_usable in blake3_dispatch.c.
+#[cfg(all(feature = "sve2", target_arch = "aarch64", target_os = "linux"))]
+pub fn sve2_detected() -> bool {
+    let vl = std::fs::read_to_string("/proc/sys/abi/sve_default_vector_length")
+        .ok()
+        .and_then(|s| s.trim().parse::<usize>().ok());
+    std::arch::is_aarch64_feature_detected!("sve2") && vl == Some(16)
+}
+
+#[cfg(all(feature = "sve2", target_arch = "aarch64", not(target_os = "linux")))]
+pub fn sve2_detected() -> bool {
+    false
+}
+
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub fn sse2_detected() -> bool {
     is_x86_feature_detected!("sse2")
@@ -308,6 +323,25 @@ pub mod ffi {
                 flags: u8,
                 out: *mut u8,
                 outblocks: usize,
+            );
+        }
+    }
+
+    #[cfg(all(feature = "sve2", target_arch = "aarch64"))]
+    pub mod sve2 {
+        unsafe extern "C" {
+            // SVE2 low level functions
+            pub fn blake3_hash_many_sve2(
+                inputs: *const *const u8,
+                num_inputs: usize,
+                blocks: usize,
+                key: *const u32,
+                counter: u64,
+                increment_counter: bool,
+                flags: u8,
+                flags_start: u8,
+                flags_end: u8,
+                out: *mut u8,
             );
         }
     }

--- a/c/blake3_c_rust_bindings/src/test.rs
+++ b/c/blake3_c_rust_bindings/src/test.rs
@@ -359,6 +359,15 @@ fn test_hash_many_neon() {
     test_hash_many_fn(crate::ffi::neon::blake3_hash_many_neon);
 }
 
+#[test]
+#[cfg(all(feature = "sve2", target_arch = "aarch64"))]
+fn test_hash_many_sve2() {
+    if !crate::sve2_detected() {
+        return;
+    }
+    test_hash_many_fn(crate::ffi::sve2::blake3_hash_many_sve2);
+}
+
 #[allow(unused)]
 type XofManyFunction = unsafe extern "C" fn(
     cv: *const u32,

--- a/c/blake3_c_rust_bindings/src/test.rs
+++ b/c/blake3_c_rust_bindings/src/test.rs
@@ -365,6 +365,15 @@ fn test_hash_many_neon() {
     test_hash_many_fn(crate::ffi::neon::blake3_hash_many_neon);
 }
 
+#[test]
+#[cfg(all(feature = "sve2", target_arch = "aarch64"))]
+fn test_hash_many_sve2() {
+    if !crate::sve2_detected() {
+        return;
+    }
+    test_hash_many_fn(crate::ffi::sve2::blake3_hash_many_sve2);
+}
+
 #[allow(unused)]
 type XofManyFunction = unsafe extern "C" fn(
     cv: *const u32,

--- a/c/blake3_dispatch.c
+++ b/c/blake3_dispatch.c
@@ -18,6 +18,27 @@
 #endif
 #endif
 
+#if BLAKE3_USE_SVE2 == 1
+#if defined(__linux__) || defined(__ANDROID__)
+#include <sys/auxv.h>
+#include <sys/prctl.h>
+#include <asm/hwcap.h>
+#ifndef HWCAP2_SVE2
+#define HWCAP2_SVE2 (1 << 1)
+#endif
+#ifndef PR_SVE_GET_VL
+#define PR_SVE_GET_VL 51
+#endif
+#ifndef PR_SVE_VL_LEN_MASK
+#define PR_SVE_VL_LEN_MASK 0xffff
+#endif
+#else
+/* No way to detect SVE2 at runtime on this platform, so don't use it. */
+#undef BLAKE3_USE_SVE2
+#define BLAKE3_USE_SVE2 0
+#endif
+#endif
+
 #if !defined(BLAKE3_ATOMICS)
 #if defined(__has_include)
 #if __has_include(<stdatomic.h>) && !defined(_MSC_VER)
@@ -247,6 +268,31 @@ void blake3_xof_many(const uint32_t cv[8],
   }
 }
 
+#if BLAKE3_USE_SVE2 == 1
+/* blake3_sve2.c is built with -msve-vector-bits=128, so it needs both SVE2 and a
+   128-bit vector length; the architecture allows up to 2048, and running the
+   fixed-length code on a wider vector would be undefined behavior.
+
+   The length must be read here and not from blake3_sve2.c, because under
+   -msve-vector-bits=128 the compiler folds svcntb() to the constant 16, so a check
+   in that file would always succeed. This file is built without SVE flags. */
+INLINE bool sve2_usable(void) {
+  static ATOMIC_INT g_sve2_usable = -1;
+  int cached = ATOMIC_LOAD(g_sve2_usable);
+  if (cached < 0) {
+    cached = 0;
+    if ((getauxval(AT_HWCAP2) & HWCAP2_SVE2) != 0) {
+      int vl = prctl(PR_SVE_GET_VL, 0, 0, 0, 0);
+      if (vl >= 0 && (vl & PR_SVE_VL_LEN_MASK) == 16) {
+        cached = 1;
+      }
+    }
+    ATOMIC_STORE(g_sve2_usable, cached);
+  }
+  return cached != 0;
+}
+#endif
+
 void blake3_hash_many(const uint8_t *const *inputs, size_t num_inputs,
                       size_t blocks, const uint32_t key[8], uint64_t counter,
                       bool increment_counter, uint8_t flags,
@@ -286,6 +332,15 @@ void blake3_hash_many(const uint8_t *const *inputs, size_t num_inputs,
     return;
   }
 #endif
+#endif
+
+#if BLAKE3_USE_SVE2 == 1
+  if (sve2_usable()) {
+    blake3_hash_many_sve2(inputs, num_inputs, blocks, key, counter,
+                          increment_counter, flags, flags_start, flags_end,
+                          out);
+    return;
+  }
 #endif
 
 #if BLAKE3_USE_NEON == 1

--- a/c/blake3_dispatch.c
+++ b/c/blake3_dispatch.c
@@ -18,6 +18,21 @@
 #endif
 #endif
 
+#if BLAKE3_USE_SVE2 == 1
+#if defined(IS_AARCH64) && defined(__linux__)
+#include <sys/auxv.h>
+#include <sys/prctl.h>
+#include <asm/hwcap.h>
+#ifndef HWCAP2_SVE2
+#define HWCAP2_SVE2 (1 << 1)
+#endif
+#else
+/* No runtime detection on this platform. */
+#undef BLAKE3_USE_SVE2
+#define BLAKE3_USE_SVE2 0
+#endif
+#endif
+
 #if !defined(BLAKE3_ATOMICS)
 #if defined(__has_include)
 #if __has_include(<stdatomic.h>) && !defined(_MSC_VER)
@@ -165,6 +180,33 @@ static
 }
 #endif
 
+#if BLAKE3_USE_SVE2 == 1
+enum cpu_feature_aarch64 {
+  SVE2 = 1 << 0,
+  /* ... */
+  UNDEFINED_AARCH64 = 1 << 30
+};
+
+static ATOMIC_INT g_cpu_features_aarch64 = UNDEFINED_AARCH64;
+
+static enum cpu_feature_aarch64 get_cpu_features_aarch64(void) {
+  enum cpu_feature_aarch64 features = ATOMIC_LOAD(g_cpu_features_aarch64);
+  if (features != UNDEFINED_AARCH64) {
+    return features;
+  }
+  /* blake3_sve2.c is built with -msve-vector-bits=128, so it needs SVE2 and a
+     128-bit vector length. Checked here because under that flag the compiler
+     folds svcntb() to 16, so a check in that file would always pass. */
+  features = 0;
+  if ((getauxval(AT_HWCAP2) & HWCAP2_SVE2) != 0 &&
+      (prctl(PR_SVE_GET_VL, 0, 0, 0, 0) & PR_SVE_VL_LEN_MASK) == 16) {
+    features |= SVE2;
+  }
+  ATOMIC_STORE(g_cpu_features_aarch64, features);
+  return features;
+}
+#endif
+
 void blake3_compress_in_place(uint32_t cv[8],
                               const uint8_t block[BLAKE3_BLOCK_LEN],
                               uint8_t block_len, uint64_t counter,
@@ -286,6 +328,15 @@ void blake3_hash_many(const uint8_t *const *inputs, size_t num_inputs,
     return;
   }
 #endif
+#endif
+
+#if BLAKE3_USE_SVE2 == 1
+  if (get_cpu_features_aarch64() & SVE2) {
+    blake3_hash_many_sve2(inputs, num_inputs, blocks, key, counter,
+                          increment_counter, flags, flags_start, flags_end,
+                          out);
+    return;
+  }
 #endif
 
 #if BLAKE3_USE_NEON == 1

--- a/c/blake3_impl.h
+++ b/c/blake3_impl.h
@@ -326,6 +326,14 @@ void blake3_hash_many_neon(const uint8_t *const *inputs, size_t num_inputs,
                            uint8_t flags_end, uint8_t *out);
 #endif
 
+#if BLAKE3_USE_SVE2 == 1
+void blake3_hash_many_sve2(const uint8_t *const *inputs, size_t num_inputs,
+                           size_t blocks, const uint32_t key[8],
+                           uint64_t counter, bool increment_counter,
+                           uint8_t flags, uint8_t flags_start,
+                           uint8_t flags_end, uint8_t *out);
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/c/blake3_sve2.c
+++ b/c/blake3_sve2.c
@@ -1,0 +1,367 @@
+#include "blake3_impl.h"
+
+#include <arm_neon.h>
+
+#ifdef __ARM_BIG_ENDIAN
+#error "This implementation only supports little-endian ARM."
+// It might be that all we need for big-endian support here is to get the loads
+// and stores right, but step zero would be finding a way to test it in CI.
+#endif
+
+INLINE uint32x4_t loadu_128(const uint8_t src[16]) {
+  // vld1q_u32 has alignment requirements. Don't use it.
+  return vreinterpretq_u32_u8(vld1q_u8(src));
+}
+
+INLINE void storeu_128(uint32x4_t src, uint8_t dest[16]) {
+  // vst1q_u32 has alignment requirements. Don't use it.
+  vst1q_u8(dest, vreinterpretq_u8_u32(src));
+}
+
+INLINE uint32x4_t add_128(uint32x4_t a, uint32x4_t b) {
+  return vaddq_u32(a, b);
+}
+
+INLINE uint32x4_t xor_128(uint32x4_t a, uint32x4_t b) {
+  return veorq_u32(a, b);
+}
+
+INLINE uint32x4_t set1_128(uint32_t x) { return vld1q_dup_u32(&x); }
+
+INLINE uint32x4_t set4(uint32_t a, uint32_t b, uint32_t c, uint32_t d) {
+  uint32_t array[4] = {a, b, c, d};
+  return vld1q_u32(array);
+}
+
+INLINE uint32x4_t rot16_128(uint32x4_t x) {
+  // The straightforward implementation would be two shifts and an or, but that's
+  // slower on microarchitectures we've tested. See
+  // https://github.com/BLAKE3-team/BLAKE3/pull/319.
+  // return vorrq_u32(vshrq_n_u32(x, 16), vshlq_n_u32(x, 32 - 16));
+  return vreinterpretq_u32_u16(vrev32q_u16(vreinterpretq_u16_u32(x)));
+}
+
+INLINE uint32x4_t rot12_128(uint32x4_t x) {
+  // See comment in rot16_128.
+  // return vorrq_u32(vshrq_n_u32(x, 12), vshlq_n_u32(x, 32 - 12));
+  return vsriq_n_u32(vshlq_n_u32(x, 32-12), x, 12);
+}
+
+INLINE uint32x4_t rot8_128(uint32x4_t x) {
+  // See comment in rot16_128.
+  // return vorrq_u32(vshrq_n_u32(x, 8), vshlq_n_u32(x, 32 - 8));
+#if defined(__clang__)
+  return vreinterpretq_u32_u8(__builtin_shufflevector(vreinterpretq_u8_u32(x), vreinterpretq_u8_u32(x), 1,2,3,0,5,6,7,4,9,10,11,8,13,14,15,12));
+#elif __GNUC__ * 10000 + __GNUC_MINOR__ * 100 >=40700
+  static const uint8x16_t r8 = {1,2,3,0,5,6,7,4,9,10,11,8,13,14,15,12};
+  return vreinterpretq_u32_u8(__builtin_shuffle(vreinterpretq_u8_u32(x), vreinterpretq_u8_u32(x), r8));
+#else 
+  return vsriq_n_u32(vshlq_n_u32(x, 32-8), x, 8);
+#endif
+}
+
+INLINE uint32x4_t rot7_128(uint32x4_t x) {
+  // See comment in rot16_128.
+  // return vorrq_u32(vshrq_n_u32(x, 7), vshlq_n_u32(x, 32 - 7));
+  return vsriq_n_u32(vshlq_n_u32(x, 32-7), x, 7);
+}
+
+// TODO: compress_neon
+
+// TODO: hash2_neon
+
+/*
+ * ----------------------------------------------------------------------------
+ * hash4_neon
+ * ----------------------------------------------------------------------------
+ */
+
+INLINE void round_fn4(uint32x4_t v[16], uint32x4_t m[16], size_t r) {
+  v[0] = add_128(v[0], m[(size_t)MSG_SCHEDULE[r][0]]);
+  v[1] = add_128(v[1], m[(size_t)MSG_SCHEDULE[r][2]]);
+  v[2] = add_128(v[2], m[(size_t)MSG_SCHEDULE[r][4]]);
+  v[3] = add_128(v[3], m[(size_t)MSG_SCHEDULE[r][6]]);
+  v[0] = add_128(v[0], v[4]);
+  v[1] = add_128(v[1], v[5]);
+  v[2] = add_128(v[2], v[6]);
+  v[3] = add_128(v[3], v[7]);
+  v[12] = xor_128(v[12], v[0]);
+  v[13] = xor_128(v[13], v[1]);
+  v[14] = xor_128(v[14], v[2]);
+  v[15] = xor_128(v[15], v[3]);
+  v[12] = rot16_128(v[12]);
+  v[13] = rot16_128(v[13]);
+  v[14] = rot16_128(v[14]);
+  v[15] = rot16_128(v[15]);
+  v[8] = add_128(v[8], v[12]);
+  v[9] = add_128(v[9], v[13]);
+  v[10] = add_128(v[10], v[14]);
+  v[11] = add_128(v[11], v[15]);
+  v[4] = xor_128(v[4], v[8]);
+  v[5] = xor_128(v[5], v[9]);
+  v[6] = xor_128(v[6], v[10]);
+  v[7] = xor_128(v[7], v[11]);
+  v[4] = rot12_128(v[4]);
+  v[5] = rot12_128(v[5]);
+  v[6] = rot12_128(v[6]);
+  v[7] = rot12_128(v[7]);
+  v[0] = add_128(v[0], m[(size_t)MSG_SCHEDULE[r][1]]);
+  v[1] = add_128(v[1], m[(size_t)MSG_SCHEDULE[r][3]]);
+  v[2] = add_128(v[2], m[(size_t)MSG_SCHEDULE[r][5]]);
+  v[3] = add_128(v[3], m[(size_t)MSG_SCHEDULE[r][7]]);
+  v[0] = add_128(v[0], v[4]);
+  v[1] = add_128(v[1], v[5]);
+  v[2] = add_128(v[2], v[6]);
+  v[3] = add_128(v[3], v[7]);
+  v[12] = xor_128(v[12], v[0]);
+  v[13] = xor_128(v[13], v[1]);
+  v[14] = xor_128(v[14], v[2]);
+  v[15] = xor_128(v[15], v[3]);
+  v[12] = rot8_128(v[12]);
+  v[13] = rot8_128(v[13]);
+  v[14] = rot8_128(v[14]);
+  v[15] = rot8_128(v[15]);
+  v[8] = add_128(v[8], v[12]);
+  v[9] = add_128(v[9], v[13]);
+  v[10] = add_128(v[10], v[14]);
+  v[11] = add_128(v[11], v[15]);
+  v[4] = xor_128(v[4], v[8]);
+  v[5] = xor_128(v[5], v[9]);
+  v[6] = xor_128(v[6], v[10]);
+  v[7] = xor_128(v[7], v[11]);
+  v[4] = rot7_128(v[4]);
+  v[5] = rot7_128(v[5]);
+  v[6] = rot7_128(v[6]);
+  v[7] = rot7_128(v[7]);
+
+  v[0] = add_128(v[0], m[(size_t)MSG_SCHEDULE[r][8]]);
+  v[1] = add_128(v[1], m[(size_t)MSG_SCHEDULE[r][10]]);
+  v[2] = add_128(v[2], m[(size_t)MSG_SCHEDULE[r][12]]);
+  v[3] = add_128(v[3], m[(size_t)MSG_SCHEDULE[r][14]]);
+  v[0] = add_128(v[0], v[5]);
+  v[1] = add_128(v[1], v[6]);
+  v[2] = add_128(v[2], v[7]);
+  v[3] = add_128(v[3], v[4]);
+  v[15] = xor_128(v[15], v[0]);
+  v[12] = xor_128(v[12], v[1]);
+  v[13] = xor_128(v[13], v[2]);
+  v[14] = xor_128(v[14], v[3]);
+  v[15] = rot16_128(v[15]);
+  v[12] = rot16_128(v[12]);
+  v[13] = rot16_128(v[13]);
+  v[14] = rot16_128(v[14]);
+  v[10] = add_128(v[10], v[15]);
+  v[11] = add_128(v[11], v[12]);
+  v[8] = add_128(v[8], v[13]);
+  v[9] = add_128(v[9], v[14]);
+  v[5] = xor_128(v[5], v[10]);
+  v[6] = xor_128(v[6], v[11]);
+  v[7] = xor_128(v[7], v[8]);
+  v[4] = xor_128(v[4], v[9]);
+  v[5] = rot12_128(v[5]);
+  v[6] = rot12_128(v[6]);
+  v[7] = rot12_128(v[7]);
+  v[4] = rot12_128(v[4]);
+  v[0] = add_128(v[0], m[(size_t)MSG_SCHEDULE[r][9]]);
+  v[1] = add_128(v[1], m[(size_t)MSG_SCHEDULE[r][11]]);
+  v[2] = add_128(v[2], m[(size_t)MSG_SCHEDULE[r][13]]);
+  v[3] = add_128(v[3], m[(size_t)MSG_SCHEDULE[r][15]]);
+  v[0] = add_128(v[0], v[5]);
+  v[1] = add_128(v[1], v[6]);
+  v[2] = add_128(v[2], v[7]);
+  v[3] = add_128(v[3], v[4]);
+  v[15] = xor_128(v[15], v[0]);
+  v[12] = xor_128(v[12], v[1]);
+  v[13] = xor_128(v[13], v[2]);
+  v[14] = xor_128(v[14], v[3]);
+  v[15] = rot8_128(v[15]);
+  v[12] = rot8_128(v[12]);
+  v[13] = rot8_128(v[13]);
+  v[14] = rot8_128(v[14]);
+  v[10] = add_128(v[10], v[15]);
+  v[11] = add_128(v[11], v[12]);
+  v[8] = add_128(v[8], v[13]);
+  v[9] = add_128(v[9], v[14]);
+  v[5] = xor_128(v[5], v[10]);
+  v[6] = xor_128(v[6], v[11]);
+  v[7] = xor_128(v[7], v[8]);
+  v[4] = xor_128(v[4], v[9]);
+  v[5] = rot7_128(v[5]);
+  v[6] = rot7_128(v[6]);
+  v[7] = rot7_128(v[7]);
+  v[4] = rot7_128(v[4]);
+}
+
+INLINE void transpose_vecs_128(uint32x4_t vecs[4]) {
+  // Individually transpose the four 2x2 sub-matrices in each corner.
+  uint32x4x2_t rows01 = vtrnq_u32(vecs[0], vecs[1]);
+  uint32x4x2_t rows23 = vtrnq_u32(vecs[2], vecs[3]);
+
+  // Swap the top-right and bottom-left 2x2s (which just got transposed).
+  vecs[0] =
+      vcombine_u32(vget_low_u32(rows01.val[0]), vget_low_u32(rows23.val[0]));
+  vecs[1] =
+      vcombine_u32(vget_low_u32(rows01.val[1]), vget_low_u32(rows23.val[1]));
+  vecs[2] =
+      vcombine_u32(vget_high_u32(rows01.val[0]), vget_high_u32(rows23.val[0]));
+  vecs[3] =
+      vcombine_u32(vget_high_u32(rows01.val[1]), vget_high_u32(rows23.val[1]));
+}
+
+INLINE void transpose_msg_vecs4(const uint8_t *const *inputs,
+                                size_t block_offset, uint32x4_t out[16]) {
+  out[0] = loadu_128(&inputs[0][block_offset + 0 * sizeof(uint32x4_t)]);
+  out[1] = loadu_128(&inputs[1][block_offset + 0 * sizeof(uint32x4_t)]);
+  out[2] = loadu_128(&inputs[2][block_offset + 0 * sizeof(uint32x4_t)]);
+  out[3] = loadu_128(&inputs[3][block_offset + 0 * sizeof(uint32x4_t)]);
+  out[4] = loadu_128(&inputs[0][block_offset + 1 * sizeof(uint32x4_t)]);
+  out[5] = loadu_128(&inputs[1][block_offset + 1 * sizeof(uint32x4_t)]);
+  out[6] = loadu_128(&inputs[2][block_offset + 1 * sizeof(uint32x4_t)]);
+  out[7] = loadu_128(&inputs[3][block_offset + 1 * sizeof(uint32x4_t)]);
+  out[8] = loadu_128(&inputs[0][block_offset + 2 * sizeof(uint32x4_t)]);
+  out[9] = loadu_128(&inputs[1][block_offset + 2 * sizeof(uint32x4_t)]);
+  out[10] = loadu_128(&inputs[2][block_offset + 2 * sizeof(uint32x4_t)]);
+  out[11] = loadu_128(&inputs[3][block_offset + 2 * sizeof(uint32x4_t)]);
+  out[12] = loadu_128(&inputs[0][block_offset + 3 * sizeof(uint32x4_t)]);
+  out[13] = loadu_128(&inputs[1][block_offset + 3 * sizeof(uint32x4_t)]);
+  out[14] = loadu_128(&inputs[2][block_offset + 3 * sizeof(uint32x4_t)]);
+  out[15] = loadu_128(&inputs[3][block_offset + 3 * sizeof(uint32x4_t)]);
+  transpose_vecs_128(&out[0]);
+  transpose_vecs_128(&out[4]);
+  transpose_vecs_128(&out[8]);
+  transpose_vecs_128(&out[12]);
+}
+
+INLINE void load_counters4(uint64_t counter, bool increment_counter,
+                           uint32x4_t *out_low, uint32x4_t *out_high) {
+  uint64_t mask = (increment_counter ? ~0 : 0);
+  *out_low = set4(
+      counter_low(counter + (mask & 0)), counter_low(counter + (mask & 1)),
+      counter_low(counter + (mask & 2)), counter_low(counter + (mask & 3)));
+  *out_high = set4(
+      counter_high(counter + (mask & 0)), counter_high(counter + (mask & 1)),
+      counter_high(counter + (mask & 2)), counter_high(counter + (mask & 3)));
+}
+
+static void blake3_hash4_neon(const uint8_t *const *inputs, size_t blocks,
+                              const uint32_t key[8], uint64_t counter,
+                              bool increment_counter, uint8_t flags,
+                              uint8_t flags_start, uint8_t flags_end, 
+                              uint8_t *out) {
+  uint32x4_t h_vecs[8] = {
+      set1_128(key[0]), set1_128(key[1]), set1_128(key[2]), set1_128(key[3]),
+      set1_128(key[4]), set1_128(key[5]), set1_128(key[6]), set1_128(key[7]),
+  };
+  uint32x4_t counter_low_vec, counter_high_vec;
+  load_counters4(counter, increment_counter, &counter_low_vec,
+                 &counter_high_vec);
+  uint8_t block_flags = flags | flags_start;
+
+  for (size_t block = 0; block < blocks; block++) {
+    if (block + 1 == blocks) {
+      block_flags |= flags_end;
+    }
+    uint32x4_t block_len_vec = set1_128(BLAKE3_BLOCK_LEN);
+    uint32x4_t block_flags_vec = set1_128(block_flags);
+    uint32x4_t msg_vecs[16];
+    transpose_msg_vecs4(inputs, block * BLAKE3_BLOCK_LEN, msg_vecs);
+
+    uint32x4_t v[16] = {
+        h_vecs[0],       h_vecs[1],        h_vecs[2],       h_vecs[3],
+        h_vecs[4],       h_vecs[5],        h_vecs[6],       h_vecs[7],
+        set1_128(IV[0]), set1_128(IV[1]),  set1_128(IV[2]), set1_128(IV[3]),
+        counter_low_vec, counter_high_vec, block_len_vec,   block_flags_vec,
+    };
+    round_fn4(v, msg_vecs, 0);
+    round_fn4(v, msg_vecs, 1);
+    round_fn4(v, msg_vecs, 2);
+    round_fn4(v, msg_vecs, 3);
+    round_fn4(v, msg_vecs, 4);
+    round_fn4(v, msg_vecs, 5);
+    round_fn4(v, msg_vecs, 6);
+    h_vecs[0] = xor_128(v[0], v[8]);
+    h_vecs[1] = xor_128(v[1], v[9]);
+    h_vecs[2] = xor_128(v[2], v[10]);
+    h_vecs[3] = xor_128(v[3], v[11]);
+    h_vecs[4] = xor_128(v[4], v[12]);
+    h_vecs[5] = xor_128(v[5], v[13]);
+    h_vecs[6] = xor_128(v[6], v[14]);
+    h_vecs[7] = xor_128(v[7], v[15]);
+
+    block_flags = flags;
+  }
+
+  transpose_vecs_128(&h_vecs[0]);
+  transpose_vecs_128(&h_vecs[4]);
+  // The first four vecs now contain the first half of each output, and the
+  // second four vecs contain the second half of each output.
+  storeu_128(h_vecs[0], &out[0 * sizeof(uint32x4_t)]);
+  storeu_128(h_vecs[4], &out[1 * sizeof(uint32x4_t)]);
+  storeu_128(h_vecs[1], &out[2 * sizeof(uint32x4_t)]);
+  storeu_128(h_vecs[5], &out[3 * sizeof(uint32x4_t)]);
+  storeu_128(h_vecs[2], &out[4 * sizeof(uint32x4_t)]);
+  storeu_128(h_vecs[6], &out[5 * sizeof(uint32x4_t)]);
+  storeu_128(h_vecs[3], &out[6 * sizeof(uint32x4_t)]);
+  storeu_128(h_vecs[7], &out[7 * sizeof(uint32x4_t)]);
+}
+
+/*
+ * ----------------------------------------------------------------------------
+ * hash_many_neon
+ * ----------------------------------------------------------------------------
+ */
+
+void blake3_compress_in_place_portable(uint32_t cv[8],
+                                       const uint8_t block[BLAKE3_BLOCK_LEN],
+                                       uint8_t block_len, uint64_t counter,
+                                       uint8_t flags);
+
+INLINE void hash_one_neon(const uint8_t *input, size_t blocks,
+                          const uint32_t key[8], uint64_t counter,
+                          uint8_t flags, uint8_t flags_start, uint8_t flags_end,
+                          uint8_t out[BLAKE3_OUT_LEN]) {
+  uint32_t cv[8];
+  memcpy(cv, key, BLAKE3_KEY_LEN);
+  uint8_t block_flags = flags | flags_start;
+  while (blocks > 0) {
+    if (blocks == 1) {
+      block_flags |= flags_end;
+    }
+    // TODO: Implement compress_neon. However note that according to
+    // https://github.com/BLAKE2/BLAKE2/commit/7965d3e6e1b4193438b8d3a656787587d2579227,
+    // compress_neon might not be any faster than compress_portable.
+    blake3_compress_in_place_portable(cv, input, BLAKE3_BLOCK_LEN, counter,
+                                      block_flags);
+    input = &input[BLAKE3_BLOCK_LEN];
+    blocks -= 1;
+    block_flags = flags;
+  }
+  memcpy(out, cv, BLAKE3_OUT_LEN);
+}
+
+void blake3_hash_many_neon(const uint8_t *const *inputs, size_t num_inputs,
+                           size_t blocks, const uint32_t key[8],
+                           uint64_t counter, bool increment_counter,
+                           uint8_t flags, uint8_t flags_start,
+                           uint8_t flags_end, uint8_t *out) {
+  while (num_inputs >= 4) {
+    blake3_hash4_neon(inputs, blocks, key, counter, increment_counter, flags,
+                      flags_start, flags_end, out);
+    if (increment_counter) {
+      counter += 4;
+    }
+    inputs += 4;
+    num_inputs -= 4;
+    out = &out[4 * BLAKE3_OUT_LEN];
+  }
+  while (num_inputs > 0) {
+    hash_one_neon(inputs[0], blocks, key, counter, flags, flags_start,
+                  flags_end, out);
+    if (increment_counter) {
+      counter += 1;
+    }
+    inputs += 1;
+    num_inputs -= 1;
+    out = &out[BLAKE3_OUT_LEN];
+  }
+}

--- a/c/blake3_sve2.c
+++ b/c/blake3_sve2.c
@@ -1,0 +1,332 @@
+// SVE2 backend for BLAKE3, degree 4. This is a port of blake3_neon.c; the only
+// difference is that every (xor, rotate-right) pair becomes a single SVE2 XAR:
+//
+//     v[12] = xor(v[12], v[0]); v[12] = rot16(v[12]);   // NEON
+//     v[12] = svxar_n_u32(v[12], v[0], 16);             // SVE2
+//
+// Compiled with -msve-vector-bits=128, which is a promise that the runtime vector
+// length is exactly 128 bits. blake3_dispatch.c checks that before dispatching
+// here; see the comment there for why the check can't live in this file.
+
+#include "blake3_impl.h"
+
+// Checked before including arm_sve.h, because the pragma in that header
+// re-establishes the target macros.
+#ifdef __ARM_BIG_ENDIAN
+#error "This implementation only supports little-endian ARM."
+// Same situation as blake3_neon.c: the loads and stores would need fixing, and
+// there is no way to test it in CI.
+#endif
+
+#include <arm_sve.h>
+
+// Fixed-length SVE types, so that these can be used as array elements. Not named
+// svuint32x4_t, because in ACLE that already means a tuple of four vectors (for
+// LD4W) rather than four lanes; the underscore form follows Arm's own usage, as in
+// svuint32_8_t in ARM-software/astc-encoder.
+#if __ARM_FEATURE_SVE_BITS != 128
+#error "blake3_sve2.c must be compiled with -msve-vector-bits=128"
+#endif
+
+typedef svuint32_t svuint32_4_t __attribute__((arm_sve_vector_bits(128)));
+typedef svuint64_t svuint64_2_t __attribute__((arm_sve_vector_bits(128)));
+
+#define PT svptrue_b32()
+#define PT64 svptrue_b64()
+
+INLINE svuint32_4_t loadu_128(const uint8_t src[16]) {
+  // Load as bytes, like blake3_neon.c does, to avoid casting a possibly
+  // unaligned uint8_t pointer to uint32_t.
+  return svreinterpret_u32_u8(svld1_u8(svptrue_b8(), src));
+}
+
+INLINE void storeu_128(svuint32_4_t src, uint8_t dest[16]) {
+  svst1_u8(svptrue_b8(), dest, svreinterpret_u8_u32(src));
+}
+
+INLINE svuint32_4_t add_128(svuint32_4_t a, svuint32_4_t b) {
+  return svadd_u32_x(PT, a, b);
+}
+
+INLINE svuint32_4_t xor_128(svuint32_4_t a, svuint32_4_t b) {
+  return sveor_u32_x(PT, a, b);
+}
+
+INLINE svuint32_4_t set1_128(uint32_t x) { return svdup_n_u32(x); }
+
+INLINE svuint32_4_t set4(uint32_t a, uint32_t b, uint32_t c, uint32_t d) {
+  uint32_t array[4] = {a, b, c, d};
+  return svld1_u32(PT, array);
+}
+
+#define xar16_128(a, b) svxar_n_u32(a, b, 16)
+#define xar12_128(a, b) svxar_n_u32(a, b, 12)
+#define xar8_128(a, b) svxar_n_u32(a, b, 8)
+#define xar7_128(a, b) svxar_n_u32(a, b, 7)
+
+/*
+ * ----------------------------------------------------------------------------
+ * hash4_sve2
+ * ----------------------------------------------------------------------------
+ */
+
+INLINE void round_fn4(svuint32_4_t v[16], svuint32_4_t m[16], size_t r) {
+  v[0] = add_128(v[0], m[(size_t)MSG_SCHEDULE[r][0]]);
+  v[1] = add_128(v[1], m[(size_t)MSG_SCHEDULE[r][2]]);
+  v[2] = add_128(v[2], m[(size_t)MSG_SCHEDULE[r][4]]);
+  v[3] = add_128(v[3], m[(size_t)MSG_SCHEDULE[r][6]]);
+  v[0] = add_128(v[0], v[4]);
+  v[1] = add_128(v[1], v[5]);
+  v[2] = add_128(v[2], v[6]);
+  v[3] = add_128(v[3], v[7]);
+  v[12] = xar16_128(v[12], v[0]);
+  v[13] = xar16_128(v[13], v[1]);
+  v[14] = xar16_128(v[14], v[2]);
+  v[15] = xar16_128(v[15], v[3]);
+  v[8] = add_128(v[8], v[12]);
+  v[9] = add_128(v[9], v[13]);
+  v[10] = add_128(v[10], v[14]);
+  v[11] = add_128(v[11], v[15]);
+  v[4] = xar12_128(v[4], v[8]);
+  v[5] = xar12_128(v[5], v[9]);
+  v[6] = xar12_128(v[6], v[10]);
+  v[7] = xar12_128(v[7], v[11]);
+  v[0] = add_128(v[0], m[(size_t)MSG_SCHEDULE[r][1]]);
+  v[1] = add_128(v[1], m[(size_t)MSG_SCHEDULE[r][3]]);
+  v[2] = add_128(v[2], m[(size_t)MSG_SCHEDULE[r][5]]);
+  v[3] = add_128(v[3], m[(size_t)MSG_SCHEDULE[r][7]]);
+  v[0] = add_128(v[0], v[4]);
+  v[1] = add_128(v[1], v[5]);
+  v[2] = add_128(v[2], v[6]);
+  v[3] = add_128(v[3], v[7]);
+  v[12] = xar8_128(v[12], v[0]);
+  v[13] = xar8_128(v[13], v[1]);
+  v[14] = xar8_128(v[14], v[2]);
+  v[15] = xar8_128(v[15], v[3]);
+  v[8] = add_128(v[8], v[12]);
+  v[9] = add_128(v[9], v[13]);
+  v[10] = add_128(v[10], v[14]);
+  v[11] = add_128(v[11], v[15]);
+  v[4] = xar7_128(v[4], v[8]);
+  v[5] = xar7_128(v[5], v[9]);
+  v[6] = xar7_128(v[6], v[10]);
+  v[7] = xar7_128(v[7], v[11]);
+
+  v[0] = add_128(v[0], m[(size_t)MSG_SCHEDULE[r][8]]);
+  v[1] = add_128(v[1], m[(size_t)MSG_SCHEDULE[r][10]]);
+  v[2] = add_128(v[2], m[(size_t)MSG_SCHEDULE[r][12]]);
+  v[3] = add_128(v[3], m[(size_t)MSG_SCHEDULE[r][14]]);
+  v[0] = add_128(v[0], v[5]);
+  v[1] = add_128(v[1], v[6]);
+  v[2] = add_128(v[2], v[7]);
+  v[3] = add_128(v[3], v[4]);
+  v[15] = xar16_128(v[15], v[0]);
+  v[12] = xar16_128(v[12], v[1]);
+  v[13] = xar16_128(v[13], v[2]);
+  v[14] = xar16_128(v[14], v[3]);
+  v[10] = add_128(v[10], v[15]);
+  v[11] = add_128(v[11], v[12]);
+  v[8] = add_128(v[8], v[13]);
+  v[9] = add_128(v[9], v[14]);
+  v[5] = xar12_128(v[5], v[10]);
+  v[6] = xar12_128(v[6], v[11]);
+  v[7] = xar12_128(v[7], v[8]);
+  v[4] = xar12_128(v[4], v[9]);
+  v[0] = add_128(v[0], m[(size_t)MSG_SCHEDULE[r][9]]);
+  v[1] = add_128(v[1], m[(size_t)MSG_SCHEDULE[r][11]]);
+  v[2] = add_128(v[2], m[(size_t)MSG_SCHEDULE[r][13]]);
+  v[3] = add_128(v[3], m[(size_t)MSG_SCHEDULE[r][15]]);
+  v[0] = add_128(v[0], v[5]);
+  v[1] = add_128(v[1], v[6]);
+  v[2] = add_128(v[2], v[7]);
+  v[3] = add_128(v[3], v[4]);
+  v[15] = xar8_128(v[15], v[0]);
+  v[12] = xar8_128(v[12], v[1]);
+  v[13] = xar8_128(v[13], v[2]);
+  v[14] = xar8_128(v[14], v[3]);
+  v[10] = add_128(v[10], v[15]);
+  v[11] = add_128(v[11], v[12]);
+  v[8] = add_128(v[8], v[13]);
+  v[9] = add_128(v[9], v[14]);
+  v[5] = xar7_128(v[5], v[10]);
+  v[6] = xar7_128(v[6], v[11]);
+  v[7] = xar7_128(v[7], v[8]);
+  v[4] = xar7_128(v[4], v[9]);
+}
+
+// 4x4 transpose of 32-bit lanes, matching transpose_vecs_128 in blake3_neon.c.
+// TRN1/TRN2 do the 2x2 corner transposes; ZIP1/ZIP2 on 64-bit lanes then swap the
+// top-right and bottom-left blocks, which is what vcombine does in the NEON version.
+INLINE void transpose_vecs_128(svuint32_4_t vecs[4]) {
+  svuint32_4_t t0 = svtrn1_u32(vecs[0], vecs[1]);
+  svuint32_4_t t1 = svtrn2_u32(vecs[0], vecs[1]);
+  svuint32_4_t t2 = svtrn1_u32(vecs[2], vecs[3]);
+  svuint32_4_t t3 = svtrn2_u32(vecs[2], vecs[3]);
+
+  svuint64_2_t a0 = svreinterpret_u64_u32(t0);
+  svuint64_2_t a1 = svreinterpret_u64_u32(t1);
+  svuint64_2_t a2 = svreinterpret_u64_u32(t2);
+  svuint64_2_t a3 = svreinterpret_u64_u32(t3);
+
+  vecs[0] = svreinterpret_u32_u64(svzip1_u64(a0, a2));
+  vecs[1] = svreinterpret_u32_u64(svzip1_u64(a1, a3));
+  vecs[2] = svreinterpret_u32_u64(svzip2_u64(a0, a2));
+  vecs[3] = svreinterpret_u32_u64(svzip2_u64(a1, a3));
+}
+
+INLINE void transpose_msg_vecs4(const uint8_t *const *inputs,
+                                size_t block_offset, svuint32_4_t out[16]) {
+  out[0] = loadu_128(&inputs[0][block_offset + 0 * sizeof(svuint32_4_t)]);
+  out[1] = loadu_128(&inputs[1][block_offset + 0 * sizeof(svuint32_4_t)]);
+  out[2] = loadu_128(&inputs[2][block_offset + 0 * sizeof(svuint32_4_t)]);
+  out[3] = loadu_128(&inputs[3][block_offset + 0 * sizeof(svuint32_4_t)]);
+  out[4] = loadu_128(&inputs[0][block_offset + 1 * sizeof(svuint32_4_t)]);
+  out[5] = loadu_128(&inputs[1][block_offset + 1 * sizeof(svuint32_4_t)]);
+  out[6] = loadu_128(&inputs[2][block_offset + 1 * sizeof(svuint32_4_t)]);
+  out[7] = loadu_128(&inputs[3][block_offset + 1 * sizeof(svuint32_4_t)]);
+  out[8] = loadu_128(&inputs[0][block_offset + 2 * sizeof(svuint32_4_t)]);
+  out[9] = loadu_128(&inputs[1][block_offset + 2 * sizeof(svuint32_4_t)]);
+  out[10] = loadu_128(&inputs[2][block_offset + 2 * sizeof(svuint32_4_t)]);
+  out[11] = loadu_128(&inputs[3][block_offset + 2 * sizeof(svuint32_4_t)]);
+  out[12] = loadu_128(&inputs[0][block_offset + 3 * sizeof(svuint32_4_t)]);
+  out[13] = loadu_128(&inputs[1][block_offset + 3 * sizeof(svuint32_4_t)]);
+  out[14] = loadu_128(&inputs[2][block_offset + 3 * sizeof(svuint32_4_t)]);
+  out[15] = loadu_128(&inputs[3][block_offset + 3 * sizeof(svuint32_4_t)]);
+  transpose_vecs_128(&out[0]);
+  transpose_vecs_128(&out[4]);
+  transpose_vecs_128(&out[8]);
+  transpose_vecs_128(&out[12]);
+}
+
+INLINE void load_counters4(uint64_t counter, bool increment_counter,
+                           svuint32_4_t *out_low, svuint32_4_t *out_high) {
+  uint64_t mask = (increment_counter ? ~0 : 0);
+  *out_low = set4(
+      counter_low(counter + (mask & 0)), counter_low(counter + (mask & 1)),
+      counter_low(counter + (mask & 2)), counter_low(counter + (mask & 3)));
+  *out_high = set4(
+      counter_high(counter + (mask & 0)), counter_high(counter + (mask & 1)),
+      counter_high(counter + (mask & 2)), counter_high(counter + (mask & 3)));
+}
+
+static void blake3_hash4_sve2(const uint8_t *const *inputs, size_t blocks,
+                              const uint32_t key[8], uint64_t counter,
+                              bool increment_counter, uint8_t flags,
+                              uint8_t flags_start, uint8_t flags_end,
+                              uint8_t *out) {
+  svuint32_4_t h_vecs[8] = {
+      set1_128(key[0]), set1_128(key[1]), set1_128(key[2]), set1_128(key[3]),
+      set1_128(key[4]), set1_128(key[5]), set1_128(key[6]), set1_128(key[7]),
+  };
+  svuint32_4_t counter_low_vec, counter_high_vec;
+  load_counters4(counter, increment_counter, &counter_low_vec,
+                 &counter_high_vec);
+  uint8_t block_flags = flags | flags_start;
+
+  for (size_t block = 0; block < blocks; block++) {
+    if (block + 1 == blocks) {
+      block_flags |= flags_end;
+    }
+    svuint32_4_t block_len_vec = set1_128(BLAKE3_BLOCK_LEN);
+    svuint32_4_t block_flags_vec = set1_128(block_flags);
+    svuint32_4_t msg_vecs[16];
+    transpose_msg_vecs4(inputs, block * BLAKE3_BLOCK_LEN, msg_vecs);
+
+    svuint32_4_t v[16] = {
+        h_vecs[0],       h_vecs[1],        h_vecs[2],       h_vecs[3],
+        h_vecs[4],       h_vecs[5],        h_vecs[6],       h_vecs[7],
+        set1_128(IV[0]), set1_128(IV[1]),  set1_128(IV[2]), set1_128(IV[3]),
+        counter_low_vec, counter_high_vec, block_len_vec,   block_flags_vec,
+    };
+    round_fn4(v, msg_vecs, 0);
+    round_fn4(v, msg_vecs, 1);
+    round_fn4(v, msg_vecs, 2);
+    round_fn4(v, msg_vecs, 3);
+    round_fn4(v, msg_vecs, 4);
+    round_fn4(v, msg_vecs, 5);
+    round_fn4(v, msg_vecs, 6);
+    h_vecs[0] = xor_128(v[0], v[8]);
+    h_vecs[1] = xor_128(v[1], v[9]);
+    h_vecs[2] = xor_128(v[2], v[10]);
+    h_vecs[3] = xor_128(v[3], v[11]);
+    h_vecs[4] = xor_128(v[4], v[12]);
+    h_vecs[5] = xor_128(v[5], v[13]);
+    h_vecs[6] = xor_128(v[6], v[14]);
+    h_vecs[7] = xor_128(v[7], v[15]);
+
+    block_flags = flags;
+  }
+
+  transpose_vecs_128(&h_vecs[0]);
+  transpose_vecs_128(&h_vecs[4]);
+  // The first four vecs now contain the first half of each output, and the
+  // second four vecs contain the second half of each output.
+  storeu_128(h_vecs[0], &out[0 * sizeof(svuint32_4_t)]);
+  storeu_128(h_vecs[4], &out[1 * sizeof(svuint32_4_t)]);
+  storeu_128(h_vecs[1], &out[2 * sizeof(svuint32_4_t)]);
+  storeu_128(h_vecs[5], &out[3 * sizeof(svuint32_4_t)]);
+  storeu_128(h_vecs[2], &out[4 * sizeof(svuint32_4_t)]);
+  storeu_128(h_vecs[6], &out[5 * sizeof(svuint32_4_t)]);
+  storeu_128(h_vecs[3], &out[6 * sizeof(svuint32_4_t)]);
+  storeu_128(h_vecs[7], &out[7 * sizeof(svuint32_4_t)]);
+}
+
+/*
+ * ----------------------------------------------------------------------------
+ * hash_many_sve2
+ * ----------------------------------------------------------------------------
+ */
+
+void blake3_compress_in_place_portable(uint32_t cv[8],
+                                       const uint8_t block[BLAKE3_BLOCK_LEN],
+                                       uint8_t block_len, uint64_t counter,
+                                       uint8_t flags);
+
+// Same as hash_one_neon: there is no SIMD single-block compression on aarch64, so
+// the tail falls back to portable.
+INLINE void hash_one_sve2(const uint8_t *input, size_t blocks,
+                          const uint32_t key[8], uint64_t counter,
+                          uint8_t flags, uint8_t flags_start, uint8_t flags_end,
+                          uint8_t out[BLAKE3_OUT_LEN]) {
+  uint32_t cv[8];
+  memcpy(cv, key, BLAKE3_KEY_LEN);
+  uint8_t block_flags = flags | flags_start;
+  while (blocks > 0) {
+    if (blocks == 1) {
+      block_flags |= flags_end;
+    }
+    blake3_compress_in_place_portable(cv, input, BLAKE3_BLOCK_LEN, counter,
+                                      block_flags);
+    input = &input[BLAKE3_BLOCK_LEN];
+    blocks -= 1;
+    block_flags = flags;
+  }
+  memcpy(out, cv, BLAKE3_OUT_LEN);
+}
+
+void blake3_hash_many_sve2(const uint8_t *const *inputs, size_t num_inputs,
+                           size_t blocks, const uint32_t key[8],
+                           uint64_t counter, bool increment_counter,
+                           uint8_t flags, uint8_t flags_start,
+                           uint8_t flags_end, uint8_t *out) {
+  while (num_inputs >= 4) {
+    blake3_hash4_sve2(inputs, blocks, key, counter, increment_counter, flags,
+                      flags_start, flags_end, out);
+    if (increment_counter) {
+      counter += 4;
+    }
+    inputs += 4;
+    num_inputs -= 4;
+    out = &out[4 * BLAKE3_OUT_LEN];
+  }
+  while (num_inputs > 0) {
+    hash_one_sve2(inputs[0], blocks, key, counter, flags, flags_start,
+                  flags_end, out);
+    if (increment_counter) {
+      counter += 1;
+    }
+    inputs += 1;
+    num_inputs -= 1;
+    out = &out[BLAKE3_OUT_LEN];
+  }
+}

--- a/c/blake3_sve2.c
+++ b/c/blake3_sve2.c
@@ -1,6 +1,7 @@
+// Port of blake3_neon.c: each xor+rotate pair becomes one SVE2 XAR.
 #include "blake3_impl.h"
 
-#include <arm_neon.h>
+#include <arm_sve.h>
 
 #ifdef __ARM_BIG_ENDIAN
 #error "This implementation only supports little-endian ARM."
@@ -8,75 +9,62 @@
 // and stores right, but step zero would be finding a way to test it in CI.
 #endif
 
-INLINE uint32x4_t loadu_128(const uint8_t src[16]) {
-  // vld1q_u32 has alignment requirements. Don't use it.
-  return vreinterpretq_u32_u8(vld1q_u8(src));
-}
-
-INLINE void storeu_128(uint32x4_t src, uint8_t dest[16]) {
-  // vst1q_u32 has alignment requirements. Don't use it.
-  vst1q_u8(dest, vreinterpretq_u8_u32(src));
-}
-
-INLINE uint32x4_t add_128(uint32x4_t a, uint32x4_t b) {
-  return vaddq_u32(a, b);
-}
-
-INLINE uint32x4_t xor_128(uint32x4_t a, uint32x4_t b) {
-  return veorq_u32(a, b);
-}
-
-INLINE uint32x4_t set1_128(uint32_t x) { return vld1q_dup_u32(&x); }
-
-INLINE uint32x4_t set4(uint32_t a, uint32_t b, uint32_t c, uint32_t d) {
-  uint32_t array[4] = {a, b, c, d};
-  return vld1q_u32(array);
-}
-
-INLINE uint32x4_t rot16_128(uint32x4_t x) {
-  // The straightforward implementation would be two shifts and an or, but that's
-  // slower on microarchitectures we've tested. See
-  // https://github.com/BLAKE3-team/BLAKE3/pull/319.
-  // return vorrq_u32(vshrq_n_u32(x, 16), vshlq_n_u32(x, 32 - 16));
-  return vreinterpretq_u32_u16(vrev32q_u16(vreinterpretq_u16_u32(x)));
-}
-
-INLINE uint32x4_t rot12_128(uint32x4_t x) {
-  // See comment in rot16_128.
-  // return vorrq_u32(vshrq_n_u32(x, 12), vshlq_n_u32(x, 32 - 12));
-  return vsriq_n_u32(vshlq_n_u32(x, 32-12), x, 12);
-}
-
-INLINE uint32x4_t rot8_128(uint32x4_t x) {
-  // See comment in rot16_128.
-  // return vorrq_u32(vshrq_n_u32(x, 8), vshlq_n_u32(x, 32 - 8));
-#if defined(__clang__)
-  return vreinterpretq_u32_u8(__builtin_shufflevector(vreinterpretq_u8_u32(x), vreinterpretq_u8_u32(x), 1,2,3,0,5,6,7,4,9,10,11,8,13,14,15,12));
-#elif __GNUC__ * 10000 + __GNUC_MINOR__ * 100 >=40700
-  static const uint8x16_t r8 = {1,2,3,0,5,6,7,4,9,10,11,8,13,14,15,12};
-  return vreinterpretq_u32_u8(__builtin_shuffle(vreinterpretq_u8_u32(x), vreinterpretq_u8_u32(x), r8));
-#else 
-  return vsriq_n_u32(vshlq_n_u32(x, 32-8), x, 8);
+#if __ARM_FEATURE_SVE_BITS != 128
+#error "blake3_sve2.c must be compiled with -msve-vector-bits=128"
 #endif
+
+// Fixed-length types, so they can be array elements. Not svuint32x4_t: in
+// ACLE that name is a tuple of four vectors.
+typedef svuint32_t svuint32_4_t __attribute__((arm_sve_vector_bits(128)));
+typedef svuint64_t svuint64_2_t __attribute__((arm_sve_vector_bits(128)));
+
+INLINE svuint32_4_t loadu_128(const uint8_t src[16]) {
+  // Load bytes; casting an unaligned uint8_t pointer to uint32_t is undefined.
+  return svreinterpret_u32_u8(svld1_u8(svptrue_b8(), src));
 }
 
-INLINE uint32x4_t rot7_128(uint32x4_t x) {
-  // See comment in rot16_128.
-  // return vorrq_u32(vshrq_n_u32(x, 7), vshlq_n_u32(x, 32 - 7));
-  return vsriq_n_u32(vshlq_n_u32(x, 32-7), x, 7);
+INLINE void storeu_128(svuint32_4_t src, uint8_t dest[16]) {
+  svst1_u8(svptrue_b8(), dest, svreinterpret_u8_u32(src));
 }
 
-// TODO: compress_neon
+INLINE svuint32_4_t add_128(svuint32_4_t a, svuint32_4_t b) {
+  return svadd_u32_x(svptrue_b32(), a, b);
+}
 
-// TODO: hash2_neon
+INLINE svuint32_4_t xor_128(svuint32_4_t a, svuint32_4_t b) {
+  return sveor_u32_x(svptrue_b32(), a, b);
+}
+
+INLINE svuint32_4_t set1_128(uint32_t x) { return svdup_n_u32(x); }
+
+INLINE svuint32_4_t set4(uint32_t a, uint32_t b, uint32_t c, uint32_t d) {
+  uint32_t array[4] = {a, b, c, d};
+  return svld1_u32(svptrue_b32(), array);
+}
+
+INLINE svuint32_4_t xar16_128(svuint32_4_t a, svuint32_4_t b) {
+  return svxar_n_u32(a, b, 16);
+}
+
+INLINE svuint32_4_t xar12_128(svuint32_4_t a, svuint32_4_t b) {
+  return svxar_n_u32(a, b, 12);
+}
+
+INLINE svuint32_4_t xar8_128(svuint32_4_t a, svuint32_4_t b) {
+  return svxar_n_u32(a, b, 8);
+}
+
+INLINE svuint32_4_t xar7_128(svuint32_4_t a, svuint32_4_t b) {
+  return svxar_n_u32(a, b, 7);
+}
 
 /*
  * ----------------------------------------------------------------------------
- * hash4_neon
+ * hash4_sve2
  * ----------------------------------------------------------------------------
  */
 
-INLINE void round_fn4(uint32x4_t v[16], uint32x4_t m[16], size_t r) {
+INLINE void round_fn4(svuint32_4_t v[16], svuint32_4_t m[16], size_t r) {
   v[0] = add_128(v[0], m[(size_t)MSG_SCHEDULE[r][0]]);
   v[1] = add_128(v[1], m[(size_t)MSG_SCHEDULE[r][2]]);
   v[2] = add_128(v[2], m[(size_t)MSG_SCHEDULE[r][4]]);
@@ -85,26 +73,18 @@ INLINE void round_fn4(uint32x4_t v[16], uint32x4_t m[16], size_t r) {
   v[1] = add_128(v[1], v[5]);
   v[2] = add_128(v[2], v[6]);
   v[3] = add_128(v[3], v[7]);
-  v[12] = xor_128(v[12], v[0]);
-  v[13] = xor_128(v[13], v[1]);
-  v[14] = xor_128(v[14], v[2]);
-  v[15] = xor_128(v[15], v[3]);
-  v[12] = rot16_128(v[12]);
-  v[13] = rot16_128(v[13]);
-  v[14] = rot16_128(v[14]);
-  v[15] = rot16_128(v[15]);
+  v[12] = xar16_128(v[12], v[0]);
+  v[13] = xar16_128(v[13], v[1]);
+  v[14] = xar16_128(v[14], v[2]);
+  v[15] = xar16_128(v[15], v[3]);
   v[8] = add_128(v[8], v[12]);
   v[9] = add_128(v[9], v[13]);
   v[10] = add_128(v[10], v[14]);
   v[11] = add_128(v[11], v[15]);
-  v[4] = xor_128(v[4], v[8]);
-  v[5] = xor_128(v[5], v[9]);
-  v[6] = xor_128(v[6], v[10]);
-  v[7] = xor_128(v[7], v[11]);
-  v[4] = rot12_128(v[4]);
-  v[5] = rot12_128(v[5]);
-  v[6] = rot12_128(v[6]);
-  v[7] = rot12_128(v[7]);
+  v[4] = xar12_128(v[4], v[8]);
+  v[5] = xar12_128(v[5], v[9]);
+  v[6] = xar12_128(v[6], v[10]);
+  v[7] = xar12_128(v[7], v[11]);
   v[0] = add_128(v[0], m[(size_t)MSG_SCHEDULE[r][1]]);
   v[1] = add_128(v[1], m[(size_t)MSG_SCHEDULE[r][3]]);
   v[2] = add_128(v[2], m[(size_t)MSG_SCHEDULE[r][5]]);
@@ -113,26 +93,18 @@ INLINE void round_fn4(uint32x4_t v[16], uint32x4_t m[16], size_t r) {
   v[1] = add_128(v[1], v[5]);
   v[2] = add_128(v[2], v[6]);
   v[3] = add_128(v[3], v[7]);
-  v[12] = xor_128(v[12], v[0]);
-  v[13] = xor_128(v[13], v[1]);
-  v[14] = xor_128(v[14], v[2]);
-  v[15] = xor_128(v[15], v[3]);
-  v[12] = rot8_128(v[12]);
-  v[13] = rot8_128(v[13]);
-  v[14] = rot8_128(v[14]);
-  v[15] = rot8_128(v[15]);
+  v[12] = xar8_128(v[12], v[0]);
+  v[13] = xar8_128(v[13], v[1]);
+  v[14] = xar8_128(v[14], v[2]);
+  v[15] = xar8_128(v[15], v[3]);
   v[8] = add_128(v[8], v[12]);
   v[9] = add_128(v[9], v[13]);
   v[10] = add_128(v[10], v[14]);
   v[11] = add_128(v[11], v[15]);
-  v[4] = xor_128(v[4], v[8]);
-  v[5] = xor_128(v[5], v[9]);
-  v[6] = xor_128(v[6], v[10]);
-  v[7] = xor_128(v[7], v[11]);
-  v[4] = rot7_128(v[4]);
-  v[5] = rot7_128(v[5]);
-  v[6] = rot7_128(v[6]);
-  v[7] = rot7_128(v[7]);
+  v[4] = xar7_128(v[4], v[8]);
+  v[5] = xar7_128(v[5], v[9]);
+  v[6] = xar7_128(v[6], v[10]);
+  v[7] = xar7_128(v[7], v[11]);
 
   v[0] = add_128(v[0], m[(size_t)MSG_SCHEDULE[r][8]]);
   v[1] = add_128(v[1], m[(size_t)MSG_SCHEDULE[r][10]]);
@@ -142,26 +114,18 @@ INLINE void round_fn4(uint32x4_t v[16], uint32x4_t m[16], size_t r) {
   v[1] = add_128(v[1], v[6]);
   v[2] = add_128(v[2], v[7]);
   v[3] = add_128(v[3], v[4]);
-  v[15] = xor_128(v[15], v[0]);
-  v[12] = xor_128(v[12], v[1]);
-  v[13] = xor_128(v[13], v[2]);
-  v[14] = xor_128(v[14], v[3]);
-  v[15] = rot16_128(v[15]);
-  v[12] = rot16_128(v[12]);
-  v[13] = rot16_128(v[13]);
-  v[14] = rot16_128(v[14]);
+  v[15] = xar16_128(v[15], v[0]);
+  v[12] = xar16_128(v[12], v[1]);
+  v[13] = xar16_128(v[13], v[2]);
+  v[14] = xar16_128(v[14], v[3]);
   v[10] = add_128(v[10], v[15]);
   v[11] = add_128(v[11], v[12]);
   v[8] = add_128(v[8], v[13]);
   v[9] = add_128(v[9], v[14]);
-  v[5] = xor_128(v[5], v[10]);
-  v[6] = xor_128(v[6], v[11]);
-  v[7] = xor_128(v[7], v[8]);
-  v[4] = xor_128(v[4], v[9]);
-  v[5] = rot12_128(v[5]);
-  v[6] = rot12_128(v[6]);
-  v[7] = rot12_128(v[7]);
-  v[4] = rot12_128(v[4]);
+  v[5] = xar12_128(v[5], v[10]);
+  v[6] = xar12_128(v[6], v[11]);
+  v[7] = xar12_128(v[7], v[8]);
+  v[4] = xar12_128(v[4], v[9]);
   v[0] = add_128(v[0], m[(size_t)MSG_SCHEDULE[r][9]]);
   v[1] = add_128(v[1], m[(size_t)MSG_SCHEDULE[r][11]]);
   v[2] = add_128(v[2], m[(size_t)MSG_SCHEDULE[r][13]]);
@@ -170,62 +134,57 @@ INLINE void round_fn4(uint32x4_t v[16], uint32x4_t m[16], size_t r) {
   v[1] = add_128(v[1], v[6]);
   v[2] = add_128(v[2], v[7]);
   v[3] = add_128(v[3], v[4]);
-  v[15] = xor_128(v[15], v[0]);
-  v[12] = xor_128(v[12], v[1]);
-  v[13] = xor_128(v[13], v[2]);
-  v[14] = xor_128(v[14], v[3]);
-  v[15] = rot8_128(v[15]);
-  v[12] = rot8_128(v[12]);
-  v[13] = rot8_128(v[13]);
-  v[14] = rot8_128(v[14]);
+  v[15] = xar8_128(v[15], v[0]);
+  v[12] = xar8_128(v[12], v[1]);
+  v[13] = xar8_128(v[13], v[2]);
+  v[14] = xar8_128(v[14], v[3]);
   v[10] = add_128(v[10], v[15]);
   v[11] = add_128(v[11], v[12]);
   v[8] = add_128(v[8], v[13]);
   v[9] = add_128(v[9], v[14]);
-  v[5] = xor_128(v[5], v[10]);
-  v[6] = xor_128(v[6], v[11]);
-  v[7] = xor_128(v[7], v[8]);
-  v[4] = xor_128(v[4], v[9]);
-  v[5] = rot7_128(v[5]);
-  v[6] = rot7_128(v[6]);
-  v[7] = rot7_128(v[7]);
-  v[4] = rot7_128(v[4]);
+  v[5] = xar7_128(v[5], v[10]);
+  v[6] = xar7_128(v[6], v[11]);
+  v[7] = xar7_128(v[7], v[8]);
+  v[4] = xar7_128(v[4], v[9]);
 }
 
-INLINE void transpose_vecs_128(uint32x4_t vecs[4]) {
+INLINE void transpose_vecs_128(svuint32_4_t vecs[4]) {
   // Individually transpose the four 2x2 sub-matrices in each corner.
-  uint32x4x2_t rows01 = vtrnq_u32(vecs[0], vecs[1]);
-  uint32x4x2_t rows23 = vtrnq_u32(vecs[2], vecs[3]);
+  svuint32_4_t t0 = svtrn1_u32(vecs[0], vecs[1]);
+  svuint32_4_t t1 = svtrn2_u32(vecs[0], vecs[1]);
+  svuint32_4_t t2 = svtrn1_u32(vecs[2], vecs[3]);
+  svuint32_4_t t3 = svtrn2_u32(vecs[2], vecs[3]);
 
   // Swap the top-right and bottom-left 2x2s (which just got transposed).
-  vecs[0] =
-      vcombine_u32(vget_low_u32(rows01.val[0]), vget_low_u32(rows23.val[0]));
-  vecs[1] =
-      vcombine_u32(vget_low_u32(rows01.val[1]), vget_low_u32(rows23.val[1]));
-  vecs[2] =
-      vcombine_u32(vget_high_u32(rows01.val[0]), vget_high_u32(rows23.val[0]));
-  vecs[3] =
-      vcombine_u32(vget_high_u32(rows01.val[1]), vget_high_u32(rows23.val[1]));
+  svuint64_2_t a0 = svreinterpret_u64_u32(t0);
+  svuint64_2_t a1 = svreinterpret_u64_u32(t1);
+  svuint64_2_t a2 = svreinterpret_u64_u32(t2);
+  svuint64_2_t a3 = svreinterpret_u64_u32(t3);
+
+  vecs[0] = svreinterpret_u32_u64(svzip1_u64(a0, a2));
+  vecs[1] = svreinterpret_u32_u64(svzip1_u64(a1, a3));
+  vecs[2] = svreinterpret_u32_u64(svzip2_u64(a0, a2));
+  vecs[3] = svreinterpret_u32_u64(svzip2_u64(a1, a3));
 }
 
 INLINE void transpose_msg_vecs4(const uint8_t *const *inputs,
-                                size_t block_offset, uint32x4_t out[16]) {
-  out[0] = loadu_128(&inputs[0][block_offset + 0 * sizeof(uint32x4_t)]);
-  out[1] = loadu_128(&inputs[1][block_offset + 0 * sizeof(uint32x4_t)]);
-  out[2] = loadu_128(&inputs[2][block_offset + 0 * sizeof(uint32x4_t)]);
-  out[3] = loadu_128(&inputs[3][block_offset + 0 * sizeof(uint32x4_t)]);
-  out[4] = loadu_128(&inputs[0][block_offset + 1 * sizeof(uint32x4_t)]);
-  out[5] = loadu_128(&inputs[1][block_offset + 1 * sizeof(uint32x4_t)]);
-  out[6] = loadu_128(&inputs[2][block_offset + 1 * sizeof(uint32x4_t)]);
-  out[7] = loadu_128(&inputs[3][block_offset + 1 * sizeof(uint32x4_t)]);
-  out[8] = loadu_128(&inputs[0][block_offset + 2 * sizeof(uint32x4_t)]);
-  out[9] = loadu_128(&inputs[1][block_offset + 2 * sizeof(uint32x4_t)]);
-  out[10] = loadu_128(&inputs[2][block_offset + 2 * sizeof(uint32x4_t)]);
-  out[11] = loadu_128(&inputs[3][block_offset + 2 * sizeof(uint32x4_t)]);
-  out[12] = loadu_128(&inputs[0][block_offset + 3 * sizeof(uint32x4_t)]);
-  out[13] = loadu_128(&inputs[1][block_offset + 3 * sizeof(uint32x4_t)]);
-  out[14] = loadu_128(&inputs[2][block_offset + 3 * sizeof(uint32x4_t)]);
-  out[15] = loadu_128(&inputs[3][block_offset + 3 * sizeof(uint32x4_t)]);
+                                size_t block_offset, svuint32_4_t out[16]) {
+  out[0] = loadu_128(&inputs[0][block_offset + 0 * sizeof(svuint32_4_t)]);
+  out[1] = loadu_128(&inputs[1][block_offset + 0 * sizeof(svuint32_4_t)]);
+  out[2] = loadu_128(&inputs[2][block_offset + 0 * sizeof(svuint32_4_t)]);
+  out[3] = loadu_128(&inputs[3][block_offset + 0 * sizeof(svuint32_4_t)]);
+  out[4] = loadu_128(&inputs[0][block_offset + 1 * sizeof(svuint32_4_t)]);
+  out[5] = loadu_128(&inputs[1][block_offset + 1 * sizeof(svuint32_4_t)]);
+  out[6] = loadu_128(&inputs[2][block_offset + 1 * sizeof(svuint32_4_t)]);
+  out[7] = loadu_128(&inputs[3][block_offset + 1 * sizeof(svuint32_4_t)]);
+  out[8] = loadu_128(&inputs[0][block_offset + 2 * sizeof(svuint32_4_t)]);
+  out[9] = loadu_128(&inputs[1][block_offset + 2 * sizeof(svuint32_4_t)]);
+  out[10] = loadu_128(&inputs[2][block_offset + 2 * sizeof(svuint32_4_t)]);
+  out[11] = loadu_128(&inputs[3][block_offset + 2 * sizeof(svuint32_4_t)]);
+  out[12] = loadu_128(&inputs[0][block_offset + 3 * sizeof(svuint32_4_t)]);
+  out[13] = loadu_128(&inputs[1][block_offset + 3 * sizeof(svuint32_4_t)]);
+  out[14] = loadu_128(&inputs[2][block_offset + 3 * sizeof(svuint32_4_t)]);
+  out[15] = loadu_128(&inputs[3][block_offset + 3 * sizeof(svuint32_4_t)]);
   transpose_vecs_128(&out[0]);
   transpose_vecs_128(&out[4]);
   transpose_vecs_128(&out[8]);
@@ -233,7 +192,7 @@ INLINE void transpose_msg_vecs4(const uint8_t *const *inputs,
 }
 
 INLINE void load_counters4(uint64_t counter, bool increment_counter,
-                           uint32x4_t *out_low, uint32x4_t *out_high) {
+                           svuint32_4_t *out_low, svuint32_4_t *out_high) {
   uint64_t mask = (increment_counter ? ~0 : 0);
   *out_low = set4(
       counter_low(counter + (mask & 0)), counter_low(counter + (mask & 1)),
@@ -243,16 +202,16 @@ INLINE void load_counters4(uint64_t counter, bool increment_counter,
       counter_high(counter + (mask & 2)), counter_high(counter + (mask & 3)));
 }
 
-static void blake3_hash4_neon(const uint8_t *const *inputs, size_t blocks,
+static void blake3_hash4_sve2(const uint8_t *const *inputs, size_t blocks,
                               const uint32_t key[8], uint64_t counter,
                               bool increment_counter, uint8_t flags,
                               uint8_t flags_start, uint8_t flags_end, 
                               uint8_t *out) {
-  uint32x4_t h_vecs[8] = {
+  svuint32_4_t h_vecs[8] = {
       set1_128(key[0]), set1_128(key[1]), set1_128(key[2]), set1_128(key[3]),
       set1_128(key[4]), set1_128(key[5]), set1_128(key[6]), set1_128(key[7]),
   };
-  uint32x4_t counter_low_vec, counter_high_vec;
+  svuint32_4_t counter_low_vec, counter_high_vec;
   load_counters4(counter, increment_counter, &counter_low_vec,
                  &counter_high_vec);
   uint8_t block_flags = flags | flags_start;
@@ -261,12 +220,12 @@ static void blake3_hash4_neon(const uint8_t *const *inputs, size_t blocks,
     if (block + 1 == blocks) {
       block_flags |= flags_end;
     }
-    uint32x4_t block_len_vec = set1_128(BLAKE3_BLOCK_LEN);
-    uint32x4_t block_flags_vec = set1_128(block_flags);
-    uint32x4_t msg_vecs[16];
+    svuint32_4_t block_len_vec = set1_128(BLAKE3_BLOCK_LEN);
+    svuint32_4_t block_flags_vec = set1_128(block_flags);
+    svuint32_4_t msg_vecs[16];
     transpose_msg_vecs4(inputs, block * BLAKE3_BLOCK_LEN, msg_vecs);
 
-    uint32x4_t v[16] = {
+    svuint32_4_t v[16] = {
         h_vecs[0],       h_vecs[1],        h_vecs[2],       h_vecs[3],
         h_vecs[4],       h_vecs[5],        h_vecs[6],       h_vecs[7],
         set1_128(IV[0]), set1_128(IV[1]),  set1_128(IV[2]), set1_128(IV[3]),
@@ -295,19 +254,19 @@ static void blake3_hash4_neon(const uint8_t *const *inputs, size_t blocks,
   transpose_vecs_128(&h_vecs[4]);
   // The first four vecs now contain the first half of each output, and the
   // second four vecs contain the second half of each output.
-  storeu_128(h_vecs[0], &out[0 * sizeof(uint32x4_t)]);
-  storeu_128(h_vecs[4], &out[1 * sizeof(uint32x4_t)]);
-  storeu_128(h_vecs[1], &out[2 * sizeof(uint32x4_t)]);
-  storeu_128(h_vecs[5], &out[3 * sizeof(uint32x4_t)]);
-  storeu_128(h_vecs[2], &out[4 * sizeof(uint32x4_t)]);
-  storeu_128(h_vecs[6], &out[5 * sizeof(uint32x4_t)]);
-  storeu_128(h_vecs[3], &out[6 * sizeof(uint32x4_t)]);
-  storeu_128(h_vecs[7], &out[7 * sizeof(uint32x4_t)]);
+  storeu_128(h_vecs[0], &out[0 * sizeof(svuint32_4_t)]);
+  storeu_128(h_vecs[4], &out[1 * sizeof(svuint32_4_t)]);
+  storeu_128(h_vecs[1], &out[2 * sizeof(svuint32_4_t)]);
+  storeu_128(h_vecs[5], &out[3 * sizeof(svuint32_4_t)]);
+  storeu_128(h_vecs[2], &out[4 * sizeof(svuint32_4_t)]);
+  storeu_128(h_vecs[6], &out[5 * sizeof(svuint32_4_t)]);
+  storeu_128(h_vecs[3], &out[6 * sizeof(svuint32_4_t)]);
+  storeu_128(h_vecs[7], &out[7 * sizeof(svuint32_4_t)]);
 }
 
 /*
  * ----------------------------------------------------------------------------
- * hash_many_neon
+ * hash_many_sve2
  * ----------------------------------------------------------------------------
  */
 
@@ -316,7 +275,7 @@ void blake3_compress_in_place_portable(uint32_t cv[8],
                                        uint8_t block_len, uint64_t counter,
                                        uint8_t flags);
 
-INLINE void hash_one_neon(const uint8_t *input, size_t blocks,
+INLINE void hash_one_sve2(const uint8_t *input, size_t blocks,
                           const uint32_t key[8], uint64_t counter,
                           uint8_t flags, uint8_t flags_start, uint8_t flags_end,
                           uint8_t out[BLAKE3_OUT_LEN]) {
@@ -327,9 +286,6 @@ INLINE void hash_one_neon(const uint8_t *input, size_t blocks,
     if (blocks == 1) {
       block_flags |= flags_end;
     }
-    // TODO: Implement compress_neon. However note that according to
-    // https://github.com/BLAKE2/BLAKE2/commit/7965d3e6e1b4193438b8d3a656787587d2579227,
-    // compress_neon might not be any faster than compress_portable.
     blake3_compress_in_place_portable(cv, input, BLAKE3_BLOCK_LEN, counter,
                                       block_flags);
     input = &input[BLAKE3_BLOCK_LEN];
@@ -339,13 +295,13 @@ INLINE void hash_one_neon(const uint8_t *input, size_t blocks,
   memcpy(out, cv, BLAKE3_OUT_LEN);
 }
 
-void blake3_hash_many_neon(const uint8_t *const *inputs, size_t num_inputs,
+void blake3_hash_many_sve2(const uint8_t *const *inputs, size_t num_inputs,
                            size_t blocks, const uint32_t key[8],
                            uint64_t counter, bool increment_counter,
                            uint8_t flags, uint8_t flags_start,
                            uint8_t flags_end, uint8_t *out) {
   while (num_inputs >= 4) {
-    blake3_hash4_neon(inputs, blocks, key, counter, increment_counter, flags,
+    blake3_hash4_sve2(inputs, blocks, key, counter, increment_counter, flags,
                       flags_start, flags_end, out);
     if (increment_counter) {
       counter += 4;
@@ -355,7 +311,7 @@ void blake3_hash_many_neon(const uint8_t *const *inputs, size_t num_inputs,
     out = &out[4 * BLAKE3_OUT_LEN];
   }
   while (num_inputs > 0) {
-    hash_one_neon(inputs[0], blocks, key, counter, flags, flags_start,
+    hash_one_sve2(inputs[0], blocks, key, counter, flags, flags_start,
                   flags_end, out);
     if (increment_counter) {
       counter += 1;


### PR DESCRIPTION
SVE2 adds `XAR`, which computes `rotr(a ^ b, imm)` in one instruction. BLAKE3's G function does exactly that eight times per round, and on NEON each one takes two or three instructions (`EOR`, then `REV32`, `TBL`, or `SHL`+`SRI`), so `round_fn4` goes from 128 vector instructions to 80 at the same 128-bit width.

This adds `blake3_sve2.c`, a copy of `blake3_neon.c` with those pairs fused, opt-in via `BLAKE3_USE_SVE2` and off by default. It is built with `-msve-vector-bits=128` because every SVE2 core shipping today is 128 bits wide, and `blake3_dispatch.c` checks `HWCAP2_SVE2` and the runtime vector length before using it, falling back to NEON otherwise.

`cargo +nightly bench --features=neon,sve2 many_` in `c/blake3_c_rust_bindings`, single-threaded, MB/s:

| | chunks NEON | chunks SVE2 | parents NEON | parents SVE2 |
|---|---|---|---|---|
| Neoverse N2 (GitHub `ubuntu-24.04-arm`) | 1557 | 2227 (1.43x) | 1354 | 1790 (1.33x) |
| Neoverse V2 (Graviton4, `m8g.large`) | 1540 | 2032 (1.32x) | 1347 | 1684 (1.25x) |
| Neoverse V3 (Graviton5, `m9g.large`) | 1827 | 3271 (1.79x) | 1630 | 2666 (1.70x) |

The Rust crate still uses NEON on AArch64; if this is merged, I will wire SVE2 into it in a follow-up PR.
