### PR TITLE
Enable supported SIMD backends under Miri

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -476,7 +476,23 @@ jobs:
     # Currently the test search "miri" only matches "test_miri_smoketest", but
     # we might add more. If this accidentally picks up anything incompatible or
     # slow, we can narrow it.
-    - run: cargo miri test miri
+
+    # build.rs selects Rust intrinsics under Miri and skips C/assembly backends.
+    # Wasm SIMD remains unselected because Miri does not support its intrinsics.
+    - name: x86-64 portable
+      run: cargo miri test miri --target x86_64-unknown-linux-gnu --features no_sse2
+    - name: x86-64 SSE2
+      run: cargo miri test miri --target x86_64-unknown-linux-gnu
+    - name: x86-64 SSE4.1
+      env:
+        RUSTFLAGS: -C target-feature=+sse4.1
+      run: cargo miri test miri --target x86_64-unknown-linux-gnu
+    - name: x86-64 AVX2
+      env:
+        RUSTFLAGS: -C target-feature=+avx2
+      run: cargo miri test miri --target x86_64-unknown-linux-gnu
+    - name: aarch64 portable
+      run: cargo miri test miri --target aarch64-unknown-linux-gnu
 
   tbb_rust_bindings_tests:
     name: TBB test bindings ${{ matrix.os }}

--- a/build.rs
+++ b/build.rs
@@ -9,6 +9,10 @@ fn is_pure() -> bool {
     defined("CARGO_FEATURE_PURE")
 }
 
+fn is_miri() -> bool {
+    env::var_os("CARGO_CFG_MIRI").is_some()
+}
+
 fn should_prefer_intrinsics() -> bool {
     defined("CARGO_FEATURE_PREFER_INTRINSICS")
 }
@@ -159,6 +163,11 @@ enum CCompilerSupport {
 use CCompilerSupport::*;
 
 fn c_compiler_support() -> CCompilerSupport {
+    // Miri cannot execute this crate's C/assembly backends.
+    if is_miri() {
+        return NoCompiler;
+    }
+
     let build = new_build();
     let flags_checked;
     let support_result: Result<bool, _> = if is_windows_msvc() {
@@ -363,14 +372,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         panic!("The NEON implementation doesn't support big-endian ARM.")
     }
 
-    if (is_arm() && is_neon())
-        || (!is_no_neon() && !is_pure() && is_aarch64() && is_little_endian())
+    // Miri cannot execute this crate's C NEON backend.
+    if !is_miri()
+        && ((is_arm() && is_neon())
+            || (!is_no_neon() && !is_pure() && is_aarch64() && is_little_endian()))
     {
         println!("cargo::rustc-cfg=blake3_neon");
         build_neon_c_intrinsics();
     }
 
-    if is_wasm32() && is_wasm32_simd() {
+    // Miri does not support the Wasm SIMD intrinsic calls used by this crate.
+    if !is_miri() && is_wasm32() && is_wasm32_simd() {
         build_wasm32_simd();
     }
 

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -63,11 +63,6 @@ pub enum Platform {
 impl Platform {
     #[allow(unreachable_code)]
     pub fn detect() -> Self {
-        #[cfg(miri)]
-        {
-            return Platform::Portable;
-        }
-
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         {
             #[cfg(blake3_avx512_ffi)]
@@ -409,10 +404,6 @@ impl Platform {
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[inline(always)]
 pub fn avx512_detected() -> bool {
-    if cfg!(miri) {
-        return false;
-    }
-
     // A testing-only short-circuit.
     if cfg!(feature = "no_avx512") {
         return false;
@@ -425,13 +416,13 @@ pub fn avx512_detected() -> bool {
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[inline(always)]
 pub fn avx2_detected() -> bool {
-    if cfg!(miri) {
-        return false;
-    }
-
     // A testing-only short-circuit.
     if cfg!(feature = "no_avx2") {
         return false;
+    }
+
+    if cfg!(target_feature = "avx2") {
+        return true;
     }
 
     cpufeatures::new!(has_avx2, "avx2");
@@ -441,13 +432,13 @@ pub fn avx2_detected() -> bool {
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[inline(always)]
 pub fn sse41_detected() -> bool {
-    if cfg!(miri) {
-        return false;
-    }
-
     // A testing-only short-circuit.
     if cfg!(feature = "no_sse41") {
         return false;
+    }
+
+    if cfg!(target_feature = "sse4.1") {
+        return true;
     }
 
     cpufeatures::new!(has_sse41, "sse4.1");
@@ -457,13 +448,13 @@ pub fn sse41_detected() -> bool {
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[inline(always)]
 pub fn sse2_detected() -> bool {
-    if cfg!(miri) {
-        return false;
-    }
-
     // A testing-only short-circuit.
     if cfg!(feature = "no_sse2") {
         return false;
+    }
+
+    if cfg!(target_feature = "sse2") {
+        return true;
     }
 
     cpufeatures::new!(has_sse2, "sse2");

--- a/src/test.rs
+++ b/src/test.rs
@@ -1002,16 +1002,28 @@ fn test_serde() {
 // they don't use incompatible features like Rayon or mmap. This test should get reasonable
 // coverage of our public API without using any large inputs, so we can run it in CI and catch
 // obvious breaks. (For example, constant_time_eq is not compatible with Miri.)
+// CI runs this test explicitly with the portable, SSE2, SSE4.1, AVX2, and
+// AArch64-portable target/target-feature combinations. Backends implemented
+// only through C/assembly or unsupported Miri intrinsics remain short-circuited.
 #[test]
 fn test_miri_smoketest() {
+    // Process both small and big chunks so the Miri smoketest exercises all
+    // single-chunk and multi-chunk/backend paths.
     let mut hasher = crate::Hasher::new_derive_key("Miri smoketest");
     hasher.update(b"foo");
     #[cfg(feature = "std")]
     hasher.update_reader(&b"bar"[..]).unwrap();
     assert_eq!(hasher.finalize(), hasher.finalize());
+
+    let input = [42; 4096];
+    hasher.update(&input);
+    #[cfg(feature = "std")]
+    hasher.update_reader(&input[..]).unwrap();
+    assert_eq!(hasher.finalize(), hasher.finalize());
     let mut reader = hasher.finalize_xof();
     reader.set_position(999999);
     reader.fill(&mut [0]);
+    reader.fill(&mut [0; 4096]);
 }
 
 // I had to move these tests out of the deprecated guts module, because leaving them there causes


### PR DESCRIPTION
Miri now has shims for a bunch of intrinsics: https://github.com/rust-lang/miri/tree/master/src/intrinsics which makes most intrinsic backends pass miri.
So we allow these backends to be used under miri and also add them to CI (verified it uses the correct code paths)
This also improves the miri smoke test to also go through multi-chunks code-paths.

Conditions like: `if cfg!(target_feature = "avx2") { return true; }` are required because right now `cpufeatures` always returns `false` under miri, I've also opened a PR to change that: https://github.com/RustCrypto/utils/pull/1513