### PR TITLE
Allow running tests manually in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,10 @@ name: tests
 on:
   push:
     branches:
-      - "*"
+      - master
     # not on tags
   pull_request:
+  workflow_dispatch:
 
 env:
   BLAKE3_CI: "1"


### PR DESCRIPTION
This simple change fixes two issues:
* annoying unnecessary CI runs on pushes to various branches
* inability to trigger CI run explicitly on a branch

This makes life much better for contributors