### PR TITLE
Add blake3::many for SIMD-batched hashing of independent equal-length inputs

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -621,3 +621,94 @@ fn bench_xof_32_blocks(b: &mut Bencher) {
 fn bench_xof_64_blocks(b: &mut Bencher) {
     bench_xof(b, 64 * BLOCK_LEN);
 }
+
+// Benchmarks for the blake3::many API, which hashes a batch of equal-length,
+// independent inputs together. Each size has two benches: the batched one, and a
+// `_loop` baseline that hashes the same values one at a time with blake3::hash().
+// The ratio between the pair is what the batching actually buys, which matters
+// most for values too small to fill a SIMD lane group on their own.
+
+// Large enough to amortize the per-call setup, small enough to stay on the stack
+// and in cache. Real callers (Merkle tree leaves, say) have far more than this,
+// and would just call the API once with all of them.
+const MANY_BATCH: usize = 64;
+
+fn many_inputs(b: &mut Bencher, len: usize) -> Vec<RandomInput> {
+    let mut inputs = Vec::with_capacity(MANY_BATCH);
+    for _ in 0..MANY_BATCH {
+        inputs.push(RandomInput::new(b, len));
+    }
+    inputs
+}
+
+fn bench_many_inputs(b: &mut Bencher, len: usize) {
+    let mut inputs = many_inputs(b, len);
+    let mut out = [blake3::Hash::from_bytes([0; OUT_LEN]); MANY_BATCH];
+    b.iter(|| {
+        let slices: ArrayVec<&[u8], MANY_BATCH> = inputs.iter_mut().map(|i| i.get()).collect();
+        assert!(blake3::many::hash(&slices[..], &mut out));
+    });
+}
+
+fn bench_many_inputs_loop(b: &mut Bencher, len: usize) {
+    let mut inputs = many_inputs(b, len);
+    let mut out = [blake3::Hash::from_bytes([0; OUT_LEN]); MANY_BATCH];
+    b.iter(|| {
+        for (out1, input) in out.iter_mut().zip(inputs.iter_mut()) {
+            *out1 = blake3::hash(input.get());
+        }
+    });
+}
+
+#[bench]
+fn bench_many_inputs_0032_bytes(b: &mut Bencher) {
+    bench_many_inputs(b, 32);
+}
+
+#[bench]
+fn bench_many_inputs_0032_bytes_loop(b: &mut Bencher) {
+    bench_many_inputs_loop(b, 32);
+}
+
+#[bench]
+fn bench_many_inputs_0001_block(b: &mut Bencher) {
+    bench_many_inputs(b, BLOCK_LEN);
+}
+
+#[bench]
+fn bench_many_inputs_0001_block_loop(b: &mut Bencher) {
+    bench_many_inputs_loop(b, BLOCK_LEN);
+}
+
+// Not a multiple of BLOCK_LEN, so every lane ends on a partial block. This is the
+// case that needs Platform::compress_many rather than hash_many.
+#[bench]
+fn bench_many_inputs_0100_bytes(b: &mut Bencher) {
+    bench_many_inputs(b, 100);
+}
+
+#[bench]
+fn bench_many_inputs_0100_bytes_loop(b: &mut Bencher) {
+    bench_many_inputs_loop(b, 100);
+}
+
+#[bench]
+fn bench_many_inputs_0001_kib(b: &mut Bencher) {
+    bench_many_inputs(b, 1 * KIB);
+}
+
+#[bench]
+fn bench_many_inputs_0001_kib_loop(b: &mut Bencher) {
+    bench_many_inputs_loop(b, 1 * KIB);
+}
+
+// Past one chunk, so the batch recurses and builds a tree per input.
+#[bench]
+fn bench_many_inputs_0004_kib(b: &mut Bencher) {
+    bench_many_inputs(b, 4 * KIB);
+}
+
+#[bench]
+fn bench_many_inputs_0004_kib_loop(b: &mut Bencher) {
+    bench_many_inputs_loop(b, 4 * KIB);
+}

--- a/c/blake3_c_rust_bindings/src/test.rs
+++ b/c/blake3_c_rust_bindings/src/test.rs
@@ -4,7 +4,6 @@
 use crate::{BLOCK_LEN, CHUNK_LEN, OUT_LEN};
 use arrayref::{array_mut_ref, array_ref};
 use arrayvec::ArrayVec;
-use core::usize;
 use rand::prelude::*;
 
 const CHUNK_START: u8 = 1 << 0;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,15 +96,14 @@ pub mod guts;
 
 pub mod hazmat;
 
+pub mod many;
+
 /// Undocumented and unstable, for benchmarks only.
 #[doc(hidden)]
 pub mod platform;
 
 // Platform-specific implementations of the compression function. These
 // BLAKE3-specific cfg flags are set in build.rs.
-#[cfg(blake3_avx2_rust)]
-#[path = "rust_avx2.rs"]
-mod avx2;
 #[cfg(blake3_avx2_ffi)]
 #[path = "ffi_avx2.rs"]
 mod avx2;
@@ -115,15 +114,21 @@ mod avx512;
 #[path = "ffi_neon.rs"]
 mod neon;
 mod portable;
+#[cfg(any(blake3_avx2_ffi, blake3_avx2_rust))]
+mod rust_avx2;
+#[cfg(blake3_avx2_rust)]
+use rust_avx2 as avx2;
+#[cfg(any(blake3_sse2_ffi, blake3_sse2_rust))]
+mod rust_sse2;
 #[cfg(blake3_sse2_rust)]
-#[path = "rust_sse2.rs"]
-mod sse2;
+use rust_sse2 as sse2;
+#[cfg(any(blake3_sse41_ffi, blake3_sse41_rust))]
+mod rust_sse41;
+#[cfg(blake3_sse41_rust)]
+use rust_sse41 as sse41;
 #[cfg(blake3_sse2_ffi)]
 #[path = "ffi_sse2.rs"]
 mod sse2;
-#[cfg(blake3_sse41_rust)]
-#[path = "rust_sse41.rs"]
-mod sse41;
 #[cfg(blake3_sse41_ffi)]
 #[path = "ffi_sse41.rs"]
 mod sse41;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1810,7 +1810,7 @@ impl std::io::Read for OutputReader {
 #[cfg(feature = "std")]
 impl std::io::Seek for OutputReader {
     fn seek(&mut self, pos: std::io::SeekFrom) -> std::io::Result<u64> {
-        let max_position = u64::max_value() as i128;
+        let max_position = u64::MAX as i128;
         let target_position: i128 = match pos {
             std::io::SeekFrom::Start(x) => x as i128,
             std::io::SeekFrom::Current(x) => self.position() as i128 + x as i128,

--- a/src/many.rs
+++ b/src/many.rs
@@ -1,0 +1,617 @@
+//! Hash many independent, equal-length inputs at once.
+//!
+//! The functions in this module are additive: they don't change the behavior of
+//! [`crate::hash`], [`crate::keyed_hash`], [`crate::derive_key`], or [`Hasher`](crate::Hasher) in
+//! any way, and hashing a single input with one of them always produces exactly the same output as
+//! the corresponding single-input function. What they add is the ability to hash a batch of
+//! same-length, independent inputs (for example, the leaves of a Merkle tree) while sharing the
+//! cost of SIMD parallelism across the whole batch, rather than paying it once per input.
+//!
+//! The one restriction is that a batch's inputs must all be the same length. That length can
+//! be anything, exactly like [`crate::hash`] and friends - there's no block alignment to
+//! worry about.
+//!
+//! # Performance
+//!
+//! Every input in a batch is hashed as its own complete, independent BLAKE3 output, not as
+//! part of one larger tree. So unlike [`Hasher`](crate::Hasher), nothing here changes the hash
+//! of any individual input based on what else is in the batch.
+//!
+//! Internally, this crate already knows how to hash up to `MAX_SIMD_DEGREE` *same-length*
+//! blocks of *different* messages in one SIMD pass - that's how it parallelizes the chunks of
+//! a single large input, and the parent nodes above them. This module reuses that machinery,
+//! but batches it across independent *inputs* instead of across the chunks or parent nodes of
+//! one input.
+//!
+//! For an input no longer than one chunk ([`CHUNK_LEN`], 1024 bytes), that's a single batched
+//! call: every input's one-and-only chunk is compressed side by side, one lane per input, and
+//! root-finalized directly. For a longer input, this module recurses the way [`crate::hash`] itself
+//! does internally, splitting at [`hazmat::left_subtree_len`] to build the same BLAKE3 tree, except
+//! every node of that recursion - each chunk, and each parent joining two subtrees - is computed
+//! for every input in the batch together. Because the inputs share a length they share a tree
+//! shape, so the recursion stays in lockstep.
+//!
+//! Within a chunk, `hash_many` compresses only *full* 64-byte blocks. Block length isn't part
+//! of its interface on any backend; it's baked in as a constant everywhere
+//! (`set1(BLOCK_LEN as u32)` in the Rust intrinsics, `set1(BLAKE3_BLOCK_LEN)` in the C
+//! intrinsics, and a rodata constant in the hand-written assembly). So a chunk's full leading
+//! blocks go through `hash_many` exactly as they always have, and its final block - the only
+//! one BLAKE3 ever allows to be short - goes through [`Platform::compress_many`], the multi-lane
+//! primitive that does take a runtime block length. Short inputs therefore get the same cross-input
+//! SIMD parallelism as long ones.
+use crate::platform::{MAX_SIMD_DEGREE, Platform};
+use crate::{
+    BLOCK_LEN, CHUNK_END, CHUNK_LEN, CHUNK_START, CVWords, DERIVE_KEY_MATERIAL, Hash,
+    IncrementCounter, KEY_LEN, KEYED_HASH, OUT_LEN, PARENT, ROOT, hazmat, platform,
+};
+use arrayref::array_ref;
+use arrayvec::ArrayVec;
+
+/// Hash a batch of equal-length, independent inputs, writing one [`struct@Hash`] per input
+/// into `out`.
+///
+/// This is equivalent to calling [`crate::hash`] on each input separately - `out[i] ==
+/// crate::hash(inputs[i])` for every `i` - but it shares SIMD work across the whole batch.
+/// See the [module documentation](self) for details.
+///
+/// Returns `false`, having written nothing, if `inputs` and `out` aren't the same length or
+/// the inputs aren't all the same length as each other. When the batch size is known at
+/// compile time this check folds away entirely.
+#[must_use = "returns false, and hashes nothing, if the batch lengths don't line up"]
+#[inline]
+pub fn hash(inputs: &[&[u8]], out: &mut [Hash]) -> bool {
+    hash_batch(inputs, crate::IV, 0, out)
+}
+
+/// The keyed hash function, applied to a batch of equal-length, independent inputs.
+///
+/// This is equivalent to calling [`crate::keyed_hash`] on each input separately, but it shares
+/// SIMD work across the whole batch. See the [module documentation](self) for details.
+///
+/// Returns `false`, having written nothing, if `inputs` and `out` aren't the same length or
+/// the inputs aren't all the same length as each other.
+#[must_use = "returns false, and hashes nothing, if the batch lengths don't line up"]
+#[inline]
+pub fn keyed_hash(key: &[u8; KEY_LEN], inputs: &[&[u8]], out: &mut [Hash]) -> bool {
+    let key_words = platform::words_from_le_bytes_32(key);
+    hash_batch(inputs, &key_words, KEYED_HASH, out)
+}
+
+/// The key derivation function, applied to a batch of equal-length, independent key materials
+/// sharing one context string.
+///
+/// This is equivalent to calling [`crate::derive_key`] with the same `context` on each element
+/// of `key_materials` separately, but it shares SIMD work across the whole batch. See the
+/// [module documentation](self) for details.
+///
+/// Returns `false`, having written nothing, if `key_materials` and `out` aren't the same
+/// length or the key materials aren't all the same length as each other.
+#[must_use = "returns false, and derives nothing, if the batch lengths don't line up"]
+#[inline]
+pub fn derive_key(context: &str, key_materials: &[&[u8]], out: &mut [[u8; OUT_LEN]]) -> bool {
+    let context_key = hazmat::hash_derive_key_context(context);
+    let context_key_words = platform::words_from_le_bytes_32(&context_key);
+    hash_batch_bytes(key_materials, &context_key_words, DERIVE_KEY_MATERIAL, out)
+}
+
+// Validates a batch and returns the length its inputs share, or None if the batch is
+// malformed. An empty batch is valid and yields 0.
+//
+// This is the single place the equal-length invariant is established. Everything below takes
+// that length as a parameter instead of re-deriving it from `inputs[0]`, which keeps the
+// optimizer from re-checking it at every level of the recursion. Always inlined so that a
+// caller with a compile-time-known batch shape pays nothing for it.
+#[must_use]
+#[inline(always)]
+fn batch_len<T>(inputs: &[&[u8]], out: &[T]) -> Option<usize> {
+    if inputs.len() != out.len() {
+        return None;
+    }
+    let Some(first) = inputs.first() else {
+        return Some(0);
+    };
+    let len = first.len();
+    if inputs.iter().all(|input| input.len() == len) {
+        Some(len)
+    } else {
+        None
+    }
+}
+
+#[inline]
+fn hash_batch(inputs: &[&[u8]], key: &CVWords, flags: u8, out: &mut [Hash]) -> bool {
+    let Some(len) = batch_len(inputs, out) else {
+        return false;
+    };
+    let platform = Platform::detect();
+    let degree = platform.simd_degree().max(1);
+    for (in_batch, out_batch) in inputs.chunks(degree).zip(out.chunks_mut(degree)) {
+        let mut raw = [[0u8; OUT_LEN]; MAX_SIMD_DEGREE];
+        let raw_out = &mut raw[..in_batch.len()];
+        hash_batch_group(&platform, in_batch, len, key, flags, raw_out);
+        for (out1, raw1) in out_batch.iter_mut().zip(raw_out.iter()) {
+            *out1 = Hash::from_bytes(*raw1);
+        }
+    }
+    true
+}
+
+#[inline]
+fn hash_batch_bytes(inputs: &[&[u8]], key: &CVWords, flags: u8, out: &mut [[u8; OUT_LEN]]) -> bool {
+    let Some(len) = batch_len(inputs, out) else {
+        return false;
+    };
+    let platform = Platform::detect();
+    let degree = platform.simd_degree().max(1);
+    for (in_batch, out_batch) in inputs.chunks(degree).zip(out.chunks_mut(degree)) {
+        hash_batch_group(&platform, in_batch, len, key, flags, out_batch);
+    }
+    true
+}
+
+// Computes each input's root hash, batched across inputs at every level of the tree. Every
+// input in `in_batch` is `len` bytes long, and there are at most MAX_SIMD_DEGREE of them.
+fn hash_batch_group(
+    platform: &Platform,
+    in_batch: &[&[u8]],
+    len: usize,
+    key: &CVWords,
+    flags: u8,
+    out: &mut [[u8; OUT_LEN]],
+) {
+    debug_assert!(!in_batch.is_empty() && in_batch.len() <= MAX_SIMD_DEGREE);
+    if len <= CHUNK_LEN {
+        // The whole input is one chunk. Root-finalize its one and only block, which may be
+        // empty or partial, the way ChunkState::output().root_hash() does.
+        hash_chunk_batch(
+            platform,
+            in_batch,
+            len,
+            0,
+            key,
+            flags,
+            CHUNK_END | ROOT,
+            out,
+        );
+        return;
+    }
+
+    // More than one chunk: split into a left power-of-two-chunks subtree and a right
+    // remainder, the way compress_subtree_wide() and hash_all_at_once() do for a single input.
+    // The inputs share a length, so they split at the same point and produce the same tree
+    // shape. That's what lets every node below be computed for the whole batch at once.
+    let (left_len, right_len) = split_lens(len);
+    let mut left_in: ArrayVec<&[u8], MAX_SIMD_DEGREE> = ArrayVec::new();
+    let mut right_in: ArrayVec<&[u8], MAX_SIMD_DEGREE> = ArrayVec::new();
+    for input in in_batch {
+        let (left, right) = input.split_at(left_len);
+        left_in.push(left);
+        right_in.push(right);
+    }
+    let n = in_batch.len();
+    let mut left_cvs = [[0u8; OUT_LEN]; MAX_SIMD_DEGREE];
+    let mut right_cvs = [[0u8; OUT_LEN]; MAX_SIMD_DEGREE];
+    let left_chunks = (left_len / CHUNK_LEN) as u64;
+    hash_subtree_batch(
+        platform,
+        &left_in,
+        left_len,
+        0,
+        key,
+        flags,
+        &mut left_cvs[..n],
+    );
+    let right_out = &mut right_cvs[..n];
+    hash_subtree_batch(
+        platform,
+        &right_in,
+        right_len,
+        left_chunks,
+        key,
+        flags,
+        right_out,
+    );
+
+    // This is the top of the tree for every input in the batch, so this parent compression is
+    // where each input's ROOT flag is applied, the way hash_all_at_once() applies it to the
+    // parent node returned by compress_subtree_to_parent_node().
+    let flags = flags | ROOT;
+    hash_parents_batch(platform, &left_cvs[..n], &right_cvs[..n], key, flags, out);
+}
+
+// The same recursion as the multi-chunk branch of hash_batch_group(), but for a non-root
+// subtree: it never applies ROOT, and it takes a chunk_counter so this subtree's chunks are
+// numbered correctly within their input.
+fn hash_subtree_batch(
+    platform: &Platform,
+    in_batch: &[&[u8]],
+    len: usize,
+    chunk_counter: u64,
+    key: &CVWords,
+    flags: u8,
+    out: &mut [[u8; OUT_LEN]],
+) {
+    if len <= CHUNK_LEN {
+        hash_chunk_batch(
+            platform,
+            in_batch,
+            len,
+            chunk_counter,
+            key,
+            flags,
+            CHUNK_END,
+            out,
+        );
+        return;
+    }
+
+    let (left_len, right_len) = split_lens(len);
+    let mut left_in: ArrayVec<&[u8], MAX_SIMD_DEGREE> = ArrayVec::new();
+    let mut right_in: ArrayVec<&[u8], MAX_SIMD_DEGREE> = ArrayVec::new();
+    for input in in_batch {
+        let (left, right) = input.split_at(left_len);
+        left_in.push(left);
+        right_in.push(right);
+    }
+    let n = in_batch.len();
+    let mut left_cvs = [[0u8; OUT_LEN]; MAX_SIMD_DEGREE];
+    let mut right_cvs = [[0u8; OUT_LEN]; MAX_SIMD_DEGREE];
+    let right_counter = chunk_counter + (left_len / CHUNK_LEN) as u64;
+    hash_subtree_batch(
+        platform,
+        &left_in,
+        left_len,
+        chunk_counter,
+        key,
+        flags,
+        &mut left_cvs[..n],
+    );
+    hash_subtree_batch(
+        platform,
+        &right_in,
+        right_len,
+        right_counter,
+        key,
+        flags,
+        &mut right_cvs[..n],
+    );
+    hash_parents_batch(platform, &left_cvs[..n], &right_cvs[..n], key, flags, out);
+}
+
+// Splits a multi-chunk length the way this crate splits a single input's subtree.
+#[inline(always)]
+fn split_lens(len: usize) -> (usize, usize) {
+    debug_assert!(len > CHUNK_LEN);
+    let left_len = hazmat::left_subtree_len(len as u64) as usize;
+    (left_len, len - left_len)
+}
+
+// Computes each input's chaining value, where every input is one chunk of `chunk_len` bytes.
+// The full leading blocks, if any, are batched across inputs through the existing hash_many()
+// kernels. The final block, the only one that may be short, goes through compress_many(),
+// which takes a runtime block length.
+#[allow(clippy::too_many_arguments)]
+fn hash_chunk_batch(
+    platform: &Platform,
+    in_batch: &[&[u8]],
+    chunk_len: usize,
+    counter: u64,
+    key: &CVWords,
+    flags: u8,
+    flags_end: u8,
+    out: &mut [[u8; OUT_LEN]],
+) {
+    debug_assert!(!in_batch.is_empty() && in_batch.len() <= MAX_SIMD_DEGREE);
+    debug_assert!(chunk_len <= CHUNK_LEN);
+    let n = in_batch.len();
+    let full_blocks = chunk_len / BLOCK_LEN;
+    let remainder = chunk_len % BLOCK_LEN;
+
+    if remainder == 0 && chunk_len > 0 {
+        // The chunk is a whole number of full blocks, so every block including the last one
+        // can go through hash_many() as-is.
+        let mut cv_bytes = [0u8; MAX_SIMD_DEGREE * OUT_LEN];
+        let cv_out = &mut cv_bytes[..n * OUT_LEN];
+        dispatch_hash_many(
+            full_blocks,
+            platform,
+            in_batch,
+            counter,
+            key,
+            flags,
+            flags_end,
+            cv_out,
+        );
+        for (out1, cv) in out.iter_mut().zip(cv_out.chunks_exact(OUT_LEN)) {
+            *out1 = *array_ref!(cv, 0, OUT_LEN);
+        }
+        return;
+    }
+
+    // The chunk's last block is short, which includes the empty chunk, where there are no full
+    // blocks at all. Batch the full leading blocks through hash_many() to get each lane's
+    // chaining value going into the final block.
+    let mut cvs = [*key; MAX_SIMD_DEGREE];
+    if full_blocks > 0 {
+        let leading: ArrayVec<&[u8], MAX_SIMD_DEGREE> = in_batch
+            .iter()
+            .map(|input| &input[..full_blocks * BLOCK_LEN])
+            .collect();
+        let mut cv_bytes = [0u8; MAX_SIMD_DEGREE * OUT_LEN];
+        let cv_out = &mut cv_bytes[..n * OUT_LEN];
+        // Not the chunk's end yet; the real end is the short block finalized below.
+        dispatch_hash_many(
+            full_blocks,
+            platform,
+            &leading,
+            counter,
+            key,
+            flags,
+            0,
+            cv_out,
+        );
+        for (cv, bytes) in cvs.iter_mut().zip(cv_out.chunks_exact(OUT_LEN)) {
+            *cv = platform::words_from_le_bytes_32(array_ref!(bytes, 0, OUT_LEN));
+        }
+    }
+    let start_flag = if full_blocks == 0 { CHUNK_START } else { 0 };
+    let block_flags = flags | flags_end | start_flag;
+
+    // Gather each lane's short final block, zero-padded, and compress them all at once. This
+    // is the one block hash_many() can't help with, because block length isn't part of its
+    // interface. compress_many() is the primitive that batches it with a real block_len.
+    let mut blocks = [[0u8; BLOCK_LEN]; MAX_SIMD_DEGREE];
+    for (block, input) in blocks[..n].iter_mut().zip(in_batch) {
+        let tail = &input[full_blocks * BLOCK_LEN..];
+        block[..tail.len()].copy_from_slice(tail);
+    }
+    let block_len = remainder as u8;
+    platform.compress_many(&mut cvs[..n], &blocks[..n], block_len, counter, block_flags);
+    for (out1, cv) in out.iter_mut().zip(cvs[..n].iter()) {
+        *out1 = platform::le_bytes_from_words_32(cv);
+    }
+}
+
+// block_count is in 1..=16 (CHUNK_LEN / BLOCK_LEN), so this dispatches to the same
+// const-generic hash_many() this crate already uses internally for whole chunks
+// (block_count == 16) and for parent nodes (block_count == 1). Values in between are new
+// territory for callers, but the block loop inside every hash_many() backend is already a
+// runtime loop over `blocks` (see e.g. rust_avx2::hash_many), not special-cased to those two.
+#[allow(clippy::too_many_arguments)]
+fn dispatch_hash_many(
+    block_count: usize,
+    platform: &Platform,
+    in_batch: &[&[u8]],
+    counter: u64,
+    key: &CVWords,
+    flags: u8,
+    flags_end: u8,
+    cv_out: &mut [u8],
+) {
+    macro_rules! dispatch {
+        ($($blocks:literal),*) => {
+            match block_count {
+                $($blocks => hash_many_fixed::<{ $blocks * BLOCK_LEN }>(
+                    platform, in_batch, counter, key, flags, flags_end, cv_out,
+                ),)*
+                _ => unreachable!("block_count out of range"),
+            }
+        };
+    }
+    dispatch!(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
+}
+
+fn hash_many_fixed<const N: usize>(
+    platform: &Platform,
+    in_batch: &[&[u8]],
+    counter: u64,
+    key: &CVWords,
+    flags: u8,
+    flags_end: u8,
+    cv_out: &mut [u8],
+) {
+    let mut arrays: ArrayVec<&[u8; N], MAX_SIMD_DEGREE> = ArrayVec::new();
+    for &input in in_batch {
+        arrays.push(input.try_into().expect("length already checked"));
+    }
+    platform.hash_many(
+        &arrays,
+        key,
+        // Every lane is the same chunk index of a *different* independent input. Unlike
+        // hashing several chunks of one input, where the counter increments per lane, the
+        // counter is the same for every lane here; it only changes between calls, as the
+        // recursion walks across each input's chunks.
+        counter,
+        IncrementCounter::No,
+        flags,
+        CHUNK_START,
+        flags_end,
+        cv_out,
+    );
+}
+
+// Batches the parent-node compression that joins each input's left and right subtree chaining
+// values, one lane per input, through the same hash_many() kernels used for chunks above (with
+// a single BLOCK_LEN-sized "block" per lane). This is the batched counterpart of
+// compress_parents_parallel(), across independent inputs rather than one input's tree.
+fn hash_parents_batch(
+    platform: &Platform,
+    left_cvs: &[[u8; OUT_LEN]],
+    right_cvs: &[[u8; OUT_LEN]],
+    key: &CVWords,
+    flags: u8,
+    out: &mut [[u8; OUT_LEN]],
+) {
+    let n = left_cvs.len();
+    debug_assert_eq!(n, right_cvs.len());
+    debug_assert_eq!(n, out.len());
+    debug_assert!(n <= MAX_SIMD_DEGREE);
+
+    let mut blocks: ArrayVec<[u8; 2 * OUT_LEN], MAX_SIMD_DEGREE> = ArrayVec::new();
+    for (left, right) in left_cvs.iter().zip(right_cvs) {
+        let mut block = [0u8; 2 * OUT_LEN];
+        block[..OUT_LEN].copy_from_slice(left);
+        block[OUT_LEN..].copy_from_slice(right);
+        blocks.push(block);
+    }
+    let arrays: ArrayVec<&[u8; 2 * OUT_LEN], MAX_SIMD_DEGREE> = blocks.iter().collect();
+
+    let mut cv_bytes = [0u8; MAX_SIMD_DEGREE * OUT_LEN];
+    let cv_out = &mut cv_bytes[..n * OUT_LEN];
+    platform.hash_many(
+        &arrays,
+        key,
+        // Parent nodes always use counter 0, same as compress_parents_parallel().
+        0,
+        IncrementCounter::No,
+        flags | PARENT,
+        0, // Parents have no start flags.
+        0, // Parents have no end flags; callers OR ROOT into `flags` when they need it.
+        cv_out,
+    );
+    for (out1, cv) in out.iter_mut().zip(cv_out.chunks_exact(OUT_LEN)) {
+        *out1 = *array_ref!(cv, 0, OUT_LEN);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    extern crate alloc;
+
+    use super::*;
+    use crate::test::{TEST_CASES_MAX, paint_test_input};
+    use alloc::vec;
+    use alloc::vec::Vec;
+
+    fn check(inputs: &[&[u8]], key: Option<&[u8; KEY_LEN]>, context: Option<&str>) {
+        let mut got = vec![Hash::from_bytes([0; OUT_LEN]); inputs.len()];
+        match (key, context) {
+            (None, None) => assert!(hash(inputs, &mut got)),
+            (Some(k), None) => assert!(keyed_hash(k, inputs, &mut got)),
+            (None, Some(ctx)) => {
+                let mut raw = vec![[0u8; OUT_LEN]; inputs.len()];
+                assert!(derive_key(ctx, inputs, &mut raw));
+                for (g, r) in got.iter_mut().zip(raw.iter()) {
+                    *g = Hash::from_bytes(*r);
+                }
+            }
+            (Some(_), Some(_)) => unreachable!(),
+        }
+        for (input, expected_hash) in inputs.iter().zip(got.iter()) {
+            let want = match (key, context) {
+                (None, None) => crate::hash(input),
+                (Some(k), None) => crate::keyed_hash(k, input),
+                (None, Some(ctx)) => Hash::from_bytes(crate::derive_key(ctx, input)),
+                (Some(_), Some(_)) => unreachable!(),
+            };
+            assert_eq!(*expected_hash, want, "input length {}", input.len());
+        }
+    }
+
+    #[test]
+    fn test_many_matches_single_for_all_lengths_and_batch_sizes() {
+        let mut input_buf = vec![0u8; TEST_CASES_MAX];
+        paint_test_input(&mut input_buf);
+
+        for &len in crate::test::TEST_CASES {
+            for &batch_size in &[0usize, 1, 2, 3, 8, 17, MAX_SIMD_DEGREE, MAX_SIMD_DEGREE + 1] {
+                if len > input_buf.len() {
+                    continue;
+                }
+                let inputs: Vec<&[u8]> = (0..batch_size).map(|_| &input_buf[..len]).collect();
+                check(&inputs, None, None);
+                check(&inputs, Some(&crate::test::TEST_KEY), None);
+                check(&inputs, None, Some("blake3 many() test context"));
+            }
+        }
+    }
+
+    #[test]
+    fn test_many_mixed_content_arbitrary_lengths() {
+        // Deliberately includes lengths that are not multiples of BLOCK_LEN, at and across
+        // chunk and multi-chunk boundaries, to exercise the short-final-block path at every
+        // depth of the recursion.
+        const LENS: &[usize] = &[
+            0,
+            1,
+            17,
+            32,
+            63,
+            64,
+            65,
+            100,
+            128,
+            1000,
+            1023,
+            1024,
+            1025,
+            1057,
+            2 * CHUNK_LEN,
+            2 * CHUNK_LEN + 1,
+            2 * CHUNK_LEN + 64,
+            2 * CHUNK_LEN + 100,
+            5 * CHUNK_LEN + 37,
+            8 * CHUNK_LEN - 1,
+            8 * CHUNK_LEN,
+        ];
+        // Start every input at a different offset, so that a lane mixup fails the test. The
+        // buffer has to hold the longest length starting from the largest offset. Note that
+        // the number of inputs scales with MAX_SIMD_DEGREE but the lengths above don't, so
+        // sizing this from MAX_SIMD_DEGREE alone underflows wherever it is 1.
+        const STRIDE: usize = 7;
+        let num_inputs = 2 * MAX_SIMD_DEGREE + 1;
+        let max_len = LENS.iter().copied().max().unwrap();
+        let mut input_buf = vec![0u8; STRIDE * (num_inputs - 1) + max_len];
+        paint_test_input(&mut input_buf);
+        for &len in LENS {
+            let inputs: Vec<&[u8]> = (0..num_inputs)
+                .map(|i| &input_buf[i * STRIDE..][..len])
+                .collect();
+            check(&inputs, None, None);
+        }
+    }
+
+    #[test]
+    fn test_many_large_multi_chunk_inputs() {
+        // Several chunks per input, a non-block-aligned length, and enough inputs to fill more
+        // than one MAX_SIMD_DEGREE-sized group, to exercise the recursive tree-splitting path
+        // across multiple batches with a short final block each time.
+        const LEN: usize = 20 * CHUNK_LEN + 3 * BLOCK_LEN + 17;
+        let mut input_buf = vec![0u8; (2 * MAX_SIMD_DEGREE + 5) * LEN];
+        paint_test_input(&mut input_buf);
+        let inputs: Vec<&[u8]> = input_buf.chunks_exact(LEN).collect();
+        check(&inputs, None, None);
+        check(&inputs, Some(&crate::test::TEST_KEY), None);
+        check(&inputs, None, Some("blake3 many() large multi-chunk test"));
+    }
+
+    #[test]
+    fn test_many_rejects_mismatched_input_lengths() {
+        let a = [0u8; 32];
+        let b = [0u8; 31];
+        let inputs: [&[u8]; 2] = [&a, &b];
+        let mut out = [Hash::from_bytes([0; OUT_LEN]); 2];
+        assert!(!hash(&inputs, &mut out));
+        assert!(!keyed_hash(&crate::test::TEST_KEY, &inputs, &mut out));
+        let mut raw = [[0u8; OUT_LEN]; 2];
+        assert!(!derive_key("ctx", &inputs, &mut raw));
+        // Nothing was written.
+        assert_eq!(out[0], Hash::from_bytes([0; OUT_LEN]));
+        assert_eq!(out[1], Hash::from_bytes([0; OUT_LEN]));
+    }
+
+    #[test]
+    fn test_many_rejects_mismatched_out_length() {
+        let a = [0u8; 32];
+        let inputs: [&[u8]; 1] = [&a];
+        let mut out: [Hash; 2] = [Hash::from_bytes([0; OUT_LEN]); 2];
+        assert!(!hash(&inputs, &mut out));
+    }
+
+    #[test]
+    fn test_many_empty_batch_is_ok() {
+        let inputs: [&[u8]; 0] = [];
+        let mut out: [Hash; 0] = [];
+        assert!(hash(&inputs, &mut out));
+    }
+}

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -192,6 +192,73 @@ impl Platform {
         }
     }
 
+    /// Compress one block for each of several independent inputs at the same time.
+    ///
+    /// This sits between the two primitives above. [`Self::compress_in_place`] takes a runtime
+    /// `block_len`, but handles only a single message. [`Self::hash_many`] compresses many messages
+    /// at once, but always assumes full blocks - `block_len` isn't part of its interface on any
+    /// backend, including the hand-written assembly. This one does both, which is what lets a batch
+    /// of independent inputs finalize their short final blocks in parallel instead of one at a
+    /// time. See [`crate::many`].
+    ///
+    /// `cvs[i]` is lane `i`'s chaining value, updated in place. `blocks[i]` is lane `i`'s block,
+    /// zero-padded to `BLOCK_LEN` if it's short. `block_len`, `counter`, and `flags` are shared by
+    /// every lane. Lanes past a whole multiple of the platform's SIMD width, and platforms with no
+    /// wide implementation, fall back to `compress_in_place`, so this is always correct - just not
+    /// always parallel.
+    ///
+    /// `cvs` and `blocks` must have the same length. This is debug-asserted rather than checked,
+    /// like the `out` length in [`Self::hash_many`].
+    #[inline]
+    pub fn compress_many(
+        &self,
+        cvs: &mut [CVWords],
+        blocks: &[[u8; BLOCK_LEN]],
+        block_len: u8,
+        counter: u64,
+        flags: u8,
+    ) {
+        debug_assert_eq!(cvs.len(), blocks.len(), "mismatched lanes");
+        // Safe in every arm below because detect() checked for platform support.
+        let processed_lanes = match self {
+            // The portable backend has no wide compression to offer, so every lane
+            // falls through to the compress_in_place() loop below.
+            Platform::Portable => 0,
+            #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+            Platform::SSE2 => unsafe { sse2_compress_many(cvs, blocks, block_len, counter, flags) },
+            #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+            Platform::SSE41 => unsafe {
+                sse41_compress_many(cvs, blocks, block_len, counter, flags)
+            },
+            #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+            Platform::AVX2 => unsafe { avx2_compress_many(cvs, blocks, block_len, counter, flags) },
+            // AVX-512 implies AVX2 on every CPU that has it, so borrowing the 8-lane
+            // AVX2 kernel is correct, just half as wide as it could be.
+            //
+            // TODO: Implement a 16-lane compress_many() once this crate has a Rust
+            //  intrinsics AVX-512 backend to put it in. Today AVX-512 is C and assembly
+            //  only, neither of which can express a runtime block_len for hash_many().
+            //  See https://github.com/BLAKE3-team/BLAKE3/pull/566.
+            #[cfg(blake3_avx512_ffi)]
+            #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+            Platform::AVX512 => unsafe {
+                avx2_compress_many(cvs, blocks, block_len, counter, flags)
+            },
+            // TODO: Implement compress_many() for NEON. Its only backend is C
+            //  (ffi_neon.rs), so this needs either a Rust intrinsics NEON module or a
+            //  new C entry point. Until then every lane falls through below.
+            #[cfg(blake3_neon)]
+            Platform::NEON => 0,
+            #[cfg(blake3_wasm32_simd)]
+            Platform::WASM32_SIMD => unsafe {
+                wasm32_simd_compress_many(cvs, blocks, block_len, counter, flags)
+            },
+        };
+        for i in processed_lanes..cvs.len() {
+            self.compress_in_place(&mut cvs[i], &blocks[i], block_len, counter, flags);
+        }
+    }
+
     // IMPLEMENTATION NOTE
     // ===================
     // hash_many() applies two optimizations. The critically important
@@ -402,6 +469,47 @@ impl Platform {
         Some(Self::WASM32_SIMD)
     }
 }
+
+// Each of these drives one backend's compress_many kernel over as many whole SIMD-width groups of
+// lanes as it can, and returns how many lanes it consumed. Platform::compress_many() finishes any
+// remainder with compress_in_place.
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", blake3_wasm32_simd))]
+macro_rules! compress_many_impl {
+    ($name:ident, $backend:ident, $kernel:ident) => {
+        unsafe fn $name(
+            cvs: &mut [CVWords],
+            blocks: &[[u8; BLOCK_LEN]],
+            block_len: u8,
+            counter: u64,
+            flags: u8,
+        ) -> usize {
+            const DEGREE: usize = crate::$backend::DEGREE;
+            let mut lane = 0;
+            while lane + DEGREE <= cvs.len() {
+                unsafe {
+                    crate::$backend::$kernel(
+                        array_mut_ref!(cvs, lane, DEGREE),
+                        array_ref!(blocks, lane, DEGREE),
+                        block_len,
+                        counter,
+                        flags,
+                    )
+                };
+                lane += DEGREE;
+            }
+            lane
+        }
+    };
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+compress_many_impl!(sse2_compress_many, rust_sse2, compress4);
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+compress_many_impl!(sse41_compress_many, rust_sse41, compress4);
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+compress_many_impl!(avx2_compress_many, rust_avx2, compress8);
+#[cfg(blake3_wasm32_simd)]
+compress_many_impl!(wasm32_simd_compress_many, wasm32_simd, compress4);
 
 // Note that AVX-512 is divided into multiple featuresets, and we use two of
 // them, F and VL.

--- a/src/rust_avx2.rs
+++ b/src/rust_avx2.rs
@@ -3,10 +3,12 @@ use core::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::*;
 
-use crate::{
-    BLOCK_LEN, CVWords, IV, IncrementCounter, MSG_SCHEDULE, OUT_LEN, counter_high, counter_low,
-};
-use arrayref::{array_mut_ref, mut_array_refs};
+use crate::{BLOCK_LEN, CVWords, IV, MSG_SCHEDULE, counter_high, counter_low};
+#[cfg(blake3_avx2_rust)]
+use crate::{IncrementCounter, OUT_LEN};
+#[cfg(blake3_avx2_rust)]
+use arrayref::array_mut_ref;
+use arrayref::mut_array_refs;
 
 pub const DEGREE: usize = 8;
 
@@ -37,6 +39,7 @@ unsafe fn set1(x: u32) -> __m256i {
     unsafe { _mm256_set1_epi32(x as i32) }
 }
 
+#[cfg(blake3_avx2_rust)]
 #[inline(always)]
 unsafe fn set8(a: u32, b: u32, c: u32, d: u32, e: u32, f: u32, g: u32, h: u32) -> __m256i {
     unsafe {
@@ -283,6 +286,7 @@ unsafe fn transpose_msg_vecs(inputs: &[*const u8; DEGREE], block_offset: usize) 
     }
 }
 
+#[cfg(blake3_avx2_rust)]
 #[inline(always)]
 unsafe fn load_counters(counter: u64, increment_counter: IncrementCounter) -> (__m256i, __m256i) {
     let mask = if increment_counter.yes() { !0 } else { 0 };
@@ -312,6 +316,7 @@ unsafe fn load_counters(counter: u64, increment_counter: IncrementCounter) -> (_
     }
 }
 
+#[cfg(blake3_avx2_rust)]
 #[target_feature(enable = "avx2")]
 pub unsafe fn hash8(
     inputs: &[*const u8; DEGREE],
@@ -399,6 +404,7 @@ pub unsafe fn hash8(
     }
 }
 
+#[cfg(blake3_avx2_rust)]
 #[target_feature(enable = "avx2")]
 pub unsafe fn hash_many<const N: usize>(
     mut inputs: &[&[u8; N]],
@@ -450,6 +456,74 @@ pub unsafe fn hash_many<const N: usize>(
     }
 }
 
+/// Compresses one (possibly partial) block for up to [`DEGREE`] (8) independent lanes at once.
+/// `cvs[i]` is lane `i`'s incoming chaining value, overwritten in place with the compression
+/// result, and `blocks[i]` points to at least `BLOCK_LEN` readable bytes for lane `i`. The
+/// `block_len`, `counter`, and `flags` are shared by every lane.
+#[target_feature(enable = "avx2")]
+pub unsafe fn compress8(
+    cvs: &mut [CVWords; DEGREE],
+    blocks: &[[u8; BLOCK_LEN]; DEGREE],
+    block_len: u8,
+    counter: u64,
+    flags: u8,
+) {
+    unsafe {
+        let mut h_vecs: [__m256i; DEGREE] =
+            core::array::from_fn(|lane| loadu(cvs[lane].as_ptr() as *const u8));
+        transpose_vecs(&mut h_vecs);
+
+        let block_ptrs: [*const u8; DEGREE] = core::array::from_fn(|lane| blocks[lane].as_ptr());
+        let msg_vecs = transpose_msg_vecs(&block_ptrs, 0);
+
+        let counter_low_vec = set1(counter_low(counter));
+        let counter_high_vec = set1(counter_high(counter));
+        let block_len_vec = set1(block_len as u32);
+        let block_flags_vec = set1(flags as u32);
+
+        let mut v = [
+            h_vecs[0],
+            h_vecs[1],
+            h_vecs[2],
+            h_vecs[3],
+            h_vecs[4],
+            h_vecs[5],
+            h_vecs[6],
+            h_vecs[7],
+            set1(IV[0]),
+            set1(IV[1]),
+            set1(IV[2]),
+            set1(IV[3]),
+            counter_low_vec,
+            counter_high_vec,
+            block_len_vec,
+            block_flags_vec,
+        ];
+        round(&mut v, &msg_vecs, 0);
+        round(&mut v, &msg_vecs, 1);
+        round(&mut v, &msg_vecs, 2);
+        round(&mut v, &msg_vecs, 3);
+        round(&mut v, &msg_vecs, 4);
+        round(&mut v, &msg_vecs, 5);
+        round(&mut v, &msg_vecs, 6);
+
+        let mut h_vecs_out = [
+            xor(v[0], v[8]),
+            xor(v[1], v[9]),
+            xor(v[2], v[10]),
+            xor(v[3], v[11]),
+            xor(v[4], v[12]),
+            xor(v[5], v[13]),
+            xor(v[6], v[14]),
+            xor(v[7], v[15]),
+        ];
+        transpose_vecs(&mut h_vecs_out);
+        for lane in 0..DEGREE {
+            storeu(h_vecs_out[lane], cvs[lane].as_mut_ptr() as *mut u8);
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -486,11 +560,62 @@ mod test {
         }
     }
 
+    #[cfg(blake3_avx2_rust)]
     #[test]
     fn test_hash_many() {
         if !crate::platform::avx2_detected() {
             return;
         }
         crate::test::test_hash_many_fn(hash_many, hash_many);
+    }
+
+    #[test]
+    fn test_compress8_matches_compress_in_place() {
+        if !crate::platform::avx2_detected() {
+            return;
+        }
+        // Give each lane a different slice of the painted buffer, so a lane mixup fails the test.
+        let mut input_buf = [0u8; DEGREE * BLOCK_LEN];
+        crate::test::paint_test_input(&mut input_buf);
+
+        for block_len in [0u8, 1, 17, 32, 63, 64] {
+            // See test_hash_many_fn in src/test.rs for why these particular counters matter.
+            for counter in [0u64, u32::MAX as u64, i32::MAX as u64] {
+                for flags in [
+                    crate::CHUNK_START | crate::CHUNK_END | crate::ROOT,
+                    crate::KEYED_HASH | crate::CHUNK_START | crate::CHUNK_END,
+                ] {
+                    let mut cvs = [[0u32; 8]; DEGREE];
+                    let mut blocks = [[0u8; BLOCK_LEN]; DEGREE];
+                    for lane in 0..DEGREE {
+                        // A rotation of TEST_KEY_WORDS, distinct for every lane.
+                        for w in 0..8 {
+                            cvs[lane][w] = crate::test::TEST_KEY_WORDS[(w + lane) % 8];
+                        }
+                        blocks[lane].copy_from_slice(&input_buf[lane * BLOCK_LEN..][..BLOCK_LEN]);
+                    }
+
+                    let mut want_cvs = cvs;
+                    for lane in 0..DEGREE {
+                        crate::portable::compress_in_place(
+                            &mut want_cvs[lane],
+                            &blocks[lane],
+                            block_len,
+                            counter,
+                            flags,
+                        );
+                    }
+
+                    unsafe {
+                        compress8(&mut cvs, &blocks, block_len, counter, flags);
+                    }
+
+                    assert_eq!(
+                        cvs, want_cvs,
+                        "block_len {block_len} counter {counter} flags {flags}"
+                    );
+                }
+            }
+        }
     }
 }

--- a/src/rust_sse2.rs
+++ b/src/rust_sse2.rs
@@ -3,11 +3,12 @@ use core::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::*;
 
-use crate::{
-    BLOCK_LEN, CVBytes, CVWords, IV, IncrementCounter, MSG_SCHEDULE, OUT_LEN, counter_high,
-    counter_low,
-};
-use arrayref::{array_mut_ref, array_ref, mut_array_refs};
+use crate::{BLOCK_LEN, CVWords, IV, MSG_SCHEDULE, counter_high, counter_low};
+#[cfg(blake3_sse2_rust)]
+use crate::{CVBytes, IncrementCounter, OUT_LEN};
+use arrayref::mut_array_refs;
+#[cfg(blake3_sse2_rust)]
+use arrayref::{array_mut_ref, array_ref};
 
 pub const DEGREE: usize = 4;
 
@@ -38,6 +39,7 @@ unsafe fn set1(x: u32) -> __m128i {
     unsafe { _mm_set1_epi32(x as i32) }
 }
 
+#[cfg(blake3_sse2_rust)]
 #[inline(always)]
 unsafe fn set4(a: u32, b: u32, c: u32, d: u32) -> __m128i {
     unsafe { _mm_setr_epi32(a as i32, b as i32, c as i32, d as i32) }
@@ -71,6 +73,7 @@ unsafe fn rot7(a: __m128i) -> __m128i {
     unsafe { _mm_or_si128(_mm_srli_epi32(a, 7), _mm_slli_epi32(a, 32 - 7)) }
 }
 
+#[cfg(blake3_sse2_rust)]
 #[inline(always)]
 unsafe fn g1(
     row0: &mut __m128i,
@@ -89,6 +92,7 @@ unsafe fn g1(
     }
 }
 
+#[cfg(blake3_sse2_rust)]
 #[inline(always)]
 unsafe fn g2(
     row0: &mut __m128i,
@@ -108,12 +112,14 @@ unsafe fn g2(
 }
 
 // Adapted from https://github.com/rust-lang-nursery/stdsimd/pull/479.
+#[cfg(blake3_sse2_rust)]
 macro_rules! _MM_SHUFFLE {
     ($z:expr, $y:expr, $x:expr, $w:expr) => {
         ($z << 6) | ($y << 4) | ($x << 2) | $w
     };
 }
 
+#[cfg(blake3_sse2_rust)]
 macro_rules! shuffle2 {
     ($a:expr, $b:expr, $c:expr) => {
         _mm_castps_si128(_mm_shuffle_ps(
@@ -127,6 +133,7 @@ macro_rules! shuffle2 {
 // Note the optimization here of leaving row1 as the unrotated row, rather than
 // row0. All the message loads below are adjusted to compensate for this. See
 // discussion at https://github.com/sneves/blake2-avx2/pull/4
+#[cfg(blake3_sse2_rust)]
 #[inline(always)]
 unsafe fn diagonalize(row0: &mut __m128i, row2: &mut __m128i, row3: &mut __m128i) {
     unsafe {
@@ -136,6 +143,7 @@ unsafe fn diagonalize(row0: &mut __m128i, row2: &mut __m128i, row3: &mut __m128i
     }
 }
 
+#[cfg(blake3_sse2_rust)]
 #[inline(always)]
 unsafe fn undiagonalize(row0: &mut __m128i, row2: &mut __m128i, row3: &mut __m128i) {
     unsafe {
@@ -145,6 +153,7 @@ unsafe fn undiagonalize(row0: &mut __m128i, row2: &mut __m128i, row3: &mut __m12
     }
 }
 
+#[cfg(blake3_sse2_rust)]
 #[inline(always)]
 unsafe fn blend_epi16(a: __m128i, b: __m128i, imm8: i32) -> __m128i {
     unsafe {
@@ -156,6 +165,7 @@ unsafe fn blend_epi16(a: __m128i, b: __m128i, imm8: i32) -> __m128i {
     }
 }
 
+#[cfg(blake3_sse2_rust)]
 #[inline(always)]
 unsafe fn compress_pre(
     cv: &CVWords,
@@ -344,6 +354,7 @@ unsafe fn compress_pre(
     }
 }
 
+#[cfg(blake3_sse2_rust)]
 #[target_feature(enable = "sse2")]
 pub unsafe fn compress_in_place(
     cv: &mut CVWords,
@@ -359,6 +370,7 @@ pub unsafe fn compress_in_place(
     }
 }
 
+#[cfg(blake3_sse2_rust)]
 #[target_feature(enable = "sse2")]
 pub unsafe fn compress_xof(
     cv: &CVWords,
@@ -557,6 +569,7 @@ unsafe fn transpose_msg_vecs(inputs: &[*const u8; DEGREE], block_offset: usize) 
     }
 }
 
+#[cfg(blake3_sse2_rust)]
 #[inline(always)]
 unsafe fn load_counters(counter: u64, increment_counter: IncrementCounter) -> (__m128i, __m128i) {
     let mask = if increment_counter.yes() { !0 } else { 0 };
@@ -578,6 +591,7 @@ unsafe fn load_counters(counter: u64, increment_counter: IncrementCounter) -> (_
     }
 }
 
+#[cfg(blake3_sse2_rust)]
 #[target_feature(enable = "sse2")]
 pub unsafe fn hash4(
     inputs: &[*const u8; DEGREE],
@@ -669,6 +683,7 @@ pub unsafe fn hash4(
     }
 }
 
+#[cfg(blake3_sse2_rust)]
 #[target_feature(enable = "sse2")]
 unsafe fn hash1<const N: usize>(
     input: &[u8; N],
@@ -702,6 +717,7 @@ unsafe fn hash1<const N: usize>(
     *out = unsafe { core::mem::transmute(cv) }; // x86 is little-endian
 }
 
+#[cfg(blake3_sse2_rust)]
 #[target_feature(enable = "sse2")]
 pub unsafe fn hash_many<const N: usize>(
     mut inputs: &[&[u8; N]],
@@ -757,6 +773,93 @@ pub unsafe fn hash_many<const N: usize>(
     }
 }
 
+/// Compresses one (possibly partial) block for up to [`DEGREE`] (4) independent lanes at once.
+/// `cvs[i]` is lane `i`'s incoming chaining value, overwritten in place with the compression
+/// result, and `blocks[i]` points to at least `BLOCK_LEN` readable bytes for lane `i`. The
+/// `block_len`, `counter`, and `flags` are shared by every lane.
+#[target_feature(enable = "sse2")]
+pub unsafe fn compress4(
+    cvs: &mut [CVWords; DEGREE],
+    blocks: &[[u8; BLOCK_LEN]; DEGREE],
+    block_len: u8,
+    counter: u64,
+    flags: u8,
+) {
+    unsafe {
+        // A CV is 8 words, but a DEGREE=4 vector only holds 4 words, so the transpose happens in
+        // two independent halves: the low 4 words of each lane's CV, and the high 4 words.
+        let mut low_vecs: [__m128i; DEGREE] =
+            core::array::from_fn(|lane| loadu(cvs[lane].as_ptr() as *const u8));
+        let mut high_vecs: [__m128i; DEGREE] =
+            core::array::from_fn(|lane| loadu(cvs[lane].as_ptr().add(4) as *const u8));
+        transpose_vecs(&mut low_vecs);
+        transpose_vecs(&mut high_vecs);
+        let h_vecs = [
+            low_vecs[0],
+            low_vecs[1],
+            low_vecs[2],
+            low_vecs[3],
+            high_vecs[0],
+            high_vecs[1],
+            high_vecs[2],
+            high_vecs[3],
+        ];
+
+        let block_ptrs: [*const u8; DEGREE] = core::array::from_fn(|lane| blocks[lane].as_ptr());
+        let msg_vecs = transpose_msg_vecs(&block_ptrs, 0);
+
+        let counter_low_vec = set1(counter_low(counter));
+        let counter_high_vec = set1(counter_high(counter));
+        let block_len_vec = set1(block_len as u32);
+        let block_flags_vec = set1(flags as u32);
+
+        let mut v = [
+            h_vecs[0],
+            h_vecs[1],
+            h_vecs[2],
+            h_vecs[3],
+            h_vecs[4],
+            h_vecs[5],
+            h_vecs[6],
+            h_vecs[7],
+            set1(IV[0]),
+            set1(IV[1]),
+            set1(IV[2]),
+            set1(IV[3]),
+            counter_low_vec,
+            counter_high_vec,
+            block_len_vec,
+            block_flags_vec,
+        ];
+        round(&mut v, &msg_vecs, 0);
+        round(&mut v, &msg_vecs, 1);
+        round(&mut v, &msg_vecs, 2);
+        round(&mut v, &msg_vecs, 3);
+        round(&mut v, &msg_vecs, 4);
+        round(&mut v, &msg_vecs, 5);
+        round(&mut v, &msg_vecs, 6);
+
+        let mut low_out = [
+            xor(v[0], v[8]),
+            xor(v[1], v[9]),
+            xor(v[2], v[10]),
+            xor(v[3], v[11]),
+        ];
+        let mut high_out = [
+            xor(v[4], v[12]),
+            xor(v[5], v[13]),
+            xor(v[6], v[14]),
+            xor(v[7], v[15]),
+        ];
+        transpose_vecs(&mut low_out);
+        transpose_vecs(&mut high_out);
+        for lane in 0..DEGREE {
+            storeu(low_out[lane], cvs[lane].as_mut_ptr() as *mut u8);
+            storeu(high_out[lane], cvs[lane].as_mut_ptr().add(4) as *mut u8);
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -793,6 +896,7 @@ mod test {
         }
     }
 
+    #[cfg(blake3_sse2_rust)]
     #[test]
     fn test_compress() {
         if !crate::platform::sse2_detected() {
@@ -801,11 +905,62 @@ mod test {
         crate::test::test_compress_fn(compress_in_place, compress_xof);
     }
 
+    #[cfg(blake3_sse2_rust)]
     #[test]
     fn test_hash_many() {
         if !crate::platform::sse2_detected() {
             return;
         }
         crate::test::test_hash_many_fn(hash_many, hash_many);
+    }
+
+    #[test]
+    fn test_compress4_matches_compress_in_place() {
+        if !crate::platform::sse2_detected() {
+            return;
+        }
+        // Give each lane a different slice of the painted buffer, so a lane mixup fails the test.
+        let mut input_buf = [0u8; DEGREE * BLOCK_LEN];
+        crate::test::paint_test_input(&mut input_buf);
+
+        for block_len in [0u8, 1, 17, 32, 63, 64] {
+            // See test_hash_many_fn in src/test.rs for why these particular counters matter.
+            for counter in [0u64, u32::MAX as u64, i32::MAX as u64] {
+                for flags in [
+                    crate::CHUNK_START | crate::CHUNK_END | crate::ROOT,
+                    crate::KEYED_HASH | crate::CHUNK_START | crate::CHUNK_END,
+                ] {
+                    let mut cvs = [[0u32; 8]; DEGREE];
+                    let mut blocks = [[0u8; BLOCK_LEN]; DEGREE];
+                    for lane in 0..DEGREE {
+                        // A rotation of TEST_KEY_WORDS, distinct for every lane.
+                        for w in 0..8 {
+                            cvs[lane][w] = crate::test::TEST_KEY_WORDS[(w + lane) % 8];
+                        }
+                        blocks[lane].copy_from_slice(&input_buf[lane * BLOCK_LEN..][..BLOCK_LEN]);
+                    }
+
+                    let mut want_cvs = cvs;
+                    for lane in 0..DEGREE {
+                        crate::portable::compress_in_place(
+                            &mut want_cvs[lane],
+                            &blocks[lane],
+                            block_len,
+                            counter,
+                            flags,
+                        );
+                    }
+
+                    unsafe {
+                        compress4(&mut cvs, &blocks, block_len, counter, flags);
+                    }
+
+                    assert_eq!(
+                        cvs, want_cvs,
+                        "block_len {block_len} counter {counter} flags {flags}"
+                    );
+                }
+            }
+        }
     }
 }

--- a/src/rust_sse41.rs
+++ b/src/rust_sse41.rs
@@ -3,11 +3,12 @@ use core::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::*;
 
-use crate::{
-    BLOCK_LEN, CVBytes, CVWords, IV, IncrementCounter, MSG_SCHEDULE, OUT_LEN, counter_high,
-    counter_low,
-};
-use arrayref::{array_mut_ref, array_ref, mut_array_refs};
+use crate::{BLOCK_LEN, CVWords, IV, MSG_SCHEDULE, counter_high, counter_low};
+#[cfg(blake3_sse41_rust)]
+use crate::{CVBytes, IncrementCounter, OUT_LEN};
+use arrayref::mut_array_refs;
+#[cfg(blake3_sse41_rust)]
+use arrayref::{array_mut_ref, array_ref};
 
 pub const DEGREE: usize = 4;
 
@@ -38,6 +39,7 @@ unsafe fn set1(x: u32) -> __m128i {
     unsafe { _mm_set1_epi32(x as i32) }
 }
 
+#[cfg(blake3_sse41_rust)]
 #[inline(always)]
 unsafe fn set4(a: u32, b: u32, c: u32, d: u32) -> __m128i {
     unsafe { _mm_setr_epi32(a as i32, b as i32, c as i32, d as i32) }
@@ -71,6 +73,7 @@ unsafe fn rot7(a: __m128i) -> __m128i {
     unsafe { _mm_or_si128(_mm_srli_epi32(a, 7), _mm_slli_epi32(a, 32 - 7)) }
 }
 
+#[cfg(blake3_sse41_rust)]
 #[inline(always)]
 unsafe fn g1(
     row0: &mut __m128i,
@@ -89,6 +92,7 @@ unsafe fn g1(
     }
 }
 
+#[cfg(blake3_sse41_rust)]
 #[inline(always)]
 unsafe fn g2(
     row0: &mut __m128i,
@@ -108,12 +112,14 @@ unsafe fn g2(
 }
 
 // Adapted from https://github.com/rust-lang-nursery/stdsimd/pull/479.
+#[cfg(blake3_sse41_rust)]
 macro_rules! _MM_SHUFFLE {
     ($z:expr, $y:expr, $x:expr, $w:expr) => {
         ($z << 6) | ($y << 4) | ($x << 2) | $w
     };
 }
 
+#[cfg(blake3_sse41_rust)]
 macro_rules! shuffle2 {
     ($a:expr, $b:expr, $c:expr) => {
         _mm_castps_si128(_mm_shuffle_ps(
@@ -127,6 +133,7 @@ macro_rules! shuffle2 {
 // Note the optimization here of leaving row1 as the unrotated row, rather than
 // row0. All the message loads below are adjusted to compensate for this. See
 // discussion at https://github.com/sneves/blake2-avx2/pull/4
+#[cfg(blake3_sse41_rust)]
 #[inline(always)]
 unsafe fn diagonalize(row0: &mut __m128i, row2: &mut __m128i, row3: &mut __m128i) {
     unsafe {
@@ -136,6 +143,7 @@ unsafe fn diagonalize(row0: &mut __m128i, row2: &mut __m128i, row3: &mut __m128i
     }
 }
 
+#[cfg(blake3_sse41_rust)]
 #[inline(always)]
 unsafe fn undiagonalize(row0: &mut __m128i, row2: &mut __m128i, row3: &mut __m128i) {
     unsafe {
@@ -145,6 +153,7 @@ unsafe fn undiagonalize(row0: &mut __m128i, row2: &mut __m128i, row3: &mut __m12
     }
 }
 
+#[cfg(blake3_sse41_rust)]
 #[inline(always)]
 unsafe fn compress_pre(
     cv: &CVWords,
@@ -333,6 +342,7 @@ unsafe fn compress_pre(
     }
 }
 
+#[cfg(blake3_sse41_rust)]
 #[target_feature(enable = "sse4.1")]
 pub unsafe fn compress_in_place(
     cv: &mut CVWords,
@@ -348,6 +358,7 @@ pub unsafe fn compress_in_place(
     }
 }
 
+#[cfg(blake3_sse41_rust)]
 #[target_feature(enable = "sse4.1")]
 pub unsafe fn compress_xof(
     cv: &CVWords,
@@ -546,6 +557,7 @@ unsafe fn transpose_msg_vecs(inputs: &[*const u8; DEGREE], block_offset: usize) 
     }
 }
 
+#[cfg(blake3_sse41_rust)]
 #[inline(always)]
 unsafe fn load_counters(counter: u64, increment_counter: IncrementCounter) -> (__m128i, __m128i) {
     let mask = if increment_counter.yes() { !0 } else { 0 };
@@ -567,6 +579,7 @@ unsafe fn load_counters(counter: u64, increment_counter: IncrementCounter) -> (_
     }
 }
 
+#[cfg(blake3_sse41_rust)]
 #[target_feature(enable = "sse4.1")]
 pub unsafe fn hash4(
     inputs: &[*const u8; DEGREE],
@@ -658,6 +671,7 @@ pub unsafe fn hash4(
     }
 }
 
+#[cfg(blake3_sse41_rust)]
 #[target_feature(enable = "sse4.1")]
 unsafe fn hash1<const N: usize>(
     input: &[u8; N],
@@ -691,6 +705,7 @@ unsafe fn hash1<const N: usize>(
     *out = unsafe { core::mem::transmute(cv) }; // x86 is little-endian
 }
 
+#[cfg(blake3_sse41_rust)]
 #[target_feature(enable = "sse4.1")]
 pub unsafe fn hash_many<const N: usize>(
     mut inputs: &[&[u8; N]],
@@ -746,6 +761,93 @@ pub unsafe fn hash_many<const N: usize>(
     }
 }
 
+/// Compresses one (possibly partial) block for up to [`DEGREE`] (4) independent lanes at once.
+/// `cvs[i]` is lane `i`'s incoming chaining value, overwritten in place with the compression
+/// result, and `blocks[i]` points to at least `BLOCK_LEN` readable bytes for lane `i`. The
+/// `block_len`, `counter`, and `flags` are shared by every lane.
+#[target_feature(enable = "sse4.1")]
+pub unsafe fn compress4(
+    cvs: &mut [CVWords; DEGREE],
+    blocks: &[[u8; BLOCK_LEN]; DEGREE],
+    block_len: u8,
+    counter: u64,
+    flags: u8,
+) {
+    unsafe {
+        // A CV is 8 words, but a DEGREE=4 vector only holds 4 words, so the transpose happens in
+        // two independent halves: the low 4 words of each lane's CV, and the high 4 words.
+        let mut low_vecs: [__m128i; DEGREE] =
+            core::array::from_fn(|lane| loadu(cvs[lane].as_ptr() as *const u8));
+        let mut high_vecs: [__m128i; DEGREE] =
+            core::array::from_fn(|lane| loadu(cvs[lane].as_ptr().add(4) as *const u8));
+        transpose_vecs(&mut low_vecs);
+        transpose_vecs(&mut high_vecs);
+        let h_vecs = [
+            low_vecs[0],
+            low_vecs[1],
+            low_vecs[2],
+            low_vecs[3],
+            high_vecs[0],
+            high_vecs[1],
+            high_vecs[2],
+            high_vecs[3],
+        ];
+
+        let block_ptrs: [*const u8; DEGREE] = core::array::from_fn(|lane| blocks[lane].as_ptr());
+        let msg_vecs = transpose_msg_vecs(&block_ptrs, 0);
+
+        let counter_low_vec = set1(counter_low(counter));
+        let counter_high_vec = set1(counter_high(counter));
+        let block_len_vec = set1(block_len as u32);
+        let block_flags_vec = set1(flags as u32);
+
+        let mut v = [
+            h_vecs[0],
+            h_vecs[1],
+            h_vecs[2],
+            h_vecs[3],
+            h_vecs[4],
+            h_vecs[5],
+            h_vecs[6],
+            h_vecs[7],
+            set1(IV[0]),
+            set1(IV[1]),
+            set1(IV[2]),
+            set1(IV[3]),
+            counter_low_vec,
+            counter_high_vec,
+            block_len_vec,
+            block_flags_vec,
+        ];
+        round(&mut v, &msg_vecs, 0);
+        round(&mut v, &msg_vecs, 1);
+        round(&mut v, &msg_vecs, 2);
+        round(&mut v, &msg_vecs, 3);
+        round(&mut v, &msg_vecs, 4);
+        round(&mut v, &msg_vecs, 5);
+        round(&mut v, &msg_vecs, 6);
+
+        let mut low_out = [
+            xor(v[0], v[8]),
+            xor(v[1], v[9]),
+            xor(v[2], v[10]),
+            xor(v[3], v[11]),
+        ];
+        let mut high_out = [
+            xor(v[4], v[12]),
+            xor(v[5], v[13]),
+            xor(v[6], v[14]),
+            xor(v[7], v[15]),
+        ];
+        transpose_vecs(&mut low_out);
+        transpose_vecs(&mut high_out);
+        for lane in 0..DEGREE {
+            storeu(low_out[lane], cvs[lane].as_mut_ptr() as *mut u8);
+            storeu(high_out[lane], cvs[lane].as_mut_ptr().add(4) as *mut u8);
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -782,6 +884,7 @@ mod test {
         }
     }
 
+    #[cfg(blake3_sse41_rust)]
     #[test]
     fn test_compress() {
         if !crate::platform::sse41_detected() {
@@ -790,11 +893,62 @@ mod test {
         crate::test::test_compress_fn(compress_in_place, compress_xof);
     }
 
+    #[cfg(blake3_sse41_rust)]
     #[test]
     fn test_hash_many() {
         if !crate::platform::sse41_detected() {
             return;
         }
         crate::test::test_hash_many_fn(hash_many, hash_many);
+    }
+
+    #[test]
+    fn test_compress4_matches_compress_in_place() {
+        if !crate::platform::sse41_detected() {
+            return;
+        }
+        // Give each lane a different slice of the painted buffer, so a lane mixup fails the test.
+        let mut input_buf = [0u8; DEGREE * BLOCK_LEN];
+        crate::test::paint_test_input(&mut input_buf);
+
+        for block_len in [0u8, 1, 17, 32, 63, 64] {
+            // See test_hash_many_fn in src/test.rs for why these particular counters matter.
+            for counter in [0u64, u32::MAX as u64, i32::MAX as u64] {
+                for flags in [
+                    crate::CHUNK_START | crate::CHUNK_END | crate::ROOT,
+                    crate::KEYED_HASH | crate::CHUNK_START | crate::CHUNK_END,
+                ] {
+                    let mut cvs = [[0u32; 8]; DEGREE];
+                    let mut blocks = [[0u8; BLOCK_LEN]; DEGREE];
+                    for lane in 0..DEGREE {
+                        // A rotation of TEST_KEY_WORDS, distinct for every lane.
+                        for w in 0..8 {
+                            cvs[lane][w] = crate::test::TEST_KEY_WORDS[(w + lane) % 8];
+                        }
+                        blocks[lane].copy_from_slice(&input_buf[lane * BLOCK_LEN..][..BLOCK_LEN]);
+                    }
+
+                    let mut want_cvs = cvs;
+                    for lane in 0..DEGREE {
+                        crate::portable::compress_in_place(
+                            &mut want_cvs[lane],
+                            &blocks[lane],
+                            block_len,
+                            counter,
+                            flags,
+                        );
+                    }
+
+                    unsafe {
+                        compress4(&mut cvs, &blocks, block_len, counter, flags);
+                    }
+
+                    assert_eq!(
+                        cvs, want_cvs,
+                        "block_len {block_len} counter {counter} flags {flags}"
+                    );
+                }
+            }
+        }
     }
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,7 +1,6 @@
 use crate::{BLOCK_LEN, CHUNK_LEN, CVBytes, CVWords, IncrementCounter, OUT_LEN};
 use arrayref::array_ref;
 use arrayvec::ArrayVec;
-use core::usize;
 use rand::prelude::*;
 
 // Interesting input lengths to run tests on.

--- a/src/wasm32_simd.rs
+++ b/src/wasm32_simd.rs
@@ -759,6 +759,93 @@ pub unsafe fn hash_many<const N: usize>(
     }
 }
 
+/// Compresses one (possibly partial) block for up to [`DEGREE`] (4) independent lanes at once.
+/// `cvs[i]` is lane `i`'s incoming chaining value, overwritten in place with the compression
+/// result, and `blocks[i]` points to at least `BLOCK_LEN` readable bytes for lane `i`. The
+/// `block_len`, `counter`, and `flags` are shared by every lane.
+#[target_feature(enable = "simd128")]
+pub unsafe fn compress4(
+    cvs: &mut [CVWords; DEGREE],
+    blocks: &[[u8; BLOCK_LEN]; DEGREE],
+    block_len: u8,
+    counter: u64,
+    flags: u8,
+) {
+    // A CV is 8 words, but a DEGREE=4 vector only holds 4 words, so the transpose happens in
+    // two independent halves: the low 4 words of each lane's CV, and the high 4 words.
+    let mut low_vecs: [v128; DEGREE] =
+        core::array::from_fn(|lane| unsafe { loadu(cvs[lane].as_ptr() as *const u8) });
+    let mut high_vecs: [v128; DEGREE] =
+        core::array::from_fn(|lane| unsafe { loadu(cvs[lane].as_ptr().add(4) as *const u8) });
+    transpose_vecs(&mut low_vecs);
+    transpose_vecs(&mut high_vecs);
+    let h_vecs = [
+        low_vecs[0],
+        low_vecs[1],
+        low_vecs[2],
+        low_vecs[3],
+        high_vecs[0],
+        high_vecs[1],
+        high_vecs[2],
+        high_vecs[3],
+    ];
+
+    let block_ptrs: [*const u8; DEGREE] = core::array::from_fn(|lane| blocks[lane].as_ptr());
+    let msg_vecs = unsafe { transpose_msg_vecs(&block_ptrs, 0) };
+
+    let counter_low_vec = set1(counter_low(counter));
+    let counter_high_vec = set1(counter_high(counter));
+    let block_len_vec = set1(block_len as u32);
+    let block_flags_vec = set1(flags as u32);
+
+    let mut v = [
+        h_vecs[0],
+        h_vecs[1],
+        h_vecs[2],
+        h_vecs[3],
+        h_vecs[4],
+        h_vecs[5],
+        h_vecs[6],
+        h_vecs[7],
+        set1(IV[0]),
+        set1(IV[1]),
+        set1(IV[2]),
+        set1(IV[3]),
+        counter_low_vec,
+        counter_high_vec,
+        block_len_vec,
+        block_flags_vec,
+    ];
+    round(&mut v, &msg_vecs, 0);
+    round(&mut v, &msg_vecs, 1);
+    round(&mut v, &msg_vecs, 2);
+    round(&mut v, &msg_vecs, 3);
+    round(&mut v, &msg_vecs, 4);
+    round(&mut v, &msg_vecs, 5);
+    round(&mut v, &msg_vecs, 6);
+
+    let mut low_out = [
+        xor(v[0], v[8]),
+        xor(v[1], v[9]),
+        xor(v[2], v[10]),
+        xor(v[3], v[11]),
+    ];
+    let mut high_out = [
+        xor(v[4], v[12]),
+        xor(v[5], v[13]),
+        xor(v[6], v[14]),
+        xor(v[7], v[15]),
+    ];
+    transpose_vecs(&mut low_out);
+    transpose_vecs(&mut high_out);
+    unsafe {
+        for lane in 0..DEGREE {
+            storeu(low_out[lane], cvs[lane].as_mut_ptr() as *mut u8);
+            storeu(high_out[lane], cvs[lane].as_mut_ptr().add(4) as *mut u8);
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -799,5 +886,52 @@ mod test {
     #[test]
     fn test_hash_many() {
         crate::test::test_hash_many_fn(hash_many, hash_many);
+    }
+
+    #[test]
+    fn test_compress4_matches_compress_in_place() {
+        // Give each lane a different slice of the painted buffer, so a lane mixup fails the test.
+        let mut input_buf = [0u8; DEGREE * BLOCK_LEN];
+        crate::test::paint_test_input(&mut input_buf);
+
+        for block_len in [0u8, 1, 17, 32, 63, 64] {
+            // See test_hash_many_fn in src/test.rs for why these particular counters matter.
+            for counter in [0u64, u32::MAX as u64, i32::MAX as u64] {
+                for flags in [
+                    crate::CHUNK_START | crate::CHUNK_END | crate::ROOT,
+                    crate::KEYED_HASH | crate::CHUNK_START | crate::CHUNK_END,
+                ] {
+                    let mut cvs = [[0u32; 8]; DEGREE];
+                    let mut blocks = [[0u8; BLOCK_LEN]; DEGREE];
+                    for lane in 0..DEGREE {
+                        // A rotation of TEST_KEY_WORDS, distinct for every lane.
+                        for w in 0..8 {
+                            cvs[lane][w] = crate::test::TEST_KEY_WORDS[(w + lane) % 8];
+                        }
+                        blocks[lane].copy_from_slice(&input_buf[lane * BLOCK_LEN..][..BLOCK_LEN]);
+                    }
+
+                    let mut want_cvs = cvs;
+                    for lane in 0..DEGREE {
+                        crate::portable::compress_in_place(
+                            &mut want_cvs[lane],
+                            &blocks[lane],
+                            block_len,
+                            counter,
+                            flags,
+                        );
+                    }
+
+                    unsafe {
+                        compress4(&mut cvs, &blocks, block_len, counter, flags);
+                    }
+
+                    assert_eq!(
+                        cvs, want_cvs,
+                        "block_len {block_len} counter {counter} flags {flags}"
+                    );
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
This is a non-disruptive implementation of https://github.com/BLAKE3-team/BLAKE3/issues/478.

I decided to implement it as a separate module and reuse Rust intrinsics implementation (where available right now) for processing of the non-block-size tail.

Overall, you can now hash multiple independent values with SIMD as long as they are all the same length.

New benchmarks and example speed-up (this PR vs naive loop on Zen 4, AVX512 tail is not implemented yet and needs https://github.com/BLAKE3-team/BLAKE3/pull/566, AVX2 tail is used in the meantime):
```
test bench_many_inputs_0001_block      ... bench:         725.50 ns/iter (+/- 25.78) = 5649 MB/s
test bench_many_inputs_0001_block_loop ... bench:       4,112.09 ns/iter (+/- 29.09) = 996 MB/s
test bench_many_inputs_0001_kib        ... bench:       7,127.05 ns/iter (+/- 178.56) = 9195 MB/s
test bench_many_inputs_0001_kib_loop   ... bench:      50,823.08 ns/iter (+/- 660.42) = 1289 MB/s
test bench_many_inputs_0004_kib        ... bench:      30,922.44 ns/iter (+/- 786.33) = 8477 MB/s
test bench_many_inputs_0004_kib_loop   ... bench:      68,108.54 ns/iter (+/- 541.17) = 3848 MB/s
test bench_many_inputs_0032_bytes      ... bench:         829.08 ns/iter (+/- 7.60) = 2470 MB/s
test bench_many_inputs_0032_bytes_loop ... bench:       4,082.21 ns/iter (+/- 81.87) = 501 MB/s
test bench_many_inputs_0100_bytes      ... bench:       1,471.28 ns/iter (+/- 29.70) = 4350 MB/s
test bench_many_inputs_0100_bytes_loop ... bench:       7,329.94 ns/iter (+/- 150.33) = 873 MB/s
```

All CI failures are unrelated to changes here and will disappear once new release of `cpufeatures` is out (should be soon).