### PR TITLE
use `seek` instead of `metadata` to establish mmap length

### DIFF
--- a/b3sum/tests/cli_tests.rs
+++ b/b3sum/tests/cli_tests.rs
@@ -216,6 +216,18 @@ fn test_no_mmap() {
 }
 
 #[test]
+#[cfg(windows)]
+fn test_null_device_on_windows() {
+    let expected = blake3::hash(b"").to_hex();
+    let output = cmd!(b3sum_exe(), "--no-names", "NUL").read().unwrap();
+    assert_eq!(&*expected, output);
+    let output = cmd!(b3sum_exe(), "--no-names", "--no-mmap", "NUL")
+        .read()
+        .unwrap();
+    assert_eq!(&*expected, output);
+}
+
+#[test]
 fn test_length_without_value_is_an_error() {
     let result = cmd!(b3sum_exe(), "--length")
         .stdin_bytes("foo")

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,10 +1,13 @@
 //! Helper functions for efficient IO.
 
-#[cfg(feature = "std")]
-pub(crate) fn copy_wide(
-    mut reader: impl std::io::Read,
-    hasher: &mut crate::Hasher,
-) -> std::io::Result<u64> {
+#[cfg(feature = "mmap")]
+use std::fs::File;
+use std::io;
+
+#[cfg(feature = "mmap")]
+const MINIMUM_MMAP_SIZE: u64 = 16 * 1024; // 16 KiB
+
+pub(crate) fn copy_wide(mut reader: impl io::Read, hasher: &mut crate::Hasher) -> io::Result<u64> {
     let mut buffer = [0; 65536];
     let mut total = 0;
     loop {
@@ -15,15 +18,23 @@ pub(crate) fn copy_wide(
                 total += n as u64;
             }
             // see test_update_reader_interrupted
-            Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
             Err(e) => return Err(e),
         }
     }
 }
 
-// Mmap a file, if it looks like a good idea. Return None in cases where we know mmap will fail, or
-// if the file is short enough that mmapping isn't worth it. However, if we do try to mmap and it
-// fails, return the error.
+// Try to `mmap` a file, unless it's short enough that ordinary reads are faster, currently 16 KiB.
+// Return `Ok(None)` if mapping fails or if we don't attempt it. Only return `Err` for unexpected
+// failures that could leave the `File` in a bad state.
+//
+// We seek to (near) end-of-file to get the length, and the prior cursor position is ignored. If
+// mapping fails, we [`rewind`] the file cursor to start-of-file before returning `None`. We don't
+// `rewind` if the mapping succeeds, however, to avoid unnecessary syscalls. In the unlikely event
+// that the caller wants to do ordinary reads in addition to mapped reads, they need to `rewind`
+// explicitly in that case. (This function isn't public, but that comes up in test cases.)
+//
+// [`rewind`]: https://doc.rust-lang.org/std/io/trait.Seek.html#method.rewind
 //
 // SAFETY: Mmaps are fundamentally unsafe, because you can call invariant-checking functions like
 // str::from_utf8 on them and then have them change out from under you. Letting a safe caller get
@@ -47,18 +58,150 @@ pub(crate) fn copy_wide(
 // But if you "know what you're doing," I don't think *const i32 and &i32 are fundamentally
 // different here. Feedback needed.
 #[cfg(feature = "mmap")]
-pub(crate) fn maybe_mmap_file(file: &std::fs::File) -> std::io::Result<Option<memmap2::Mmap>> {
-    let metadata = file.metadata()?;
-    let file_size = metadata.len();
-    if !metadata.is_file() {
-        // Not a real file.
-        Ok(None)
-    } else if file_size < 16 * 1024 {
-        // Mapping small files is not worth it, and some special files that can't be mapped report
-        // a size of zero.
-        Ok(None)
-    } else {
-        let map = unsafe { memmap2::Mmap::map(file)? };
-        Ok(Some(map))
+pub(crate) fn maybe_mmap_file(file: &mut File) -> io::Result<Option<memmap2::Mmap>> {
+    // Seeking is more reliable than `.metadata()` for getting the length. Either is valid for
+    // regular files, but block devices sometimes report zero length despite being mappable. See
+    // https://github.com/BLAKE3-team/BLAKE3/pull/487.
+    use io::Seek;
+    // In debug mode only, check that the cursor is at the beginning. If the seek below fails,
+    // we'll leave the cursor where it is, and that can be confusing if it isn't at the beginning.
+    // (This function isn't public, but this comes up in test cases.)
+    if cfg!(debug_assertions) {
+        if let Ok(position) = file.stream_position() {
+            assert_eq!(position, 0, "initial file offset isn't at the beginning");
+        }
+    }
+    // Seek to "16 KiB less 1 byte" from end-of-file. For short files, this will generally fail
+    // with an invalid argument error and leave the cursor at the beginning. For a regular file of
+    // exactly 16383 bytes, it will succeed and return 0, again leaving the cursor at the
+    // beginning. For some special/device files like /dev/random, it will also return 0. In all
+    // those cases, we can return without doing any extra syscalls to reset the cursor, and let the
+    // caller fall back to ordinary reads.
+    let seek_offset = MINIMUM_MMAP_SIZE - 1;
+    let seek_target = io::SeekFrom::End(-(seek_offset as i64));
+    let Ok(offset_len) = file.seek(seek_target) else {
+        return Ok(None); // short or unseekable files
+    };
+    if offset_len == 0 {
+        return Ok(None); // either exactly 16383 bytes, or e.g. /dev/random
+    }
+    // It's UB to produce a slice longer than `isize::MAX`. `memmap2` checks that internally, so
+    // it's kind of redundant to check it here, but we need to guard the `usize` cast in any case.
+    if offset_len <= isize::MAX as u64 - seek_offset {
+        // We have a seekable file that's long enough to be worth mapping, but not too long to map
+        // (e.g. on a 32-bit system). Try to map it. If this succeeds, we'll assume the caller
+        // isn't going to do any ordinary reads, so we don't need to `rewind`.
+        let mut mmap_options = memmap2::MmapOptions::new();
+        mmap_options.len((offset_len + seek_offset) as usize); // checked above
+        if let Ok(mmap) = unsafe { mmap_options.map(&*file) } {
+            return Ok(Some(mmap));
+        }
+    }
+    // `mmap` failed (or would've failed), so we need to `rewind` and let the caller do ordinary
+    // reads. This is the only failure case where we return `Err`, since if it does fail somehow
+    // (not clear if that's possible in practice), the file cursor position will be wrong.
+    file.rewind()?;
+    Ok(None)
+}
+
+#[cfg(all(test, feature = "mmap"))]
+mod test {
+    use super::*;
+    use std::io;
+    use std::io::prelude::*;
+
+    #[test]
+    fn test_maybe_mmap_small_files() -> io::Result<()> {
+        let test_cases = [0, 1, MINIMUM_MMAP_SIZE - 2, MINIMUM_MMAP_SIZE - 1];
+        for len in test_cases {
+            dbg!(len);
+            // Create a file smaller than 16 KiB. `maybe_mmap_file` should return `Ok(None)`.
+            let mut input = vec![0; len as usize];
+            crate::test::paint_test_input(&mut input);
+            let mut f = tempfile::NamedTempFile::new()?;
+            f.write_all(&input)?;
+            f.flush()?;
+            // We have a debug assert that the initial file offset is 0.
+            f.rewind()?;
+            assert!(maybe_mmap_file(f.as_file_mut())?.is_none());
+            // Check that the file cursor got rewound to start-of-file.
+            assert_eq!(
+                crate::hash(&input),
+                crate::Hasher::new()
+                    .update_reader(f.as_file_mut())?
+                    .finalize(),
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_maybe_mmap_mappable_files() -> io::Result<()> {
+        let test_cases = [MINIMUM_MMAP_SIZE, MINIMUM_MMAP_SIZE + 1];
+        for len in test_cases {
+            dbg!(len);
+            // Create a file that's 16 KiB or larger. `maybe_mmap_file` should return `Ok(Some(_))`.
+            let mut input = vec![0; len as usize];
+            crate::test::paint_test_input(&mut input);
+            let mut f = tempfile::NamedTempFile::new()?;
+            f.write_all(&input)?;
+            f.flush()?;
+            // We have a debug assert that the initial file offset is 0.
+            f.rewind()?;
+            let Ok(Some(mmap)) = maybe_mmap_file(f.as_file_mut()) else {
+                panic!("mmap failed");
+            };
+            // `maybe_mmap_file` doesn't `rewind` the file in this case, so we need to do that
+            // ourselves.
+            assert_ne!(f.stream_position()?, 0);
+            f.rewind()?;
+            assert_eq!(mmap[..], input[..]);
+            assert_eq!(crate::hash(&input), crate::hash(&mmap));
+            assert_eq!(
+                crate::hash(&input),
+                crate::Hasher::new()
+                    .update_reader(f.as_file_mut())?
+                    .finalize(),
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_maybe_mmap_current_exe() -> io::Result<()> {
+        // The current executable should always be a regular file larger than 16 KiB, so mmap
+        // should ~always succeed. (A filesystem might not support mmap at all, but we don't test
+        // any of those in CI.)
+        let mut exe_file = File::open(std::env::current_exe()?)?;
+        assert!(exe_file.metadata()?.len() > MINIMUM_MMAP_SIZE);
+        let mmap = maybe_mmap_file(&mut exe_file)?.expect("maybe_mmap_file should return Some");
+        // Mainly we're testing that we got `Some` above, but go ahead and read the mmap just to
+        // make sure it doesn't bus fault or anything like that. `maybe_mmap_file` doesn't `rewind`
+        // the file in this case, so we need to do that ourselves.
+        exe_file.rewind()?;
+        assert_eq!(
+            crate::hash(&mmap),
+            crate::Hasher::new().update_reader(&exe_file)?.finalize(),
+        );
+        Ok(())
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_unmappable_linux() -> io::Result<()> {
+        // I'm not aware of any similarly unmappable paths on macOS or Windows, so this test is
+        // Linux-only for now.
+        let unmappable_path = "/sys/kernel/btf/vmlinux";
+        let mut unmappable_file = File::open(unmappable_path)?;
+        // The file is large enough to attempt mmapping.
+        assert!(unmappable_file.metadata()?.len() > MINIMUM_MMAP_SIZE);
+        // We're allowed to read the file.
+        assert_eq!(unmappable_file.read(&mut [0])?, 1);
+        // But mmapping the file fails. (We have a debug assert that requires `rewind` here.)
+        unmappable_file.rewind()?;
+        unsafe { memmap2::Mmap::map(&unmappable_file) }.unwrap_err();
+        // `maybe_mmap_file` swallows that error and returns `None`.
+        assert!(maybe_mmap_file(&mut unmappable_file)?.is_none());
+        Ok(())
     }
 }

--- a/src/io.rs
+++ b/src/io.rs
@@ -124,7 +124,8 @@ mod test {
             // We have a debug assert that the initial file offset is 0.
             f.rewind()?;
             assert!(maybe_mmap_file(f.as_file_mut())?.is_none());
-            // Check that the file cursor got rewound to start-of-file.
+            // Check that the file cursor remains at start-of-file.
+            assert_eq!(f.stream_position()?, 0);
             assert_eq!(
                 crate::hash(&input),
                 crate::Hasher::new()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,6 +135,7 @@ mod wasm32_simd;
 #[cfg(feature = "traits-preview")]
 pub mod traits;
 
+#[cfg(feature = "std")]
 mod io;
 mod join;
 
@@ -1541,8 +1542,8 @@ impl Hasher {
     /// ```
     #[cfg(feature = "mmap")]
     pub fn update_mmap(&mut self, path: impl AsRef<std::path::Path>) -> std::io::Result<&mut Self> {
-        let file = std::fs::File::open(path.as_ref())?;
-        if let Some(mmap) = io::maybe_mmap_file(&file)? {
+        let mut file = std::fs::File::open(path.as_ref())?;
+        if let Some(mmap) = io::maybe_mmap_file(&mut file)? {
             self.update(&mmap);
         } else {
             io::copy_wide(&file, self)?;
@@ -1596,8 +1597,8 @@ impl Hasher {
         &mut self,
         path: impl AsRef<std::path::Path>,
     ) -> std::io::Result<&mut Self> {
-        let file = std::fs::File::open(path.as_ref())?;
-        if let Some(mmap) = io::maybe_mmap_file(&file)? {
+        let mut file = std::fs::File::open(path.as_ref())?;
+        if let Some(mmap) = io::maybe_mmap_file(&mut file)? {
             self.update_rayon(&mmap);
         } else {
             io::copy_wide(&file, self)?;

--- a/src/test.rs
+++ b/src/test.rs
@@ -915,9 +915,6 @@ fn test_mmap() -> Result<(), std::io::Error> {
 fn test_mmap_virtual_file() -> Result<(), std::io::Error> {
     // Virtual files like /proc/version can't be mmapped, because their contents don't actually
     // exist anywhere in memory. Make sure we fall back to regular file IO in these cases.
-    // Currently this is handled with a length check, where the assumption is that virtual files
-    // will always report length 0. If that assumption ever breaks, hopefully this test will catch
-    // it.
     let virtual_filepath = "/proc/version";
     let mut mmap_hasher = crate::Hasher::new();
     // We'll fail right here if the fallback doesn't work.


### PR DESCRIPTION
Originally suggested by @nabijaczleweli in https://github.com/BLAKE3-team/BLAKE3/pull/487. The main motivation here is that seeking to EOF is more reliable than `.metadata()` at identifying things that can be memory mapped, particularly block devices. However, that also means we need to be more tolerant of IO errors, because it's more common for a file to be not-seekable than not-metadata-able.

This PR uses a cute trick to avoid an extra syscall when files are short. Codex gets credit for thinking of this. Rather than seeking to EOF, we seek to (EOF-16383). That means that for short files, the seek either succeeds (if the length is exactly 16383) or fails (if it's less) but either way leaves the file cursor at 0, so we don't need to `rewind` it. For larger files, we're going to `mmap` them anyway, so we don't care where the cursor is. We do need to `rewind` if the `mmap` fails though.

This happens to fix a bug (arguably) that I didn't know we had on Windows. Both `metadata` and `seek` fail on Windows when you're working with the `NUL` special file. Previously:

```
> b3sum NUL
b3sum: NUL: Incorrect function. (os error 1)
```

With this change:

```
> b3sum NUL
af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262  NUL
```